### PR TITLE
render-build.sh追加

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,0 +1,6 @@
+set -o errexit
+
+bundle install
+bundle exec rails assets:precompile
+bundle exec rails assets:clean
+bundle exec rails db:migrate


### PR DESCRIPTION
## 概要

Render でのデプロイ時に必要なビルド処理を自動化するため、`bin/render-build.sh` を追加しました。

## 作業内容

* `bin/render-build.sh` を新規作成
  * アセットのプリコンパイル / クリーン
  * データベースマイグレーション実行

```bash
set -o errexit

bundle install
bundle exec rails assets:precompile
bundle exec rails assets:clean
bundle exec rails db:migrate
```

## 動作確認

* ローカル環境でファイルが正しく作成されていることを確認

