### PR TITLE
Feature/profile create

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,27 @@
+class ProfilesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :redirect_if_profile_exists, only: %i[new create]
+
+  def new
+    @profile = current_user.build_profile
+  end
+
+  def create
+    @profile = current_user.build_profile(profile_params)
+    if @profile.save
+      redirect_to root_path, notice: "プロフィールを作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def profile_params
+    params.require(:profile).permit(:bio)
+  end
+
+  def redirect_if_profile_exists
+    redirect_to root_path, notice: "プロフィールは作成済みです" if current_user.profile
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,3 @@
+class Profile < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,3 +1,5 @@
 class Profile < ApplicationRecord
   belongs_to :user
+  validates :user_id, uniqueness: true
+  validates :bio, presence: true, length: { maximum: 500 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+has_one :profile, dependent: :destroy
+
 validates :nickname, presence: true, length: { maximum: 20 }
 end

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,0 +1,51 @@
+<div class="w-full max-w-xl bg-white rounded-2xl shadow-lg p-8">
+
+  <!-- タイトル -->
+  <h1 class="text-2xl font-bold text-center text-gray-800 mb-4">
+    プロフィール作成
+  </h1>
+
+  <!-- ログイン中ユーザー名 -->
+  <p class="text-center text-gray-600 mb-8">
+    <span class="font-semibold text-gray-800">
+      <%= current_user.nickname.presence || current_user.email %>
+    </span>
+    さんのプロフィール
+  </p>
+
+  <%= form_with model: @profile, url: profile_path, class: "space-y-6" do |f| %>
+
+    <!-- エラーメッセージ -->
+    <% if @profile.errors.any? %>
+      <div class="rounded-lg border border-red-300 bg-red-50 p-4">
+        <ul class="list-disc list-inside text-sm text-red-700 space-y-1">
+          <% @profile.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <!-- 自己紹介 -->
+    <div class="space-y-2">
+      <%= f.label :bio, "自己紹介",
+            class: "block text-sm font-semibold text-gray-700" %>
+
+      <%= f.text_area :bio,
+            rows: 6,
+            placeholder: "あなたの趣味や好きなことを書いてください",
+            class: "w-full rounded-lg border border-gray-300 px-4 py-3 text-gray-800
+                   focus:border-blue-500 focus:ring-2 focus:ring-blue-200
+                   focus:outline-none resize-none" %>
+    </div>
+
+    <!-- 送信 -->
+    <div class="pt-4">
+      <%= f.submit "作成する",
+            class: "w-full rounded-lg bg-blue-600 px-6 py-3
+                   text-white font-semibold text-base
+                   hover:bg-blue-700 transition-colors" %>
+    </div>
+
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,8 @@ Rails.application.routes.draw do
   # トップページ
   root "home#index"
 
+  # 1ユーザー1件
+  resource :profile, only: %i[new create]
+
   # resources :posts
 end

--- a/db/migrate/20260120054224_create_profiles.rb
+++ b/db/migrate/20260120054224_create_profiles.rb
@@ -1,0 +1,10 @@
+class CreateProfiles < ActiveRecord::Migration[7.2]
+  def change
+    create_table :profiles do |t|
+      t.references :user, null: false, foreign_key: true, index: { unique: true }
+      t.text :bio
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_17_081747) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_20_054224) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "profiles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.text "bio"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id", unique: true
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -26,4 +34,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_17_081747) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "profiles", "users"
 end

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  bio: MyText
+
+two:
+  user: two
+  bio: MyText

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProfileTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

ユーザーが初回のみプロフィール（自己紹介カード）を作成できる機能を実装しました。
プロフィールは1ユーザーにつき1件のみ作成可能とし、2回目以降は新規作成できないよう制御しています。

## 実装内容

* Profileモデルを新規作成
* users と profiles を has_one / belongs_to で関連付け
* profiles テーブルに user_id の unique 制約を設定し、DBレベルで1ユーザー1件を保証
* プロフィール新規作成画面（new / create）を実装
* プロフィール作成済みの場合は新規作成画面にアクセスできないよう制御

## 動作確認

* 未作成ユーザーはプロフィール作成画面にアクセスでき、作成できる
* 作成済みユーザーは新規作成画面にアクセスできない
* 同一ユーザーでプロフィールが複数作成されない

## 補足

プロフィールの表示（マイページ）や編集機能は、別Issueで実装予定です。

closes #12 