### PR TITLE
プロフィール一覧ページ作成

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -15,6 +15,12 @@ class ProfilesController < ApplicationController
     end
   end
 
+  def index
+    @profiles = Profile.includes(:user)
+  end
+
+  # TODO のちにshowを追加
+
   private
 
   def profile_params

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,0 +1,24 @@
+<div class="w-full max-w-3xl flex flex-col gap-6">
+
+  <h1 class="text-2xl font-semibold text-gray-800">
+    プロフィール一覧
+  </h1>
+
+  <% @profiles.each do |profile| %>
+    <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+
+      <!-- ユーザー名（クリック可能） -->
+      <%= link_to profile_path(profile),
+            class: "inline-block text-sm font-medium text-indigo-600 hover:underline mb-2" do %>
+        <%= profile.user.nickname %>
+      <% end %>
+
+      <!-- 自己紹介 -->
+      <p class="text-gray-800 leading-relaxed whitespace-pre-line">
+        <%= profile.bio.presence || "自己紹介は未入力です" %>
+      </p>
+
+    </div>
+  <% end %>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,8 @@ Rails.application.routes.draw do
   # トップページ
   root "home#index"
 
-  # 1ユーザー1件
+  # TODO のちにshowを追加
   resource :profile, only: %i[new create]
-
+  resources :profiles, only: %i[index]
   # resources :posts
 end


### PR DESCRIPTION
## 概要
ログイン中のユーザーが、プロフィールを作成済みの他ユーザー一覧を閲覧できるページを作成しました。  
アプリ内にどのようなユーザーが存在するかを把握できる状態を作り、今後のプロフィール詳細表示やフォロー機能の土台となる機能です。

## 実装内容
- プロフィール一覧ページ用のルーティングを追加
- ProfilesController に index アクションを実装
- プロフィール一覧ページ（index）を作成
- プロフィール作成済みユーザーのみが一覧表示されるように実装
- 各プロフィールからプロフィール詳細ページへ遷移できるリンクを設置  
  ※ プロフィール詳細表示の中身は別 Issue で実装予定

## 動作確認
- ログイン中のユーザーがプロフィール一覧ページにアクセスできること
- プロフィール作成済みユーザーのみが一覧表示されること
- 一覧ページからプロフィール詳細ページへ遷移できること（後回し）

## 影響範囲
- プロフィール一覧表示に関するルーティング・コントローラ・ビュー

## 備考
プロフィール詳細ページの表示内容やフォロー機能については、別 Issue にて対応予定です。