### PR TITLE
Feature/profile show

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   # ログイン後も同じ場所に飛ばしたい場合（任意）
   def after_sign_in_path_for(resource)
-    root_path
+    profiles_path
   end
 
   def configure_permitted_parameters

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -19,7 +19,12 @@ class ProfilesController < ApplicationController
     @profiles = Profile.includes(:user)
   end
 
-  # TODO のちにshowを追加
+  def show
+    @profile = Profile.find_by(id: params[:id])
+    return if @profile
+
+    redirect_to profiles_path #alert: "プロフィールが見つかりません"
+  end
 
   private
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -23,7 +23,7 @@ class ProfilesController < ApplicationController
     @profile = Profile.find_by(id: params[:id])
     return if @profile
 
-    redirect_to profiles_path #alert: "プロフィールが見つかりません"
+    redirect_to profiles_path # alert: "プロフィールが見つかりません"
   end
 
   private

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -7,17 +7,19 @@
   <% @profiles.each do |profile| %>
     <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
 
-      <!-- ユーザー名（クリック可能） -->
-      <%= link_to profile_path(profile),
-            class: "inline-block text-sm font-medium text-indigo-600 hover:underline mb-2" do %>
+      <!-- ユーザー名 -->
+      <p class="text-sm font-medium text-gray-600 mb-2">
         <%= profile.user.nickname %>
-      <% end %>
+      </p>
 
       <!-- 自己紹介 -->
       <p class="text-gray-800 leading-relaxed whitespace-pre-line">
         <%= profile.bio.presence || "自己紹介は未入力です" %>
       </p>
-
+      <%# のちにshowページに遷移できるようにする %>
+      <%= link_to "詳細を見る",
+                            profile_path(profile),
+                            class: "text-blue-600 hover:underline text-sm font-medium" %>
     </div>
   <% end %>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,29 @@
+<div class="w-3/4 max-w-lg space-y-6">
+
+  <!-- タイトル -->
+  <h1 class="text-xl font-bold text-gray-700 border-b pb-2">
+    プロフィール詳細
+  </h1>
+
+  <!-- プロフィールカード -->
+  <div class="bg-white rounded-xl shadow p-6 space-y-4">
+
+    <!-- ユーザー名 -->
+    <div>
+      <p class="text-sm text-gray-500">ユーザー名</p>
+      <p class="text-base font-medium text-gray-800">
+        <%= @profile.user.nickname %>
+      </p>
+    </div>
+
+    <!-- 自己紹介 -->
+    <div>
+      <p class="text-sm text-gray-500 mb-1">自己紹介</p>
+      <p class="whitespace-pre-line text-gray-800">
+        <%= @profile.bio.presence || "自己紹介は未入力です" %>
+      </p>
+    </div>
+
+  </div>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,6 @@ Rails.application.routes.draw do
 
   # TODO のちにshowを追加
   resource :profile, only: %i[new create]
-  resources :profiles, only: %i[index]
+  resources :profiles, only: %i[index show] # 他人用
   # resources :posts
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,8 @@ Rails.application.routes.draw do
   # トップページ
   root "home#index"
 
-  # TODO のちにshowを追加
+  resources :profiles, only: %i[index show]
   resource :profile, only: %i[new create]
-  resources :profiles, only: %i[index show] # 他人用
+  
   # resources :posts
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,6 @@ Rails.application.routes.draw do
 
   resources :profiles, only: %i[index show]
   resource :profile, only: %i[new create]
-  
+
   # resources :posts
 end


### PR DESCRIPTION
## 概要

プロフィール一覧ページから選択したユーザーのプロフィール詳細を表示できる機能を実装しました。
ユーザーの自己紹介内容を確認できるようにし、今後のフォロー機能やマッチング機能の基盤となる機能です。

## 実装内容

* プロフィール詳細表示用のルーティングを追加
* ProfilesController に show アクションを実装
* プロフィール詳細ページ（show）を作成
* ユーザー名・自己紹介を詳細ページに表示
* 存在しないプロフィールIDにアクセスした場合は一覧ページへリダイレクトする制御を実装
* `before_action :authenticate_user!` により、未ログイン状態ではアクセスできないよう制御

## 動作確認

* プロフィール一覧ページから詳細ページへ遷移できること
* 選択したユーザーのプロフィール情報（ユーザー名・自己紹介）が表示されること
* 存在しないIDにアクセスしてもエラー画面にならず、一覧ページへ遷移すること
* 未ログイン状態ではプロフィール詳細ページにアクセスできないこと

closes #13 
