### PR TITLE
Feature/profile delete 16

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -48,7 +48,7 @@ class ProfilesController < ApplicationController
   end
 
   def redirect_if_profile_exists
-    redirect_to root_path, notice: "プロフィールは作成済みです" if current_user.profile
+    redirect_to profiles_path, notice: "プロフィールは作成済みです" if current_user.profile
   end
 
   def set_profile

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,7 +1,7 @@
 class ProfilesController < ApplicationController
-  before_action :authenticate_user!
-  before_action :redirect_if_profile_exists, only: %i[new create]
-  before_action :set_profile, only: %i[edit update]
+  before_action :authenticate_user! # 誰？
+  before_action :redirect_if_profile_exists, only: %i[new create] # 作れる？
+  before_action :set_profile, only: %i[edit update] # どれ？
 
   def new
     @profile = current_user.build_profile

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,7 +1,7 @@
 class ProfilesController < ApplicationController
   before_action :authenticate_user! # 誰？
   before_action :redirect_if_profile_exists, only: %i[new create] # 作れる？
-  before_action :set_profile, only: %i[edit update] # どれ？
+  before_action :set_profile, only: %i[edit update destroy] # どれ？
 
   def new
     @profile = current_user.build_profile
@@ -34,6 +34,11 @@ class ProfilesController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @profile.destroy
+    redirect_to profiles_path
   end
 
   private

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -14,5 +14,14 @@
   <%= render "form",
         profile: @profile,
         submit_label: "更新する" %>
+  
+  <hr>
 
+  <div class="mt-6 pt-4 border-t border-gray-200">
+    <%= button_to "プロフィールを削除する",
+      my_profile_path,
+      method: :delete,
+      data: { turbo_confirm: "本当に削除しますか？" },
+      class: "w-full bg-red-50 text-red-600 py-2 rounded-lg text-sm hover:bg-red-100 transition" %>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ resources :profiles, only: %i[index show]
 resource :profile,
          as: :my_profile,
          controller: :profiles,
-         only: %i[new create edit update]
+         only: %i[new create edit update destroy]
 
   # resources :posts
 end


### PR DESCRIPTION
## 概要

投稿者本人が、自分のプロフィールを削除できる機能を実装しました。
編集機能と同様に、削除処理の基本実装とアクセス制御までを本PRの対象としています。

## 実装内容

* プロフィール削除用のルーティング（destroy）を追加
* ProfilesController に削除処理を実装
* プロフィール詳細ページに削除ボタンを追加
* 削除前に確認ダイアログを表示する導線を実装
* 削除成功時にプロフィール一覧ページへリダイレクト
* 投稿者本人のみ削除可能となるようアクセス制御を実装

  * `resource :profile` によるルーティング設計
  * `current_user.profile` のみを扱うことで他人の削除を防止
* プロフィール未作成・不正なアクセス時でもエラー落ちしないよう制御

## 動作確認

* 投稿者本人が自分のプロフィールを削除できる
* 削除後、プロフィール一覧から対象プロフィールが消える
* 投稿者以外は削除できない
* URL直打ちや不正な操作でもアプリがエラー落ちしない

## 補足

フラッシュメッセージの文言やデザイン調整については、別Issueで対応予定です。

closes #16 