### PR TITLE
Feature/flash message

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -11,7 +11,7 @@ class ProfilesController < ApplicationController
     @profile = current_user.build_profile(profile_params)
     if @profile.save
       #TODO あとでroot_path → profiles_pathに変更
-      redirect_to root_path, notice: "プロフィールを作成しました"
+      redirect_to profiles_path, notice: "プロフィールを作成しました"
     else
       flash.now[:alert] = "プロフィールを作成できませんでした"
       render :new, status: :unprocessable_entity

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -10,8 +10,10 @@ class ProfilesController < ApplicationController
   def create
     @profile = current_user.build_profile(profile_params)
     if @profile.save
+      #TODO あとでroot_path → profiles_pathに変更
       redirect_to root_path, notice: "プロフィールを作成しました"
     else
+      flash.now[:alert] = "プロフィールを作成できませんでした"
       render :new, status: :unprocessable_entity
     end
   end
@@ -30,15 +32,16 @@ class ProfilesController < ApplicationController
 
   def update
     if @profile.update(profile_params)
-      redirect_to profile_path(@profile)
+      redirect_to profile_path(@profile), notice: "プロフィールを更新しました"
     else
+      flash.now[:alert] = "プロフィールを更新できませんでした"
       render :edit, status: :unprocessable_entity
     end
   end
 
   def destroy
     @profile.destroy
-    redirect_to profiles_path
+    redirect_to profiles_path, alert: "プロフィールを削除しました"
   end
 
   private
@@ -53,6 +56,6 @@ class ProfilesController < ApplicationController
 
   def set_profile
     @profile = current_user.profile
-    redirect_to new_my_profile_path unless @profile
+    redirect_to new_my_profile_path,  alert: "プロフィールを作成してください" unless @profile
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -10,7 +10,6 @@ class ProfilesController < ApplicationController
   def create
     @profile = current_user.build_profile(profile_params)
     if @profile.save
-      #TODO あとでroot_path → profiles_pathに変更
       redirect_to profiles_path, notice: "プロフィールを作成しました"
     else
       flash.now[:alert] = "プロフィールを作成できませんでした"

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,14 +1,15 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+  <div id="error_explanation">
+    <h2 class="text-lg text-gray-700 mb-3">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
     </h2>
+ 
     <ul>
       <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <li class="leading-5 text-red-500 mb-2"><%= message %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,7 @@
 
   <body>
     <%= render "shared/navbar" %>
+    <%= render 'shared/flash' %>
     <main class="container mx-auto mt-20 py-8 px-5 flex items-center justify-center">
       <%= yield %>
     </main>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,11 @@
+<% if flash[:notice] %>
+  <div class="p-4 mt-3 mb-4 mx-3 text-sm text-blue-700 bg-blue-100 rounded-lg dark:bg-blue-200 dark:text-blue-800" role="alert">
+    <%= flash[:notice] %>
+  </div>
+<% end %>
+ 
+<% if flash[:alert] %>
+  <div class="p-4 mt-3 mb-4 mx-3 text-sm text-red-700 bg-red-100 rounded-lg dark:bg-red-200 dark:text-red-800" role="alert">
+    <%= flash[:alert] %>
+  </div>
+<% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,21 +1,37 @@
-<nav class="bg-gray-800 border-gray-200 px-2 sm:px-4 py-2.5">
-  <div class="container flex flex-wrap justify-between items-center mx-auto">
-    <%= link_to "hobby-matching-app", profiles_path, class: "self-center text-white text-xl font-semibold whitespace-nowrap" %>
-    <div class="w-full md:block md:w-auto">
-      <ul class="flex flex-col mt-4 md:flex-row md:space-x-8 md:mt-0 md:text-sm md:font-medium">
-        <% if current_user %>
-          <li>
-            <%= button_to "ログアウト", destroy_user_session_path, class: "block py-2 pr-4 pl-3 text-gray-200 hover:text-white border-b border-gray-700 hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-blue-white md:p-0", method: :delete %>
-          </li>
-        <% else %>
-          <li>
-            <%= link_to "ユーザー登録", new_user_registration_path, class: "block py-2 pr-4 pl-3 text-gray-200 hover:text-white border-b border-gray-700 hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-blue-white md:p-0" %>
-          </li>
-          <li>
-            <%= link_to "ログイン", new_user_session_path, class: "block py-2 pr-4 pl-3 text-gray-200 hover:text-white border-b border-gray-700 hover:bg-gray-700 md:hover:bg-transparent md:border-0 md:hover:text-blue-white md:p-0" %>
-          </li>
+<nav class="bg-gray-800 px-4 py-2.5">
+  <div class="container mx-auto flex items-center justify-between">
+    <!-- ロゴ -->
+    <%= link_to "hobby-matching-app",
+                profiles_path,
+                class: "text-white text-xl font-semibold whitespace-nowrap" %>
+
+    <!-- 右側メニュー -->
+    <div class="flex items-center gap-x-4">
+      <% if current_user %>
+
+        <% unless current_user.profile %>
+          <%= link_to "プロフィール作成",
+                      new_my_profile_path,
+                      class: "px-4 py-2 rounded-md bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition" %>
         <% end %>
-      </ul>
+
+        <%= button_to "ログアウト",
+                      destroy_user_session_path,
+                      method: :delete,
+                      class: "text-gray-300 text-sm hover:text-white transition",
+                      form_class: "m-0" %>
+
+      <% else %>
+
+        <%= link_to "ユーザー登録",
+                    new_user_registration_path,
+                    class: "text-gray-300 text-sm hover:text-white transition" %>
+
+        <%= link_to "ログイン",
+                    new_user_session_path,
+                    class: "text-gray-300 text-sm hover:text-white transition" %>
+
+      <% end %>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
## 概要

CRUD処理および認証まわりのユーザー操作に対して、
フラッシュメッセージの追加とナビゲーションバーの改善を行いました。

これまで実装してきた機能について、
「操作結果がユーザーに分かる」「次に取るべき行動が明確になる」ことを目的としています。

## 実装内容

* フラッシュメッセージ表示用の共通ビューを実装
* プロフィールの Create / Update / Destroy 処理にフラッシュメッセージを追加
* プロフィール未作成時のアクセス制御にフラッシュメッセージを追加
* Devise のバリデーションエラーメッセージの表示を調整
* ナビゲーションバーに「プロフィール作成」ボタンを追加

  * ログイン済み & プロフィール未作成時のみ表示
* root_path を profiles_path に変更し、ログイン後の遷移先を統一

## 動作確認

* [ ] CRUD操作後に、成功・失敗がフラッシュメッセージで表示される
* [ ] 不正な操作や制限ページへのアクセス時に、理由が分かるメッセージが表示される
* [ ] プロフィール未作成ユーザーがナビゲーションから作成画面へ遷移できる
* [ ] ログイン・認証まわりの既存挙動に影響が出ていない

## 補足

* フラッシュメッセージの文言およびデザインは暫定対応としています
* UIの細かい調整については、必要に応じて別Issueで対応予定です

closes #40 