### PR TITLE
Fix/review feedback 44

### DIFF
--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -32,8 +32,9 @@ ja:
   devise:
     failure:
       invalid: "%{authentication_keys}またはパスワードが違います。"
-      unauthenticated: "ログインまたは新規登録してください"
+      unauthenticated: "ログインまたは新規登録してください。"
       not_found_in_database: "メールアドレスまたはパスワードが違います。"
+      already_authenticated: "すでにログインしています。"
     registrations:
       user:
         signed_up: ユーザー登録に成功しました。


### PR DESCRIPTION
# fix: Devise の already_authenticated メッセージを日本語化

## 概要
ログイン済みユーザーがログイン画面へアクセスした際に表示される
Devise の already_authenticated メッセージを日本語化しました。

## 背景
日本語翻訳が未定義だったため、Translation missing が表示されていました。

## 確認内容
- ログイン済み状態でログイン画面へアクセスした際に
  日本語メッセージが表示されること
- Translation missing が表示されないこと
