### PR TITLE
Feature/fix something

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -10,7 +10,7 @@ class ProfilesController < ApplicationController
   def create
     @profile = current_user.build_profile(profile_params)
     if @profile.save
-      redirect_to profiles_path, notice: "プロフィールを作成しました"
+      redirect_to profile_path(@profile), notice: "プロフィールを作成しました"
     else
       flash.now[:alert] = "プロフィールを作成できませんでした"
       render :new, status: :unprocessable_entity

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -24,10 +24,15 @@
       </p>
     </div>
 
-    <% if current_user.own?(@profile) %>
-      <%= link_to "編集する", edit_my_profile_path, class: "text-blue-600 hover:underline" %>
-    <% end %>
+    <div class="mt-8 flex flex-col gap-3 items-center">
+      <% if current_user == @profile.user %>
+          <%= link_to "編集する", edit_my_profile_path, class: "w-full max-w-xs px-4 py-2 rounded bg-blue-600 text-white text-center hover:bg-blue-700" %>
+      <% end %>
 
+      <%= link_to "プロフィール一覧へ戻る",
+              profiles_path,
+              class: "text-sm text-gray-600 hover:underline" %>
+    </div>
   </div>
 
 </div>


### PR DESCRIPTION
## 概要

プロフィール作成・更新後の画面遷移を見直し、
詳細画面からプロフィール一覧へ戻りやすい導線になるよう修正しました。

ブラウザバックによる遷移を減らし、
ユーザーが次に取る行動を迷わず選べることを目的としています。

## 変更内容

* プロフィール作成後・更新後の遷移先を詳細画面に統一
* 詳細画面からプロフィール一覧へ遷移できる導線を追加
* ブラウザバックに依存した遷移を減らすことで、
  操作直後ではないフラッシュメッセージが一覧画面に表示され続ける状況を回避

## 確認方法

* プロフィール作成後、詳細画面へ遷移すること
* 詳細画面からプロフィール一覧へ通常操作で戻れること
* ブラウザバックで一覧画面へ戻った際、
  作成・更新成功のフラッシュメッセージが表示されないこと

## 影響範囲

* プロフィール作成・更新後の画面遷移のみ
  （CRUD処理や認証ロジックへの影響はありません）
