### PR TITLE
新規作成ページと編集ページに一覧へのリンクを追加

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -24,4 +24,8 @@
       data: { turbo_confirm: "本当に削除しますか？" },
       class: "w-full bg-red-50 text-red-600 py-2 rounded-lg text-sm hover:bg-red-100 transition" %>
   </div>
+
+  <br>
+
+  <%= link_to "プロフィール一覧へ戻る", profiles_path, class: "text-sm text-gray-600 hover:underline" %>
 </div>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -14,5 +14,8 @@
   <%= render "form",
         profile: @profile,
         submit_label: "作成する" %>
+  <br>
+
+  <%= link_to "プロフィール一覧へ戻る", profiles_path, class: "text-sm text-gray-600 hover:underline" %>
 
 </div>


### PR DESCRIPTION
## 概要

プロフィールの新規作成ページ・編集ページに、
プロフィール一覧へ戻るためのリンクを追加しました。

ユーザーが操作を中断・見直したい場合でも、
迷わず一覧画面へ戻れる導線を用意することを目的としています。

## 変更内容

プロフィール新規作成ページに「一覧へ戻る」リンクを追加

プロフィール編集ページに「一覧へ戻る」リンクを追加

ボタンではなくテキストリンクとし、操作の主導線と区別

## 変更の意図

作成・編集途中でも他ユーザーのプロフィールを確認しやすくするため

ブラウザバックに依存しない、明示的な画面遷移を提供するため

## 確認方法

プロフィール新規作成ページから一覧画面へ戻れること

プロフィール編集ページから一覧画面へ戻れること