### PR TITLE
Feature/profile hobby tags UI 79

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,1 +1,27 @@
 @import "tailwindcss";
+
+@layer components {
+  .tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .tag-chip {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 9999px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    background: #f3f4f6; /* gray-100 */
+  }
+
+  .tag-empty {
+    color: #6b7280; /* gray-500 */
+    font-size: 0.875rem;
+  }
+}

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -18,7 +18,7 @@ class ProfilesController < ApplicationController
   end
 
   def index
-    @profiles = Profile.includes(:user)
+    @profiles = Profile.includes(:user, :hobbies).order(created_at: :desc)
   end
 
   def show

--- a/app/views/profiles/_profile_card.html.erb
+++ b/app/views/profiles/_profile_card.html.erb
@@ -7,7 +7,7 @@
 
   <!-- タグ（一覧では多すぎると崩れるので limit 推奨） -->
   <div class="mt-3">
-    <%= render "shared/hobby_tags", hobbies: profile.hobbies, limit: 4 %>
+    <%= render "shared/hobby_tags", hobbies: profile.hobbies, limit: 5 %>
   </div>
 
 

--- a/app/views/profiles/_profile_card.html.erb
+++ b/app/views/profiles/_profile_card.html.erb
@@ -1,0 +1,31 @@
+<div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+
+  <!-- ユーザー名 -->
+  <p class="text-sm font-medium text-gray-600 mb-2">
+    <%= profile.user.nickname %>
+  </p>
+
+  <!-- タグ（一覧では多すぎると崩れるので limit 推奨） -->
+  <div class="mt-3">
+    <%= render "shared/hobby_tags", hobbies: profile.hobbies, limit: 4 %>
+  </div>
+
+
+  <!-- 自己紹介 -->
+  <p class="text-gray-800 leading-relaxed whitespace-pre-line">
+    <%= profile.bio.presence || "自己紹介は未入力です" %>
+  </p>
+
+  <div class="mt-4 flex items-center gap-4">
+    <%= link_to "詳細を見る",
+                profile_path(profile),
+                class: "text-blue-600 hover:underline text-sm font-medium" %>
+
+    <% if current_user.own?(profile) %>
+      <%= link_to "編集する",
+                  edit_my_profile_path,
+                  class: "text-blue-600 hover:underline text-sm font-medium" %>
+    <% end %>
+  </div>
+
+</div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -3,29 +3,7 @@
   <h1 class="text-2xl font-semibold text-gray-800">
     プロフィール一覧
   </h1>
-
   <% @profiles.each do |profile| %>
-    <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-
-      <!-- ユーザー名 -->
-      <p class="text-sm font-medium text-gray-600 mb-2">
-        <%= profile.user.nickname %>
-      </p>
-
-      <!-- 自己紹介 -->
-      <p class="text-gray-800 leading-relaxed whitespace-pre-line">
-        <%= profile.bio.presence || "自己紹介は未入力です" %>
-      </p>
-      <%# のちにshowページに遷移できるようにする %>
-      <%= link_to "詳細を見る",
-                            profile_path(profile),
-                            class: "text-blue-600 hover:underline text-sm font-medium" %>
-      <!-- 編集ボタン（本人のみ） -->
-      <% if current_user.own?(profile) %>
-        <%= link_to "編集する", edit_my_profile_path, class: "text-blue-600 hover:underline" %>
-      <% end %>
-
-    </div>
+    <%= render "profile_card", profile: profile %>
   <% end %>
-
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -17,11 +17,10 @@
     </div>
 
     <!-- タグ -->
-    <div>
-      <% @profile.hobbies.each do |hobby| %>
-        <span><%= hobby.name %></span>
-      <% end %>
-    </div>
+    <section>
+      <p class="text-sm text-gray-500 mb-1">趣味</p>
+      <%= render "shared/hobby_tags", hobbies: @profile.hobbies %>
+    </section>
 
 
     <!-- 自己紹介 -->

--- a/app/views/shared/_hobby_tags.html.erb
+++ b/app/views/shared/_hobby_tags.html.erb
@@ -1,11 +1,17 @@
-<%# locals: hobbies: Array (nil OK) %>
 <% hobby_list = Array(hobbies).compact %>
+<% limit = local_assigns.fetch(:limit, nil) %>
+<% visible = limit ? hobby_list.first(limit) : hobby_list %>
+<% hidden_count = limit ? [hobby_list.size - visible.size, 0].max : 0 %>
 
 <div class="tag-section">
   <% if hobby_list.any? %>
     <ul class="tag-list" aria-label="趣味タグ一覧">
-      <% hobby_list.each do |hobby| %>
+      <% visible.each do |hobby| %>
         <li class="tag-chip"><%= hobby.name %></li>
+      <% end %>
+
+      <% if hidden_count.positive? %>
+        <li class="tag-chip tag-chip-muted">+<%= hidden_count %></li>
       <% end %>
     </ul>
   <% else %>

--- a/app/views/shared/_hobby_tags.html.erb
+++ b/app/views/shared/_hobby_tags.html.erb
@@ -1,0 +1,16 @@
+<%# locals: hobbies: Array (nil OK) %>
+<% hobby_list = Array(hobbies).compact %>
+
+<div class="tag-section">
+  <% if hobby_list.any? %>
+    <ul class="flex flex-wrap gap-2" aria-label="趣味タグ一覧">
+      <% hobby_list.each do |hobby| %>
+        <li class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
+          <%= hobby.name %>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="tag-empty">未登録</p>
+  <% end %>
+</div>

--- a/app/views/shared/_hobby_tags.html.erb
+++ b/app/views/shared/_hobby_tags.html.erb
@@ -3,11 +3,9 @@
 
 <div class="tag-section">
   <% if hobby_list.any? %>
-    <ul class="flex flex-wrap gap-2" aria-label="趣味タグ一覧">
+    <ul class="tag-list" aria-label="趣味タグ一覧">
       <% hobby_list.each do |hobby| %>
-        <li class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-800">
-          <%= hobby.name %>
-        </li>
+        <li class="tag-chip"><%= hobby.name %></li>
       <% end %>
     </ul>
   <% else %>

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Profiles", type: :request do
+  describe "GET /profiles" do
+    let(:user) { create(:user) }
+
+    before do
+      sign_in user
+    end
+
+    it "profiles一覧でタグが表示される" do
+      profile = create(:profile)
+      rails = create(:hobby, name: "rails")
+      create(:profile_hobby, profile:, hobby: rails)
+
+      get profiles_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("rails")
+    end
+
+    it "一覧で趣味が0件の場合、未登録が表示される" do
+      create(:profile)
+
+      get profiles_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("未登録")
+    end
+  end
+end


### PR DESCRIPTION
## 概要

プロフィール一覧／詳細の趣味（タグ）表示UIを改善しました。タグをchip表示（横並び＋折り返し）にし、一覧では表示数を制限して描画負荷と見た目の崩れを防ぎます。

## 変更点

* タグ表示を共通partial化して一覧／詳細で再利用
* タグのスタイルをflex + wrap対応（chip表示）
* 一覧はlimit件のみ表示し、超過分は hidden_count（+◯）で表現／0件は「未登録」表示
* N+1対策として一覧取得を eager load

## 動作確認

* 一覧でタグが表示される／0件は「未登録」
* 一覧の表示数制限と +◯ 表示が期待通り

closes #79 
