### PR TITLE
Feature/unauthenticated user flow 60

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :nickname ])
   end
 
   private

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,4 +1,6 @@
 class ProfilesController < ApplicationController
+  before_action :authenticate_user!
+  
   def index
     @profiles = Profile.includes(:user, :hobbies).order(created_at: :desc)
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :authenticate_user!
-  
+
   def index
     @profiles = Profile.includes(:user, :hobbies).order(created_at: :desc)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,13 @@
 module ApplicationHelper
+  def primary_btn_class(size: :lg)
+    base = "inline-flex items-center justify-center rounded-lg font-semibold"
+    padding = size == :lg ? "px-8 py-3 text-lg" : "px-4 py-2 text-sm"
+    "#{base} #{padding} bg-indigo-600 text-white hover:bg-indigo-700"
+  end
+
+  def outline_btn_class(size: :lg)
+    base = "inline-flex items-center justify-center rounded-lg font-semibold"
+    padding = size == :lg ? "px-8 py-3 text-lg" : "px-4 py-2 text-sm"
+    "#{base} #{padding} border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+  end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,11 +13,16 @@
       <span class="font-semibold">補助ツール</span>
     </p>
 
-    <div class="flex flex-col sm:flex-row gap-4 justify-center">
-      <%= link_to "無料で始める", new_user_registration_path, class: "btn btn-primary btn-lg px-8" %>
-      <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-lg px-8" %>
-    </div>
-
+    <% if user_signed_in? %>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <%= link_to "プロフィール一覧へ", profiles_path, class: "btn btn-primary btn-lg px-8" %>
+      </div>
+    <% else %>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <%= link_to "無料で始める", new_user_registration_path, class: "btn btn-primary btn-lg px-8" %>
+        <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-lg px-8" %>
+      </div>
+    <% end %>
   </div>
 </section>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -19,8 +19,8 @@
       </div>
     <% else %>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <%= link_to "無料で始める", new_user_registration_path, class: "btn btn-primary btn-lg px-8" %>
-        <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-lg px-8" %>
+        <%= link_to "無料で始める", new_user_registration_path, class: primary_btn_class %>
+        <%= link_to "ログイン", new_user_session_path, class: outline_btn_class %>
       </div>
     <% end %>
   </div>

--- a/app/views/shared/_login_cta.html.erb
+++ b/app/views/shared/_login_cta.html.erb
@@ -1,0 +1,13 @@
+<div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
+  <p class="text-sm text-gray-700">
+    共通の趣味の表示や「趣味追加」などの機能は、ログイン後に利用できます。
+  </p>
+
+  <div class="mt-3 flex flex-col sm:flex-row gap-2">
+    <%= link_to "ログイン", new_user_session_path,
+          class: "inline-flex items-center justify-center rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white" %>
+
+    <%= link_to "新規登録", new_user_registration_path,
+          class: "inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700" %>
+  </div>
+</div>

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "Login guard", type: :request do
     get edit_my_profile_path
     expect(response).to redirect_to(new_user_session_path)
 
-    post user_session_path, params:{
-      user: { email: user.email, password: user.password}
+    post user_session_path, params: {
+      user: { email: user.email, password: user.password }
     }
 
     # 元のページへリダイレクトされることを確認

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Login guard", type: :request do
+  it "未ログインでmy_profile/editに行くとログインへリダイレクトしメッセージが出る" do
+    get edit_my_profile_path
+
+    expect(response).to redirect_to(new_user_session_path)
+    follow_redirect!
+
+    expect(response.body).to include("ログインまたは新規登録してください。")
+  end
+
+  it "ログイン後に元のページへ戻れる" do
+    user = create(:user)
+    profile = create(:profile, user:)
+
+    get edit_my_profile_path
+    expect(response).to redirect_to(new_user_session_path)
+
+    post user_session_path, params:{
+      user: { email: user.email, password: user.password}
+    }
+
+    # 元のページへリダイレクトされることを確認
+    expect(response).to redirect_to(edit_my_profile_path)
+
+    follow_redirect!
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
## 概要

未ログインユーザーが迷わず「ログイン/新規登録」へ進めるように導線を整備しました。あわせて、ログイン必須ページへのアクセス時の誘導（フラッシュ）と、ログイン後の復帰（元ページへ戻る）を改善しました。

Closes #60

## 変更内容

* トップページのCTAをログイン状態で出し分け

  * 未ログイン: 「無料で始める（新規登録）」「ログイン」
  * ログイン中: 「プロフィール一覧へ」
* 画面の見た目を `btn` などの非対応クラス依存から外し、Tailwind標準クラスで統一
* `store_location_for` を使って、ログイン後に元ページへ戻れる導線を補強
* `after_sign_in_path_for` を見直し、保存された遷移先があれば優先して復帰

  * `stored_location_for(resource) || profiles_path`
* 未ログイン誘導時のメッセージを統一（例：「ログインが必要です。」）

## 動作確認

* [ ] 未ログインでログイン必須ページ（例: `/my_profile/edit`）へアクセスするとログイン画面へリダイレクトされる
* [ ] その際に「ログインが必要です。」等のメッセージが表示される
* [ ] ログイン後、元のページへ戻れる（保存済み遷移先がある場合）
* [ ] トップページで未ログイン時に「無料で始める/ログイン」、ログイン時に「プロフィール一覧へ」が表示される

### コマンド

* `docker compose exec web bundle exec rspec spec/requests/authentication_spec.rb`

## 補足

* プロフィール詳細ページの未ログイン表示（共通趣味/趣味追加の補足 + CTA）は、現状 index/show がログイン必須のためユーザーが到達できない。ゲスト導入 or 閲覧範囲の見直し後に別Issueで対応予定。
