### PR TITLE
Feature/shared hobbies 85

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -6,14 +6,10 @@ class ProfilesController < ApplicationController
   end
 
   def show
-    @profile = Profile.find_by(id: params[:id])
-    redirect_to profiles_path, alert: "プロフィールが見つかりません" unless @profile
+    @profile = Profile.includes(:user, :hobbies).find_by(id: params[:id])
+    return redirect_to profiles_path, alert: "プロフィールが見つかりません" unless @profile
 
-    @shared_hobbies =
-      if current_user
-        current_user.profile.hobbies & @profile.hobbies
-      else
-        []
-      end
+    my_hobbies = current_user.profile&.hobbies || []
+    @shared_hobbies = my_hobbies & @profile.hobbies
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,5 +8,12 @@ class ProfilesController < ApplicationController
   def show
     @profile = Profile.find_by(id: params[:id])
     redirect_to profiles_path, alert: "プロフィールが見つかりません" unless @profile
+
+    @shared_hobbies =
+      if current_user
+        current_user.profile.hobbies & @profile.hobbies
+      else
+        []
+      end
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,7 +9,7 @@ class ProfilesController < ApplicationController
     @profile = Profile.includes(:user, :hobbies).find_by(id: params[:id])
     return redirect_to profiles_path, alert: "プロフィールが見つかりません" unless @profile
 
-    my_hobbies = current_user.profile&.hobbies || []
-    @shared_hobbies = my_hobbies & @profile.hobbies
+    my_profile = current_user.profile
+    @shared_hobbies = my_profile ? my_profile.shared_hobbies_with(@profile) : []
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -17,4 +17,8 @@ class Profile < ApplicationRecord
 
     self.hobbies = hobbies
   end
+
+  def shared_hobbies_with(other_profile)
+    hobbies.to_a & other_profile.hobbies.to_a
+  end
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -22,15 +22,17 @@
       <%= render "shared/hobby_tags", hobbies: @profile.hobbies %>
     </section>
 
-    <section>
-      <p class="text-sm text-gray-500 mb-1">共通の趣味</p>
+    <% if current_user != @profile.user %>
+      <section>
+        <p class="text-sm text-gray-500 mb-1">共通の趣味</p>
 
-      <% if @shared_hobbies.any? %>
-        <%= render "shared/hobby_tags", hobbies: @shared_hobbies %>
-      <% else %>
-        <p class="text-sm text-gray-600">共通の趣味はまだありません</p>
-      <% end %>
-    </section>
+        <% if @shared_hobbies.any? %>
+          <%= render "shared/hobby_tags", hobbies: @shared_hobbies %>
+        <% else %>
+          <p class="text-sm text-gray-600">共通の趣味はまだありません</p>
+        <% end %>
+      </section>
+    <% end %>
 
     <!-- 自己紹介 -->
     <div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -22,6 +22,15 @@
       <%= render "shared/hobby_tags", hobbies: @profile.hobbies %>
     </section>
 
+    <section>
+      <p class="text-sm text-gray-500 mb-1">共通の趣味</p>
+
+      <% if @shared_hobbies.any? %>
+        <%= render "shared/hobby_tags", hobbies: @shared_hobbies %>
+      <% else %>
+        <p class="text-sm text-gray-600">共通の趣味はまだありません</p>
+      <% end %>
+    </section>
 
     <!-- 自己紹介 -->
     <div>

--- a/spec/requests/profiles_show_auth_spec.rb
+++ b/spec/requests/profiles_show_auth_spec.rb
@@ -6,6 +6,5 @@ RSpec.describe "Profiles#show authentication", type: :request do
 
     get profile_path(profile)
     expect(response).to redirect_to(new_user_session_path)
-
   end
 end

--- a/spec/requests/profiles_show_auth_spec.rb
+++ b/spec/requests/profiles_show_auth_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "Profiles#show authentication", type: :request do
+  it "未ログインでprofiles/:idにアクセスすると、ログインページにリダイレクトする" do
+    profile = create(:profile)
+
+    get profile_path(profile)
+    expect(response).to redirect_to(new_user_session_path)
+
+  end
+end

--- a/spec/requests/profiles_show_shared_hobbies_spec.rb
+++ b/spec/requests/profiles_show_shared_hobbies_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Profiles#show shared hobbies", type: :request do
+  it "ログイン済みで他人プロフィール詳細を聞くと、共通hobbiesが表示される" do
+
+    # ログインユーザー
+    my_user = create(:user)
+    my_profile = create(:profile, user: my_user)
+
+    # 相手ユーザー
+    other_user = create(:user)
+    other_profile = create(:profile, user: other_user)
+
+    # 共通Hobby
+    rails = create(:hobby, name: "rails")
+    create(:profile_hobby, profile: my_profile, hobby: rails)
+    create(:profile_hobby, profile: other_profile, hobby: rails)
+
+    sign_in my_user
+
+    get profile_path(other_profile)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("共通の趣味")
+    expect(response.body).to include("rails")
+  end
+end

--- a/spec/requests/profiles_show_shared_hobbies_spec.rb
+++ b/spec/requests/profiles_show_shared_hobbies_spec.rb
@@ -22,6 +22,6 @@ RSpec.describe "Profiles#show shared hobbies", type: :request do
 
     expect(response).to have_http_status(:ok)
     expect(response.body).to include("共通の趣味")
-    expect(response.body).to include("rails")
+    expect(response.body).to match(/共通の趣味.*rails/m)
   end
 end

--- a/spec/requests/profiles_show_shared_hobbies_spec.rb
+++ b/spec/requests/profiles_show_shared_hobbies_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Profiles#show shared hobbies", type: :request do
   it "ログイン済みで他人プロフィール詳細を聞くと、共通hobbiesが表示される" do
-
     # ログインユーザー
     my_user = create(:user)
     my_profile = create(:profile, user: my_user)

--- a/spec/requests/profiles_show_shared_hobbies_spec.rb
+++ b/spec/requests/profiles_show_shared_hobbies_spec.rb
@@ -24,4 +24,15 @@ RSpec.describe "Profiles#show shared hobbies", type: :request do
     expect(response.body).to include("共通の趣味")
     expect(response.body).to match(/共通の趣味.*rails/m)
   end
+
+  it "自分のプロフィール詳細では共通の趣味セクションを表示しない" do
+    my_user = create(:user)
+    my_profile = create(:profile, user: my_user)
+
+    sign_in my_user
+    get profile_path(my_profile)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).not_to include("共通の趣味")
+  end
 end

--- a/spec/requests/profiles_show_shared_hobbies_spec.rb
+++ b/spec/requests/profiles_show_shared_hobbies_spec.rb
@@ -49,4 +49,19 @@ RSpec.describe "Profiles#show shared hobbies", type: :request do
     expect(response).to have_http_status(:ok)
     expect(response.body).to include("共通の趣味はまだありません")
   end
+
+  it "ログイン済みでもプロフィール未作成なら、共通hobbyは0件扱いで表示される" do
+    my_user = create(:user)
+    # わざと profile を作らない
+
+    other_user = create(:user)
+    other_profile = create(:profile, user: other_user)
+
+    sign_in my_user
+    get profile_path(other_profile)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("共通の趣味")
+    expect(response.body).to include("共通の趣味はまだありません")
+  end
 end

--- a/spec/requests/profiles_show_shared_hobbies_spec.rb
+++ b/spec/requests/profiles_show_shared_hobbies_spec.rb
@@ -35,4 +35,18 @@ RSpec.describe "Profiles#show shared hobbies", type: :request do
     expect(response).to have_http_status(:ok)
     expect(response.body).not_to include("共通の趣味")
   end
+
+  it "共通の０件の場合、メッセージが表示される" do
+    my_user = create(:user)
+    my_profile = create(:profile, user: my_user)
+
+    other_user = create(:user)
+    other_profile = create(:profile, user: other_user)
+
+    sign_in my_user
+    get profile_path(other_profile)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("共通の趣味はまだありません")
+  end
 end


### PR DESCRIPTION
## 概要

他人プロフィール詳細ページで、ログイン中ユーザーとの**共通hobby（共有タグ）**を表示できるようにしました。
共通が0件の場合はメッセージを表示し、自分のプロフィール閲覧時は共通セクションを出さない仕様にしています。

Closes #85

## 変更内容

* `profiles#show` で共通hobbyを表示

  * 見出し「共通の趣味」
  * 共通あり：タグ一覧を表示
  * 共通0件：`共通の趣味はまだありません` を表示
  * 自分のプロフィールの場合：共通セクションは非表示
* 共通hobby算出ロジックを `Profile#shared_hobbies_with` に抽出（責務分離）
* ログイン中でも `current_user.profile` が未作成(nil)の場合は **0件扱い**で安全に表示
* N+1対策として `Profile.includes(:user, :hobbies)` を適用

## テスト

* request spec を追加/更新

  * 未ログインはログインページへリダイレクト
  * 他人プロフィールで共通hobbyが表示される
  * 共通0件時にメッセージが表示される
  * 自分のプロフィールでは共通セクションが表示されない
  * ログイン済みだがプロフィール未作成の場合も落ちずに0件扱いになる

### 実行コマンド

* `docker compose exec web bundle exec rspec spec/requests/profiles_show_shared_hobbies_spec.rb`
* `docker compose exec web bundle exec rspec spec/requests/profiles_show_auth_spec.rb`
