### PR TITLE
fix: correct custom domain host configuration

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,6 +104,6 @@ Rails.application.configure do
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   # ホワイトリストに追加
-  config.hosts << "example.com"      # 独自ドメイン
-  config.hosts << "www.example.com"  # サブドメイン
+  config.hosts << "hobby-matching-app.com"      # 独自ドメイン
+  config.hosts << "www.hobby-matching-app.com"  # サブドメイン
 end


### PR DESCRIPTION
## 🔧 fix: 独自ドメイン設定の不備を修正

Closes #64

---

## 概要

独自ドメイン反映後に発生したアクセス不具合の原因を特定し、設定を修正しました。

---

## 発生していた問題

* 独自ドメイン経由でアクセスした際に正常表示されないケースが発生
* Host Authorization 設定が不十分だった

---

## 原因

Rails の `config.hosts` に本番用ドメインの許可設定が不足していたため、
一部アクセスがブロックされていた。

---

## 対応内容

* `config.hosts` に以下を追加

```
hobby-match-app.com
www.hobby-match-app.com
```

* 再デプロイ実施

---

## 確認内容

* 独自ドメインで 200 OK
* HTTPS 有効（証明書エラーなし）
* HTTP → HTTPS リダイレクト確認
* www → apex リダイレクト確認
* ログイン含む主要導線動作確認

---

## 影響範囲

* アプリケーションロジック変更なし
* DB変更なし
* 本番環境設定のみ

---

## 備考

本件はインフラ設定起因の問題であり、
アプリケーションコードの機能追加・変更はありません。
