### PR TITLE
chore: enforce one share link per room

### DIFF
--- a/app/models/share_link.rb
+++ b/app/models/share_link.rb
@@ -1,6 +1,8 @@
 class ShareLink < ApplicationRecord
   belongs_to :room
 
+  validates :room_id, uniqueness: true
+
   before_validation :set_token, on: :create
   before_validation :set_expires_at, on: :create
 

--- a/db/migrate/20260302113759_make_share_links_room_id_unique.rb
+++ b/db/migrate/20260302113759_make_share_links_room_id_unique.rb
@@ -1,0 +1,8 @@
+class MakeShareLinksRoomIdUnique < ActiveRecord::Migration[7.2]
+  def change
+    # 既存の通常indexを外して、unique indexに差し替える
+    remove_index :share_links, :room_id if index_exists?(:share_links, :room_id)
+
+    add_index :share_links, :room_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_17_130019) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_02_113759) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,7 +63,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_17_130019) do
     t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["room_id"], name: "index_share_links_on_room_id"
+    t.index ["room_id"], name: "index_share_links_on_room_id", unique: true
     t.index ["token"], name: "index_share_links_on_token", unique: true
   end
 


### PR DESCRIPTION
## Why

「1部屋1リンク」をDBレベルでも保証するため。
アプリ側の `validates :room_id, uniqueness: true` だけでは同時実行時に重複作成の可能性があるため、`share_links.room_id` に unique index を追加し整合性を担保します。

## What

* 既存の `share_links.room_id` の通常indexを削除
* `unique: true` を付けて再作成
* モデルに `validates :room_id, uniqueness: true` を追加（補助）

## 確認事項

* `rails db:migrate` が通る
* `schema.rb` に `unique: true` が反映される
* 同一roomで2件目作成時にエラーとなることを確認済み

closes #100 