### PR TITLE
refactor: simplify jsMind node selection handler

### DIFF
--- a/app/javascript/jsmind_map.js
+++ b/app/javascript/jsmind_map.js
@@ -18,8 +18,11 @@ document.addEventListener("turbo:load", () => {
 
   jm.add_event_listener((type, data) => {
     if (type !== jsMind.event_type.select) return;
-    const node = jm.get_node(data.node);
-    const url = node && node.data && node.data.data && node.data.data.url;
+
+    const nodeId = data.node;
+    const node = jm.get_node(nodeId);
+
+    const url = node?.data?.data?.url;
     if (!url) return;
 
     document.getElementById("member_detail").src = url;


### PR DESCRIPTION
## 概要

jsMind のノードクリック処理の可読性を改善しました。

## 変更内容

* `data.node` を `nodeId` 変数として切り出し
* `node.data.data.url` のアクセスを optional chaining に変更
* ノードクリック処理の可読性を向上

## 変更前

```js
const node = jm.get_node(data.node);
const url = node && node.data && node.data.data && node.data.data.url;
```

## 変更後

```js
const nodeId = data.node;
const node = jm.get_node(nodeId);

const url = node?.data?.data?.url;
```

## 目的

* コードの可読性向上
* null / undefined 安全なアクセス

## 動作確認

* jsMind マップ表示確認
* ノードクリック時に Turbo Frame (`member_detail`) にメンバー詳細が表示されることを確認

## 影響範囲

フロントエンドの jsMind ノードクリック処理のみ
