### PR TITLE
feat: プロフィール一覧にマルチ検索機能を追加 #106

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,25 @@
 
 ---
 
+# コミット粒度ルール
+
+コミットは **責務単位** で分割する。1つのPRに複数コミットを持たせてよい。
+
+## 分割の基準（例）
+
+| コミット | 対象 |
+|---------|------|
+| Query / Service オブジェクト追加 | `app/queries/`, `app/services/` + そのspec |
+| Controller・ビューへの組み込み | `app/controllers/`, `app/views/` + request spec |
+| マイグレーション | `db/migrate/`, `db/schema.rb` のみ |
+| モデル変更 | `app/models/` + model spec |
+
+* 1コミットに詰め込みすぎない
+* 「何を変えたか」が1行で言えない場合は分割を検討する
+* コミット前に必ずユーザーに分割案を提示し、確認を得る
+
+---
+
 # 禁止事項
 
 * Issueなしで実装開始

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,7 +2,7 @@ class ProfilesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @profiles = Profile.includes(:user, :hobbies).order(created_at: :desc)
+    @profiles = ProfileSearchQuery.call(q: params[:q], mode: params[:mode])
   end
 
   def show

--- a/app/queries/profile_search_query.rb
+++ b/app/queries/profile_search_query.rb
@@ -1,0 +1,50 @@
+class ProfileSearchQuery
+  # q  : 検索キーワード文字列（カンマ区切り）
+  # mode: "and" or "or"
+  def self.call(params)
+    new(params).call
+  end
+
+  def initialize(params)
+    @raw_query = params[:q].to_s.strip
+    @mode      = params[:mode].to_s == "or" ? :or : :and
+  end
+
+  def call
+    terms = @raw_query.split(",").map(&:strip).reject(&:blank?)
+    return base_scope if terms.empty?
+
+    ids = @mode == :and ? and_profile_ids(terms) : or_profile_ids(terms)
+    base_scope.where(id: ids)
+  end
+
+  private
+
+  # 全termにマッチする（趣味名 or nickname）プロフィールIDの積集合
+  def and_profile_ids(terms)
+    terms.map { |term| matched_ids_for(term) }.reduce(:&)
+  end
+
+  # いずれかのtermにマッチするプロフィールIDの和集合
+  def or_profile_ids(terms)
+    terms.flat_map { |term| matched_ids_for(term) }.uniq
+  end
+
+  # 1つのtermに対して「趣味名一致」または「nickname部分一致」するプロフィールID一覧
+  def matched_ids_for(term)
+    hobby_ids    = Hobby.where(name: term).pluck(:id)
+    by_hobby     = ProfileHobby.where(hobby_id: hobby_ids).pluck(:profile_id)
+    by_nickname  = Profile.joins(:user)
+                          .where("users.nickname LIKE ?", "%#{sanitize_sql_like(term)}%")
+                          .pluck(:id)
+    (by_hobby + by_nickname).uniq
+  end
+
+  def base_scope
+    Profile.includes(:user, :hobbies).order(created_at: :desc)
+  end
+
+  def sanitize_sql_like(str)
+    ActiveRecord::Base.sanitize_sql_like(str)
+  end
+end

--- a/app/views/profiles/_search_form.html.erb
+++ b/app/views/profiles/_search_form.html.erb
@@ -1,0 +1,34 @@
+<%= form_with url: profiles_path, method: :get, local: true, class: "flex flex-col gap-4" do |f| %>
+  <div class="flex flex-col sm:flex-row gap-3 items-start sm:items-end">
+
+    <!-- 検索ワード入力 -->
+    <div class="flex-1">
+      <%= f.label :q, "検索（趣味タグ・ユーザー名）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.text_field :q,
+            value: params[:q],
+            placeholder: "例：ゲーム, 釣り",
+            class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+    </div>
+
+    <!-- AND/OR トグル -->
+    <div class="flex items-center gap-2">
+      <span class="text-sm font-medium text-gray-700">検索モード：</span>
+      <% current_mode = params[:mode] == "or" ? "or" : "and" %>
+
+      <%= link_to "AND",
+            profiles_path(q: params[:q], mode: "and"),
+            class: "px-3 py-1.5 rounded-l-lg border text-sm font-medium #{current_mode == 'and' ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'}" %>
+      <%= link_to "OR",
+            profiles_path(q: params[:q], mode: "or"),
+            class: "px-3 py-1.5 rounded-r-lg border-t border-b border-r text-sm font-medium #{current_mode == 'or' ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'}" %>
+    </div>
+
+    <!-- 検索ボタン -->
+    <%= f.submit "検索",
+          class: "px-4 py-1.5 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg cursor-pointer" %>
+
+    <!-- リセット -->
+    <%= link_to "クリア", profiles_path,
+          class: "px-4 py-1.5 bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm font-medium rounded-lg" %>
+  </div>
+<% end %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -2,9 +2,9 @@
   <h1 class="text-2xl font-semibold text-gray-800">プロフィール一覧</h1>
   <%= link_to "共有リンク管理", my_rooms_path, class: "text-blue-600 hover:underline text-sm font-medium" %>
 
-  <!-- 検索フォーム（横幅いっぱい・実装予定） -->
+  <!-- 検索フォーム -->
   <div class="w-full rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
-    <p class="text-sm text-gray-400">検索フォーム（実装予定）</p>
+    <%= render "search_form" %>
   </div>
 
   <!-- カードグリッド：4列 -->

--- a/spec/queries/profile_search_query_spec.rb
+++ b/spec/queries/profile_search_query_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe ProfileSearchQuery do
+  let(:user_taro)  { create(:user, nickname: "たろう") }
+  let(:user_hanako) { create(:user, nickname: "はなこ") }
+  let(:user_jiro)  { create(:user, nickname: "じろう") }
+
+  let(:profile_taro)   { create(:profile, user: user_taro) }
+  let(:profile_hanako) { create(:profile, user: user_hanako) }
+  let(:profile_jiro)   { create(:profile, user: user_jiro) }
+
+  let(:hobby_game)    { create(:hobby, name: "ゲーム") }
+  let(:hobby_fishing) { create(:hobby, name: "釣り") }
+  let(:hobby_reading) { create(:hobby, name: "読書") }
+
+  before do
+    # たろう：ゲーム・釣り
+    create(:profile_hobby, profile: profile_taro, hobby: hobby_game)
+    create(:profile_hobby, profile: profile_taro, hobby: hobby_fishing)
+
+    # はなこ：ゲーム・読書
+    create(:profile_hobby, profile: profile_hanako, hobby: hobby_game)
+    create(:profile_hobby, profile: profile_hanako, hobby: hobby_reading)
+
+    # じろう：釣り
+    create(:profile_hobby, profile: profile_jiro, hobby: hobby_fishing)
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(params) }
+
+    context "条件が空の場合" do
+      let(:params) { { q: "", mode: "and" } }
+
+      it "全プロフィールを返す" do
+        expect(result).to match_array([ profile_taro, profile_hanako, profile_jiro ])
+      end
+    end
+
+    context "趣味タグ1件でAND検索の場合" do
+      let(:params) { { q: "ゲーム", mode: "and" } }
+
+      it "ゲームを持つプロフィールを返す" do
+        expect(result).to match_array([ profile_taro, profile_hanako ])
+      end
+    end
+
+    context "趣味タグ複数件でAND検索の場合" do
+      let(:params) { { q: "ゲーム,釣り", mode: "and" } }
+
+      it "ゲームと釣りを両方持つプロフィールを返す" do
+        expect(result).to match_array([ profile_taro ])
+      end
+    end
+
+    context "趣味タグ複数件でOR検索の場合" do
+      let(:params) { { q: "ゲーム,釣り", mode: "or" } }
+
+      it "ゲームまたは釣りを持つプロフィールを返す" do
+        expect(result).to match_array([ profile_taro, profile_hanako, profile_jiro ])
+      end
+    end
+
+    context "nicknameのみでAND検索の場合" do
+      let(:params) { { q: "たろう", mode: "and" } }
+
+      it "nicknameが部分一致するプロフィールを返す" do
+        expect(result).to match_array([ profile_taro ])
+      end
+    end
+
+    context "趣味タグとnicknameでAND検索の場合" do
+      let(:params) { { q: "ゲーム,たろう", mode: "and" } }
+
+      it "ゲームを持ちかつnicknameが一致するプロフィールを返す" do
+        expect(result).to match_array([ profile_taro ])
+      end
+    end
+
+    context "趣味タグとnicknameでOR検索の場合" do
+      let(:params) { { q: "読書,たろう", mode: "or" } }
+
+      it "読書を持つまたはnicknameが一致するプロフィールを返す" do
+        expect(result).to match_array([ profile_taro, profile_hanako ])
+      end
+    end
+
+    context "一致するプロフィールが存在しない場合" do
+      let(:params) { { q: "存在しない趣味", mode: "and" } }
+
+      it "空のコレクションを返す" do
+        expect(result).to be_empty
+      end
+    end
+  end
+end

--- a/spec/requests/profiles/profiles_spec.rb
+++ b/spec/requests/profiles/profiles_spec.rb
@@ -28,5 +28,33 @@ RSpec.describe "Profiles", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("未登録")
     end
+
+    context "検索クエリがある場合" do
+      let(:target_user) { create(:user, nickname: "たろう") }
+      let(:other_user)  { create(:user, nickname: "はなこ") }
+      let(:target_profile) { create(:profile, user: target_user) }
+      let(:other_profile)  { create(:profile, user: other_user) }
+      let(:hobby_game) { create(:hobby, name: "ゲーム") }
+
+      before do
+        create(:profile_hobby, profile: target_profile, hobby: hobby_game)
+      end
+
+      it "趣味タグで絞り込まれた一覧が返る" do
+        get profiles_path, params: { q: "ゲーム", mode: "and" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("たろう")
+        expect(response.body).not_to include("はなこ")
+      end
+
+      it "nicknameで絞り込まれた一覧が返る" do
+        get profiles_path, params: { q: "たろう", mode: "and" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("たろう")
+        expect(response.body).not_to include("はなこ")
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要
プロフィール一覧ページに、趣味タグ・ユーザー名によるマルチ検索機能を追加した。

## 変更内容
- `ProfileSearchQuery` を新規作成（AND/OR 検索ロジック）
- `ProfilesController#index` で `ProfileSearchQuery` を呼ぶよう変更
- 検索フォーム partial を新規作成（テキスト入力・AND/OR トグル・クリア）

## 検索仕様
- **趣味タグ**: カンマ区切りで複数指定可（例：`ゲーム, 釣り`）
- **ユーザー名**: nickname の部分一致
- **AND**: 全条件を満たすプロフィールを返す
- **OR**: いずれかの条件を満たすプロフィールを返す
- 条件なしの場合は全件表示

## テスト
- `spec/queries/profile_search_query_spec.rb`（8ケース）
- `spec/requests/profiles/profiles_spec.rb`（2ケース追加）
- 12 examples, 0 failures / RuboCop オフェンスなし

## 関連
- Closes #106
- #108（リアルタイム絞り込み）は別PRで対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)