### PR TITLE
feat: プロフィール検索をリアルタイム化（Turbo Frame + Stimulus）

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,6 +3,10 @@ class ProfilesController < ApplicationController
 
   def index
     @profiles = ProfileSearchQuery.call(q: params[:q], mode: params[:mode])
+
+    if turbo_frame_request?
+      render partial: "profiles/profile_list", locals: { profiles: @profiles }
+    end
   end
 
   def show

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import ProfileSearchController from "./profile_search_controller"
+application.register("profile-search", ProfileSearchController)

--- a/app/javascript/controllers/profile_search_controller.js
+++ b/app/javascript/controllers/profile_search_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["form", "mode"]
+
+  connect() {
+    this._debounceTimer = null
+  }
+
+  // テキスト入力時に debounce 経由でサブミット
+  search() {
+    clearTimeout(this._debounceTimer)
+    this._debounceTimer = setTimeout(() => {
+      this.formTarget.requestSubmit()
+    }, 300)
+  }
+
+  // AND/OR トグルボタン押下時
+  setMode(event) {
+    event.preventDefault()
+    const mode = event.params.mode
+    this.modeTarget.value = mode
+
+    const active   = "bg-blue-600 text-white border-blue-600"
+    const inactive = "bg-white text-gray-600 border-gray-300 hover:bg-gray-50"
+    const andBtn = this.element.querySelector("[data-profile-search-mode-param='and']")
+    const orBtn  = this.element.querySelector("[data-profile-search-mode-param='or']")
+
+    andBtn.className = `px-3 py-1.5 rounded-l-lg border text-sm font-medium ${mode === "and" ? active : inactive}`
+    orBtn.className  = `px-3 py-1.5 rounded-r-lg border-t border-b border-r text-sm font-medium ${mode === "or" ? active : inactive}`
+
+    this.formTarget.requestSubmit()
+  }
+}

--- a/app/views/profiles/_profile_list.html.erb
+++ b/app/views/profiles/_profile_list.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag "profile_list" do %>
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+    <% profiles.each do |profile| %>
+      <%= render "profile_card", profile: profile %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/profiles/_search_form.html.erb
+++ b/app/views/profiles/_search_form.html.erb
@@ -1,4 +1,17 @@
-<%= form_with url: profiles_path, method: :get, local: true, class: "flex flex-col gap-4" do |f| %>
+<%= form_with url: profiles_path,
+      method: :get,
+      local: false,
+      data: {
+        controller: "profile-search",
+        profile_search_target: "form",
+        turbo_frame: "profile_list"
+      },
+      class: "flex flex-col gap-4" do |f| %>
+
+  <!-- AND/OR hidden フィールド -->
+  <% current_mode = params[:mode] == "or" ? "or" : "and" %>
+  <%= hidden_field_tag :mode, current_mode, data: { profile_search_target: "mode" } %>
+
   <div class="flex flex-col sm:flex-row gap-3 items-start sm:items-end">
 
     <!-- 検索ワード入力 -->
@@ -7,20 +20,26 @@
       <%= f.text_field :q,
             value: params[:q],
             placeholder: "例：ゲーム, 釣り",
+            data: { action: "input->profile-search#search" },
             class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400" %>
     </div>
 
     <!-- AND/OR トグル -->
     <div class="flex items-center gap-2">
       <span class="text-sm font-medium text-gray-700">検索モード：</span>
-      <% current_mode = params[:mode] == "or" ? "or" : "and" %>
 
-      <%= link_to "AND",
-            profiles_path(q: params[:q], mode: "and"),
-            class: "px-3 py-1.5 rounded-l-lg border text-sm font-medium #{current_mode == 'and' ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'}" %>
-      <%= link_to "OR",
-            profiles_path(q: params[:q], mode: "or"),
-            class: "px-3 py-1.5 rounded-r-lg border-t border-b border-r text-sm font-medium #{current_mode == 'or' ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'}" %>
+      <button type="button"
+              data-action="click->profile-search#setMode"
+              data-profile-search-mode-param="and"
+              class="px-3 py-1.5 rounded-l-lg border text-sm font-medium <%= current_mode == 'and' ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50' %>">
+        AND
+      </button>
+      <button type="button"
+              data-action="click->profile-search#setMode"
+              data-profile-search-mode-param="or"
+              class="px-3 py-1.5 rounded-r-lg border-t border-b border-r text-sm font-medium <%= current_mode == 'or' ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50' %>">
+        OR
+      </button>
     </div>
 
     <!-- 検索ボタン -->

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -8,9 +8,5 @@
   </div>
 
   <!-- カードグリッド：4列 -->
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-    <% @profiles.each do |profile| %>
-      <%= render "profile_card", profile: profile %>
-    <% end %>
-  </div>
+  <%= render "profile_list", profiles: @profiles %>
 </div>

--- a/spec/requests/profiles/profiles_spec.rb
+++ b/spec/requests/profiles/profiles_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe "Profiles", type: :request do
       expect(response.body).to include("未登録")
     end
 
+    context "Turbo Frame リクエストの場合" do
+      it "turbo-frame id='profile_list' のみを含むレスポンスを返す" do
+        get profiles_path, headers: { "Turbo-Frame" => "profile_list" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('id="profile_list"')
+        expect(response.body).not_to include("プロフィール一覧")
+      end
+    end
+
     context "検索クエリがある場合" do
       let(:target_user) { create(:user, nickname: "たろう") }
       let(:other_user)  { create(:user, nickname: "はなこ") }


### PR DESCRIPTION
## Summary
- `turbo_frame_tag "profile_list"` でカードグリッドをパーシャルに分離し、部分レンダリングに対応
- Controller に `turbo_frame_request?` の判定を追加し、Turbo Frame リクエスト時はパーシャルのみを返すよう変更
- Stimulus `ProfileSearchController` を実装し、テキスト入力時の debounce（300ms）検索・AND/OR モード切替をリアルタイムで動作させる

## Test plan
- [x] `rspec spec/requests/profiles/profiles_spec.rb` — 5例題すべて通過
- [x] `rspec` （全体）— 66例題、0 failures
- [x] `rubocop` — Rubyファイルに違反なし

## Related
- Issue: #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)