### PR TITLE
feat: Google OmniAuth によるソーシャルログインを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,7 @@ end
 
 # deviseを追加
 gem "devise"
+
+# OmniAuth Google OAuth2
+gem "omniauth-google-oauth2"
+gem "omniauth-rails_csrf_protection"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,8 +121,16 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hashie (5.1.0)
+      logger
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -136,6 +144,8 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.18.0)
+    jwt (3.1.2)
+      base64
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -153,6 +163,10 @@ GEM
     mini_mime (1.1.5)
     minitest (5.27.0)
     msgpack (1.8.0)
+    multi_xml (0.8.1)
+      bigdecimal (>= 3.1, < 5)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.6.2)
       date
       net-protocol
@@ -179,6 +193,30 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.0-x86_64-linux-musl)
       racc (~> 1.4)
+    oauth2 (2.0.18)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0, >= 2.0.3)
+      version_gem (~> 1.1, >= 1.1.9)
+    omniauth (2.1.4)
+      hashie (>= 3.4.6)
+      logger
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-google-oauth2 (1.2.2)
+      jwt (>= 2.9.2)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.9.0)
+      oauth2 (>= 2.0.2, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (2.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -203,6 +241,10 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.4)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -311,6 +353,9 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    snaky_hash (2.0.3)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
     spring (4.4.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -336,7 +381,9 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    uri (1.1.1)
     useragent (0.16.11)
+    version_gem (1.1.9)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -375,6 +422,8 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   minitest (~> 5.20)
+  omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3)
@@ -429,13 +478,17 @@ CHECKSUMS
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   factory_bot (6.5.6) sha256=12beb373214dccc086a7a63763d6718c49769d5606f0501e0a4442676917e077
   factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
+  faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
+  faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.16.0) sha256=2abe56c9ac947cdcb2f150572904ba798c1e93c890c256f8429981a7675b0806
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
   json (2.18.0) sha256=b10506aee4183f5cf49e0efc48073d7b75843ce3782c68dbeb763351c08fd505
+  jwt (3.1.2) sha256=af6991f19a6bb4060d618d9add7a66f0eeb005ac0bc017cd01f63b42e122d535
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
@@ -446,6 +499,8 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
+  multi_xml (0.8.1) sha256=addba0290bac34e9088bfe73dc4878530297a82a7bbd66cb44dcd0a4b86edf5a
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   net-imap (0.6.2) sha256=08caacad486853c61676cca0c0c47df93db02abc4a8239a8b67eb0981428acc6
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
@@ -459,6 +514,11 @@ CHECKSUMS
   nokogiri (1.19.0-x86_64-darwin) sha256=1dad56220b603a8edb9750cd95798bffa2b8dd9dd9aa47f664009ee5b43e3067
   nokogiri (1.19.0-x86_64-linux-gnu) sha256=f482b95c713d60031d48c44ce14562f8d2ce31e3a9e8dd0ccb131e9e5a68b58c
   nokogiri (1.19.0-x86_64-linux-musl) sha256=1c4ca6b381622420073ce6043443af1d321e8ed93cc18b08e2666e5bd02ffae4
+  oauth2 (2.0.18) sha256=bacf11e470dfb963f17348666d0a75c7b29ca65bc48fd47be9057cf91a403287
+  omniauth (2.1.4) sha256=42a05b0496f0d22e1dd85d42aaf602f064e36bb47a6826a27ab55e5ba608763c
+  omniauth-google-oauth2 (1.2.2) sha256=74c3f3d0221c048f938846092fb15a1f15237526f50a7c93d9793f9a4ff1be11
+  omniauth-oauth2 (1.9.0) sha256=ed15f6d9d20991807ce114cc5b9c1453bce3645b64e51c68c90cff5ff153fee8
+  omniauth-rails_csrf_protection (2.0.1) sha256=c6e3204d7e3925bb537cb52d50fdfc9f05293f1a9d87c5d4ab4ca3a39ba8c32d
   orm_adapter (0.5.0) sha256=aa5d0be5d540cbb46d3a93e88061f4ece6a25f6e97d6a47122beb84fe595e9b9
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.0) sha256=ce3587fa5cc55a88c4ba5b2b37621b3329aadf5728f9eafa36bbd121462aabd6
@@ -477,6 +537,7 @@ CHECKSUMS
   puma (7.1.0) sha256=e45c10cb124f224d448c98db653a75499794edbecadc440ad616cf50f2fd49dd
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.4) sha256=5d74b6f75082a643f43c1e76b419c40f0e5527fcfee1e669ac1e6b73c0ccb6f6
+  rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
@@ -506,6 +567,7 @@ CHECKSUMS
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.39.0) sha256=984a1e63d39472eaf286bac3c6f1822fa7eea6eed9c07a66ce7b3bc5417ba826
+  snaky_hash (2.0.3) sha256=25a3d299566e8153fb02fa23fd9a9358845950f7a523ddbbe1fa1e0d79a6d456
   spring (4.4.0) sha256=ec4e6cf5fb48d96b9ec9a80ebb40f962f2467b651c000693f33c14b6d6c340af
   spring-commands-rspec (1.0.4) sha256=6202e54fa4767452e3641461a83347645af478bf45dddcca9737b43af0dd1a2c
   sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
@@ -519,7 +581,9 @@ CHECKSUMS
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
+  version_gem (1.1.9) sha256=0c1a0962ae543c84a00889bb018d9f14d8f8af6029d26b295d98774e3d2eb9a4
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   web-console (4.2.1) sha256=e7bcf37a10ea2b4ec4281649d1cee461b32232d0a447e82c786e6841fd22fe20
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,15 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def google_oauth2
+    result = SocialAuthService.call(request.env["omniauth.auth"])
+
+    if result.success?
+      sign_in_and_redirect result.user, event: :authentication
+    else
+      redirect_to new_user_session_path, alert: result.error_message
+    end
+  end
+
+  def failure
+    redirect_to new_user_session_path, alert: "認証に失敗しました"
+  end
+end

--- a/app/models/social_account.rb
+++ b/app/models/social_account.rb
@@ -1,0 +1,8 @@
+class SocialAccount < ApplicationRecord
+  belongs_to :user
+
+  validates :provider, presence: true
+  validates :uid, presence: true
+  validates :uid, uniqueness: { scope: :provider }
+  validates :provider, uniqueness: { scope: :user_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,9 +2,11 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :omniauthable, omniauth_providers: %i[google_oauth2]
 
 has_one :profile, dependent: :destroy
+  has_many :social_accounts, dependent: :destroy
 
 validates :nickname, presence: true, length: { maximum: 20 }
 

--- a/app/services/social_auth_service.rb
+++ b/app/services/social_auth_service.rb
@@ -1,0 +1,86 @@
+class SocialAuthService
+  Result = Struct.new(:success?, :user, :error_message, keyword_init: true)
+
+  def self.call(auth)
+    new(auth).call
+  end
+
+  def initialize(auth)
+    @auth = auth
+  end
+
+  def call
+    # 1. 既存 SocialAccount を検索
+    existing = SocialAccount.includes(:user).find_by(provider: provider, uid: uid)
+    return success(existing.user) if existing
+
+    # 2. email / email_verified チェック
+    return failure("メールアドレスが取得できませんでした") if email.blank?
+    return failure("メールアドレスが検証されていません") unless email_verified?
+
+    # 3. 同一メールの既存ユーザーを検索
+    user = User.find_by(email: email)
+
+    if user
+      user.social_accounts.create!(provider: provider, uid: uid)
+      return success(user)
+    end
+
+    # 4. 新規ユーザー + SocialAccount を作成
+    user = create_user_with_social_account
+    success(user)
+  rescue ActiveRecord::RecordNotUnique
+    # 5. 競合時: 再取得
+    existing = SocialAccount.includes(:user).find_by!(provider: provider, uid: uid)
+    success(existing.user)
+  end
+
+  private
+
+  def provider
+    @auth.provider
+  end
+
+  def uid
+    @auth.uid
+  end
+
+  def email
+    @auth.info.email
+  end
+
+  def nickname
+    name = @auth.info.name.to_s.strip
+    if name.blank?
+      "user_#{SecureRandom.hex(4)}"
+    else
+      name.truncate(20, omission: "")
+    end
+  end
+
+  def email_verified?
+    verified = @auth.dig("extra", "id_info", "email_verified")
+    verified = @auth.dig("extra", "raw_info", "email_verified") if verified.nil?
+    ActiveModel::Type::Boolean.new.cast(verified)
+  end
+
+  def create_user_with_social_account
+    ActiveRecord::Base.transaction do
+      user = User.create!(
+        email: email,
+        password: Devise.friendly_token[0, 20],
+        nickname: nickname
+      )
+      user.social_accounts.create!(provider: provider, uid: uid)
+      user
+    end
+  end
+
+  def success(user)
+    Result.new(success?: true, user: user, error_message: nil)
+  end
+
+  def failure(message)
+    Result.new(success?: false, user: nil, error_message: message)
+  end
+end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,22 +1,35 @@
-<%= form_with scope: resource, as: resource_name, url: session_path(resource_name), class: "space-y-6 w-3/4 max-w-lg bg-white p-6 rounded-lg shadow", local: true do |f| %>
- 
+<div class="flex flex-col w-3/4 max-w-lg bg-white p-6 rounded-lg shadow space-y-6">
   <label class="block text-xl font-bold text-gray-700">ログイン</label>
- 
-  <div class="mt-1">
-    <label class="text-gray-700 text-md">
-      メールアドレス
-    </label>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 py-1 px-2 block w-full sm:text-sm placeholder-gray-400 border border-gray-300 rounded-md", placeholder: "test@example.com" %>
+
+  <%= form_with scope: resource, as: resource_name, url: session_path(resource_name), class: "space-y-6", local: true do |f| %>
+    <div>
+      <label class="text-gray-700 text-md">メールアドレス</label>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 py-1 px-2 block w-full sm:text-sm placeholder-gray-400 border border-gray-300 rounded-md", placeholder: "test@example.com" %>
+    </div>
+
+    <div>
+      <label class="text-gray-700 text-md">パスワード</label>
+      <%= f.password_field :password, autocomplete: "password", class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 py-1 px-2 block w-full sm:text-sm placeholder-gray-400 border border-gray-300 rounded-md", placeholder: "pass1234" %>
+    </div>
+
+    <button type="submit" class="w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 hover:cursor-pointer">
+      ログイン
+    </button>
+  <% end %>
+
+  <div class="relative flex items-center">
+    <div class="flex-grow border-t border-gray-300"></div>
+    <span class="mx-3 text-sm text-gray-500"></span>
+    <div class="flex-grow border-t border-gray-300"></div>
   </div>
- 
-  <div class="mt-1">
-    <label class="text-gray-700 text-md">
-      パスワード
-    </label>
-    <%= f.password_field :password, autocomplete: "password", class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 py-1 px-2 block w-full sm:text-sm placeholder-gray-400 border border-gray-300 rounded-md", placeholder: "pass1234" %>
-  </div>
- 
-  <button type="submit" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 hover:cursor-pointer">
-    <%= f.submit "ログイン" %>
-  </button>
-<% end %>
+
+  <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "w-full flex items-center justify-center gap-3 py-2 px-4 border border-gray-300 rounded-md bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 hover:cursor-pointer" do %>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="20" height="20" style="min-width:20px">
+      <path fill="#EA4335" d="M24 9.5c3.14 0 5.95 1.08 8.17 2.86l6.09-6.09C34.46 3.11 29.5 1 24 1 14.82 1 7.07 6.48 3.64 14.22l7.08 5.5C12.4 13.72 17.73 9.5 24 9.5z"/>
+      <path fill="#4285F4" d="M46.5 24.5c0-1.64-.15-3.22-.42-4.75H24v9h12.7c-.55 2.98-2.2 5.5-4.67 7.2l7.17 5.57C43.26 37.27 46.5 31.36 46.5 24.5z"/>
+      <path fill="#FBBC05" d="M10.72 28.28A14.6 14.6 0 0 1 9.5 24c0-1.49.26-2.94.72-4.28l-7.08-5.5A23.94 23.94 0 0 0 0 24c0 3.86.92 7.5 2.55 10.72l8.17-6.44z"/>
+      <path fill="#34A853" d="M24 47c5.5 0 10.12-1.82 13.5-4.93l-7.17-5.57C28.6 38.1 26.42 39 24 39c-6.27 0-11.6-4.22-13.28-9.72l-8.17 6.44C6.07 43.52 14.45 47 24 47z"/>
+    </svg>
+    <span class="text-sm font-medium text-gray-700">Sign in with Google</span>
+  <% end %>
+</div>

--- a/app/views/profiles/_profile_card.html.erb
+++ b/app/views/profiles/_profile_card.html.erb
@@ -19,11 +19,13 @@
   <div class="mt-4 flex items-center gap-4">
     <%= link_to "詳細を見る",
                 profile_path(profile),
+                data: { turbo_frame: "_top" },
                 class: "text-blue-600 hover:underline text-sm font-medium" %>
 
     <% if current_user.own?(profile) %>
       <%= link_to "編集する",
                   edit_my_profile_path,
+                  data: { turbo_frame: "_top" },
                   class: "text-blue-600 hover:underline text-sm font-medium" %>
     <% end %>
   </div>

--- a/compose.yml
+++ b/compose.yml
@@ -26,6 +26,8 @@ services:
       - .:/myapp
       - bundle_data:/usr/local/bundle:cached
       - node_modules:/myapp/node_modules
+    env_file:
+      - .env
     environment:
       TZ: Asia/Tokyo
     ports:

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -305,6 +305,11 @@ Devise.setup do |config|
   config.responder.error_status = :unprocessable_entity
   config.responder.redirect_status = :see_other
 
+  # ==> OmniAuth
+  config.omniauth :google_oauth2,
+                  ENV["GOOGLE_CLIENT_ID"],
+                  ENV["GOOGLE_CLIENT_SECRET"]
+
   # ==> Configuration for :registerable
 
   # When set to false, does not sign a user in automatically after their password is

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
   get "home/index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20260310125228_create_social_accounts.rb
+++ b/db/migrate/20260310125228_create_social_accounts.rb
@@ -1,0 +1,14 @@
+class CreateSocialAccounts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :social_accounts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :provider, null: false
+      t.string :uid, null: false
+
+      t.timestamps
+    end
+
+    add_index :social_accounts, %i[provider uid], unique: true
+    add_index :social_accounts, %i[user_id provider], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_02_113759) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_10_125228) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,6 +67,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_02_113759) do
     t.index ["token"], name: "index_share_links_on_token", unique: true
   end
 
+  create_table "social_accounts", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_social_accounts_on_provider_and_uid", unique: true
+    t.index ["user_id", "provider"], name: "index_social_accounts_on_user_id_and_provider", unique: true
+    t.index ["user_id"], name: "index_social_accounts_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -87,4 +98,5 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_02_113759) do
   add_foreign_key "room_memberships", "rooms"
   add_foreign_key "rooms", "profiles", column: "issuer_profile_id"
   add_foreign_key "share_links", "rooms"
+  add_foreign_key "social_accounts", "users"
 end

--- a/spec/factories/social_accounts.rb
+++ b/spec/factories/social_accounts.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :social_account do
+    association :user
+    provider { "google_oauth2" }
+    sequence(:uid) { |n| "google_uid_#{n}" }
+  end
+end

--- a/spec/models/social_account_spec.rb
+++ b/spec/models/social_account_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe SocialAccount, type: :model do
+  describe "associations" do
+    it "belongs to user" do
+      social_account = build(:social_account)
+      expect(social_account).to respond_to(:user)
+      expect(social_account.user).to be_a(User)
+    end
+  end
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      social_account = build(:social_account)
+      expect(social_account).to be_valid
+    end
+
+    it "is invalid without provider" do
+      social_account = build(:social_account, provider: nil)
+      expect(social_account).not_to be_valid
+      expect(social_account.errors[:provider]).to be_present
+    end
+
+    it "is invalid without uid" do
+      social_account = build(:social_account, uid: nil)
+      expect(social_account).not_to be_valid
+      expect(social_account.errors[:uid]).to be_present
+    end
+
+    it "is invalid with duplicate provider and uid" do
+      create(:social_account, provider: "google_oauth2", uid: "same_uid")
+      duplicate = build(:social_account, provider: "google_oauth2", uid: "same_uid")
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:uid]).to be_present
+    end
+
+    it "is invalid with duplicate user_id and provider" do
+      user = create(:user)
+      create(:social_account, user: user, provider: "google_oauth2")
+      duplicate = build(:social_account, user: user, provider: "google_oauth2")
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:provider]).to be_present
+    end
+
+    it "allows same provider with different uids" do
+      create(:social_account, provider: "google_oauth2", uid: "uid_1")
+      other = build(:social_account, provider: "google_oauth2", uid: "uid_2")
+      expect(other).to be_valid
+    end
+
+    it "allows same user with different providers" do
+      user = create(:user)
+      create(:social_account, user: user, provider: "google_oauth2")
+      other = build(:social_account, user: user, provider: "discord")
+      expect(other).to be_valid
+    end
+  end
+
+  describe "user association" do
+    it "user has_many social_accounts" do
+      user = create(:user)
+      create(:social_account, user: user, provider: "google_oauth2")
+      create(:social_account, user: user, provider: "discord", uid: "discord_uid")
+      expect(user.social_accounts.count).to eq(2)
+    end
+  end
+end

--- a/spec/requests/users/omniauth_callbacks_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe "Users::OmniauthCallbacks", type: :request do
+  before do
+    OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+      provider: "google_oauth2",
+      uid: "123456",
+      info: {
+        email: "oauth@example.com",
+        name: "Google User"
+      },
+      extra: {
+        id_info: {
+          email_verified: true
+        }
+      }
+    )
+  end
+
+  after do
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+  end
+
+  describe "GET /users/auth/google_oauth2/callback" do
+    context "when authentication succeeds" do
+      it "signs in and redirects" do
+        get "/users/auth/google_oauth2/callback"
+
+        expect(response).to redirect_to(profiles_path)
+        expect(controller.current_user).to be_present
+      end
+
+      it "creates a new user for first-time OAuth login" do
+        expect { get "/users/auth/google_oauth2/callback" }
+          .to change(User, :count).by(1)
+          .and change(SocialAccount, :count).by(1)
+      end
+
+      it "does not create a new user when SocialAccount already exists" do
+        user = create(:user)
+        create(:social_account, user: user, provider: "google_oauth2", uid: "123456")
+
+        expect { get "/users/auth/google_oauth2/callback" }
+          .to change(User, :count).by(0)
+          .and change(SocialAccount, :count).by(0)
+      end
+    end
+
+    context "when email is missing" do
+      before do
+        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+          provider: "google_oauth2",
+          uid: "123456",
+          info: { email: nil, name: "Google User" },
+          extra: { id_info: { email_verified: true } }
+        )
+      end
+
+      it "redirects to sign in page with error message" do
+        get "/users/auth/google_oauth2/callback"
+
+        expect(response).to redirect_to(new_user_session_path)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    context "when email_verified is false" do
+      before do
+        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+          provider: "google_oauth2",
+          uid: "123456",
+          info: { email: "oauth@example.com", name: "Google User" },
+          extra: { id_info: { email_verified: false } }
+        )
+      end
+
+      it "redirects to sign in page with error message" do
+        get "/users/auth/google_oauth2/callback"
+
+        expect(response).to redirect_to(new_user_session_path)
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+end

--- a/spec/services/social_auth_service_spec.rb
+++ b/spec/services/social_auth_service_spec.rb
@@ -1,0 +1,179 @@
+require "rails_helper"
+
+RSpec.describe SocialAuthService, type: :service do
+  let(:auth) do
+    OmniAuth::AuthHash.new(
+      provider: "google_oauth2",
+      uid: "123456",
+      info: {
+        email: "oauth@example.com",
+        name: "Google User"
+      },
+      extra: {
+        id_info: {
+          email_verified: true
+        }
+      }
+    )
+  end
+
+  describe ".call" do
+    context "when SocialAccount already exists for provider + uid" do
+      it "returns the existing user" do
+        user = create(:user)
+        create(:social_account, user: user, provider: "google_oauth2", uid: "123456")
+
+        result = described_class.call(auth)
+
+        expect(result).to be_success
+        expect(result.user).to eq(user)
+      end
+
+      it "does not create a new User or SocialAccount" do
+        user = create(:user)
+        create(:social_account, user: user, provider: "google_oauth2", uid: "123456")
+
+        expect { described_class.call(auth) }
+          .to change(User, :count).by(0)
+          .and change(SocialAccount, :count).by(0)
+      end
+    end
+
+    context "when SocialAccount does not exist but same email user exists" do
+      it "links SocialAccount to existing user" do
+        existing_user = create(:user, email: "oauth@example.com")
+
+        result = described_class.call(auth)
+
+        expect(result).to be_success
+        expect(result.user).to eq(existing_user)
+        expect(existing_user.social_accounts.find_by(provider: "google_oauth2", uid: "123456")).to be_present
+      end
+
+      it "creates a SocialAccount but not a User" do
+        create(:user, email: "oauth@example.com")
+
+        expect { described_class.call(auth) }
+          .to change(User, :count).by(0)
+          .and change(SocialAccount, :count).by(1)
+      end
+    end
+
+    context "when neither SocialAccount nor same email user exists" do
+      it "creates a new User and SocialAccount" do
+        result = described_class.call(auth)
+
+        expect(result).to be_success
+        expect(result.user).to be_persisted
+        expect(result.user.email).to eq("oauth@example.com")
+        expect(result.user.social_accounts.find_by(provider: "google_oauth2", uid: "123456")).to be_present
+      end
+
+      it "increments User and SocialAccount counts" do
+        expect { described_class.call(auth) }
+          .to change(User, :count).by(1)
+          .and change(SocialAccount, :count).by(1)
+      end
+    end
+
+    context "nickname handling" do
+      it "sets auth.info.name as nickname" do
+        result = described_class.call(auth)
+
+        expect(result.user.nickname).to eq("Google User")
+      end
+
+      it "truncates nickname longer than 20 characters" do
+        auth.info.name = "A" * 25
+
+        result = described_class.call(auth)
+
+        expect(result.user.nickname).to eq("A" * 20)
+      end
+
+      it "sets fallback nickname when name is blank" do
+        auth.info.name = ""
+
+        result = described_class.call(auth)
+
+        expect(result.user.nickname).to be_present
+        expect(result.user.nickname.length).to be <= 20
+      end
+
+      it "sets fallback nickname when name is nil" do
+        auth.info.name = nil
+
+        result = described_class.call(auth)
+
+        expect(result.user.nickname).to be_present
+      end
+    end
+
+    context "when email is missing" do
+      it "returns failure result" do
+        auth.info.email = nil
+
+        result = described_class.call(auth)
+
+        expect(result).not_to be_success
+        expect(result.error_message).to be_present
+      end
+
+      it "returns failure when email is empty string" do
+        auth.info.email = ""
+
+        result = described_class.call(auth)
+
+        expect(result).not_to be_success
+      end
+    end
+
+    context "when email_verified is not true" do
+      it "returns failure when email_verified is false in id_info" do
+        auth.extra.id_info.email_verified = false
+
+        result = described_class.call(auth)
+
+        expect(result).not_to be_success
+        expect(result.error_message).to be_present
+      end
+
+      it "falls back to raw_info when id_info is not available" do
+        auth.extra = { raw_info: { email_verified: "true" } }
+
+        result = described_class.call(auth)
+
+        expect(result).to be_success
+      end
+
+      it "returns failure when raw_info email_verified is false string" do
+        auth.extra = { raw_info: { email_verified: "false" } }
+
+        result = described_class.call(auth)
+
+        expect(result).not_to be_success
+      end
+    end
+
+    context "when RecordNotUnique is raised (race condition)" do
+      it "retries and returns the existing SocialAccount user" do
+        user = create(:user, email: "oauth@example.com")
+
+        first_call = true
+        allow_any_instance_of(ActiveRecord::Associations::CollectionProxy).to receive(:create!).and_wrap_original do |method, **args|
+          if first_call
+            first_call = false
+            create(:social_account, user: user, provider: "google_oauth2", uid: "123456")
+            raise ActiveRecord::RecordNotUnique
+          end
+          method.call(**args)
+        end
+
+        result = described_class.call(auth)
+
+        expect(result).to be_success
+        expect(result.user).to eq(user)
+      end
+    end
+  end
+end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,0 +1,2 @@
+OmniAuth.config.test_mode = true
+OmniAuth.config.silence_get_warning = true


### PR DESCRIPTION
## Summary
- `social_accounts` テーブルと `SocialAccount` モデルを追加し、Google アカウントとユーザーの紐付けを管理
- `SocialAuthService` を追加し、初回ログイン・既存ユーザー連携・レースコンディション対応を実装
- `omniauth-google-oauth2` gem を導入し、Devise に Google OmniAuth を設定
- ログイン画面に Google サインインボタンを追加
- Turbo Frame 内のプロフィールカードリンクに `data-turbo-frame: "_top"` を追加し、ページ遷移を修正

## Test plan
- [x] Google アカウントで初回ログイン → 新規ユーザーが作成されること
- [x] 同じ Google アカウントで再ログイン → 既存ユーザーでサインインされること
- [x] メールアドレス未検証の Google アカウントでログイン → エラーメッセージが表示されること
- [x] ログイン画面に「Sign in with Google」ボタンが表示されること
- [x] プロフィール一覧の「詳細を見る」「編集する」リンクが正常に遷移すること
- [x] RSpec: 96 examples, 0 failures
- [x] RuboCop: no offenses

## Related
- Issue: #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)