### PR TITLE
fix: ダッシュボードUIの中央揃えを条件制御し、ルーム一覧レイアウトを修正

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: issue
-description: GitHub Issueを作成する。Phase 0の整理結果を基に、GitHub Projectに紐づくIssueを作成する。
+description: GitHub Issueと作業ブランチを作成する。Phase 1の設計合意後に実行する。
 user-invocable: true
 disable-model-invocation: false
 allowed-tools: Bash, AskUserQuestion
 ---
 
-# Issue作成
+# Issue + 作業ブランチ作成
 
-GitHub Issueを作成します。CLAUDE.mdの「Issueを作成してから作業開始」ルールに対応します。
+Phase 1（設計合意）完了後に、GitHub Issue と作業ブランチを作成します。
 
 ## 依頼内容
 
@@ -18,7 +18,7 @@ $ARGUMENTS
 
 ### 1. Issue内容の確認
 
-Phase 0（インテイク）の結果がある場合はそれを基にする。
+Phase 0〜1 の合意内容を基にする。
 ない場合は $ARGUMENTS からIssue内容を整理する。
 
 以下をAskUserQuestionで確認する：
@@ -45,12 +45,25 @@ EOF
 )" --project "hobby-matching-app"
 ```
 
-### 3. 完了報告
-- Issue URLを表示する
-- 対応するブランチ名を提案する（例：`feature/search-profiles-123`）
+### 3. 作業ブランチ作成
+
+Issue番号を含むブランチを main から作成する：
+
+```bash
+git checkout main && git pull origin main && git checkout -b feature/<Issue番号>-<短い説明>
+```
+
+ブランチ名の例：`feature/114-dashboard-ui-consistency`
+
+### 4. 完了報告
+
+- Issue URL を表示する
+- 作成したブランチ名を表示する
 
 ## ルール
 
 - Issueタイトルは簡潔に（50文字以内目安）
 - 受入条件はチェックリスト形式にする
 - GitHub Project「hobby-matching-app」に紐づける
+- ブランチ名はIssue番号を含める（例: `feature/123-xxx`）
+- main から最新を pull してからブランチを切る

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 ## 最重要ルール（絶対遵守）
 
-* **Issueを作成してから**作業開始（GitHub Project「hobby-matching-app」に作成）
-* ブランチ作成 → **RED → GREEN → REFACTOR** → PR
+* **Phase 1 設計合意後に Issue + 作業ブランチを作成**してから実装開始（GitHub Project「hobby-matching-app」に作成）
+* **RED → GREEN → REFACTOR** → PR
 * すべてのコマンドは `docker compose exec web` 経由
 * PR前に **RSpec / RuboCop 全通過**
 * 不明点が1つでもある場合、必ず質問する（推測で実装しない）
@@ -29,6 +29,11 @@
 * 複数案がある場合は 案A / 案B / 推奨案 / トレードオフ を提示する
 
 合意が取れるまで次へ進まない。
+
+### 設計合意後
+
+1. `/issue` で GitHub Issue + 作業ブランチを作成する
+2. Issue / ブランチが揃ってから Phase 2 へ進む
 
 ---
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
     <div id="flash">
         <%= render 'shared/flash' %>
     </div>
-    <main class="container mx-auto mt-20 py-8 px-5 flex items-center justify-center">
+    <main class="container mx-auto mt-20 py-8 px-5 <%= content_for?(:no_center) ? '' : 'flex items-center justify-center' %>">
       <%= yield %>
     </main>
   </body>

--- a/app/views/my/rooms/_room.html.erb
+++ b/app/views/my/rooms/_room.html.erb
@@ -1,16 +1,16 @@
         <%= turbo_frame_tag dom_id(room) do %>
-          <div class="bg-white rounded-xl shadow-md p-6 border border-gray-200">
+          <div class="bg-white rounded-xl shadow-md p-6 border border-gray-200 flex flex-col">
 
             <!-- 部屋名 -->
             <h3 class="text-lg font-semibold mb-3">
-              ■ <%= room.label.presence || "名無しの部屋" %>
+              🏠 <%= room.label.presence || "名無しの部屋" %>
             </h3>
 
             <% if link.present? %>
 
               <!-- URL -->
-              <p class="text-sm text-gray-600 break-all mb-2">
-                共有URL:<br>
+              <p class="text-sm break-all mb-2">
+                <span class="text-gray-500 font-medium">共有URL</span><br>
                 <%= link_to share_url(link.token),
                             share_path(link.token),
                             target: "_blank",
@@ -19,7 +19,7 @@
 
               <!-- 有効期限 -->
               <p class="text-sm mb-2">
-                有効期限:
+                <span class="text-gray-500 font-medium">有効期限</span>
                 <%= link.expires_at.strftime("%Y/%m/%d %H:%M") if link.expires_at.present? %>
 
 
@@ -42,7 +42,7 @@
             </p>
 
             <!-- 操作 -->
-            <div class="flex justify-between text-sm">
+            <div class="flex justify-end gap-4 text-sm w-full">
               <%= link_to "編集",
                           edit_my_room_path(room),
                           data: { turbo_frame: dom_id(room) },

--- a/app/views/my/rooms/index.html.erb
+++ b/app/views/my/rooms/index.html.erb
@@ -10,7 +10,7 @@
   <!-- 作成フォーム -->
   <div class="bg-white shadow-md rounded-xl p-6 mb-10">
     <h2 class="text-xl font-semibold mb-4">
-      ＋ 新しい共有リンクを作る
+      ＋ 部屋を新規作成
     </h2>
 
     <%= form_with model: Room.new, url: my_rooms_path, class: "space-y-4" do |f| %>
@@ -20,7 +20,7 @@
               class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
       </div>
 
-      <%= f.submit "共有リンクを作成",
+      <%= f.submit "部屋を作成",
             class: "bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg shadow" %>
     <% end %>
   </div>

--- a/app/views/my/rooms/index.html.erb
+++ b/app/views/my/rooms/index.html.erb
@@ -1,4 +1,5 @@
 <!-- app/views/my/rooms/index.html.erb -->
+<% content_for :no_center, true %>
 
 <div class="max-w-6xl mx-auto px-6 py-10">
 
@@ -35,8 +36,6 @@
 
     </div>
 
-  <% else %>
-    <p class="text-gray-500">まだ部屋は作成されていません。</p>
   <% end %>
 
 </div>


### PR DESCRIPTION
## Summary
- `application.html.erb` の `<main>` タグに `content_for(:no_center)` による条件分岐を追加し、ページごとに中央揃えを無効化できる仕組みを導入
- ルーム一覧ページ (`my/rooms/index.html.erb`) で `content_for :no_center` を設定し、左寄せレイアウトに統一
- 「まだ部屋は作成されていません」の不要な `else` 分岐を削除
- `/issue` スキルにブランチ自動作成手順を追加し、`CLAUDE.md` の開発フローを更新

## Test plan
- [x] RSpec 96 examples, 0 failures 通過確認済み
- [x] RuboCop 99 files, no offenses 確認済み
- [x] ルーム一覧ページのレイアウトが左寄せで正しく表示されること
- [x] 他ページの中央揃えレイアウトに影響がないこと

## Related
- Issue: #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)