### PR TITLE
feat: Discord OAuth連携を追加する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ end
 # deviseを追加
 gem "devise"
 
-# OmniAuth Google OAuth2
+# OmniAuth
 gem "omniauth-google-oauth2"
+gem "omniauth-discord"
 gem "omniauth-rails_csrf_protection"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,8 @@ GEM
       logger
       rack (>= 2.2.3)
       rack-protection
+    omniauth-discord (1.2.0)
+      omniauth-oauth2 (~> 1.6)
     omniauth-google-oauth2 (1.2.2)
       jwt (>= 2.9.2)
       oauth2 (~> 2.0)
@@ -422,6 +424,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   minitest (~> 5.20)
+  omniauth-discord
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   pg (~> 1.1)
@@ -516,6 +519,7 @@ CHECKSUMS
   nokogiri (1.19.0-x86_64-linux-musl) sha256=1c4ca6b381622420073ce6043443af1d321e8ed93cc18b08e2666e5bd02ffae4
   oauth2 (2.0.18) sha256=bacf11e470dfb963f17348666d0a75c7b29ca65bc48fd47be9057cf91a403287
   omniauth (2.1.4) sha256=42a05b0496f0d22e1dd85d42aaf602f064e36bb47a6826a27ab55e5ba608763c
+  omniauth-discord (1.2.0) sha256=e6e92649a645862ccb29ce3d5f2f876de9e26198722b9d05f9f6d4f3805d5c70
   omniauth-google-oauth2 (1.2.2) sha256=74c3f3d0221c048f938846092fb15a1f15237526f50a7c93d9793f9a4ff1be11
   omniauth-oauth2 (1.9.0) sha256=ed15f6d9d20991807ce114cc5b9c1453bce3645b64e51c68c90cff5ff153fee8
   omniauth-rails_csrf_protection (2.0.1) sha256=c6e3204d7e3925bb537cb52d50fdfc9f05293f1a9d87c5d4ab4ca3a39ba8c32d

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,5 +1,19 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def google_oauth2
+    handle_oauth
+  end
+
+  def discord
+    handle_oauth
+  end
+
+  def failure
+    redirect_to new_user_session_path, alert: "認証に失敗しました"
+  end
+
+  private
+
+  def handle_oauth
     result = SocialAuthService.call(request.env["omniauth.auth"])
 
     if result.success?
@@ -7,9 +21,5 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     else
       redirect_to new_user_session_path, alert: result.error_message
     end
-  end
-
-  def failure
-    redirect_to new_user_session_path, alert: "認証に失敗しました"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: %i[google_oauth2]
+         :omniauthable, omniauth_providers: %i[google_oauth2 discord]
 
 has_one :profile, dependent: :destroy
   has_many :social_accounts, dependent: :destroy

--- a/app/services/social_auth_service.rb
+++ b/app/services/social_auth_service.rb
@@ -59,9 +59,16 @@ class SocialAuthService
   end
 
   def email_verified?
-    verified = @auth.dig("extra", "id_info", "email_verified")
-    verified = @auth.dig("extra", "raw_info", "email_verified") if verified.nil?
-    ActiveModel::Type::Boolean.new.cast(verified)
+    case @auth.provider
+    when "google_oauth2"
+      verified = @auth.dig("extra", "id_info", "email_verified")
+      verified = @auth.dig("extra", "raw_info", "email_verified") if verified.nil?
+      ActiveModel::Type::Boolean.new.cast(verified)
+    when "discord"
+      @auth.extra&.raw_info&.verified == true
+    else
+      false
+    end
   end
 
   def create_user_with_social_account

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -32,4 +32,11 @@
     </svg>
     <span class="text-sm font-medium text-gray-700">Sign in with Google</span>
   <% end %>
+
+  <%= button_to user_discord_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "w-full flex items-center justify-center gap-3 py-2 px-4 border border-gray-300 rounded-md bg-[#5865F2] hover:bg-[#4752C4] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#5865F2] hover:cursor-pointer" do %>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 127.14 96.36" width="20" height="20" style="min-width:20px">
+      <path fill="#ffffff" d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"/>
+    </svg>
+    <span class="text-sm font-medium text-white">Sign in with Discord</span>
+  <% end %>
 </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,6 +310,11 @@ Devise.setup do |config|
                   ENV["GOOGLE_CLIENT_ID"],
                   ENV["GOOGLE_CLIENT_SECRET"]
 
+  config.omniauth :discord,
+                  ENV["DISCORD_CLIENT_ID"],
+                  ENV["DISCORD_CLIENT_SECRET"],
+                  scope: "identify email"
+
   # ==> Configuration for :registerable
 
   # When set to false, does not sign a user in automatically after their password is

--- a/spec/requests/users/omniauth_callbacks_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_spec.rb
@@ -82,4 +82,57 @@ RSpec.describe "Users::OmniauthCallbacks", type: :request do
       end
     end
   end
+
+  describe "GET /users/auth/discord/callback" do
+    before do
+      OmniAuth.config.mock_auth[:discord] = OmniAuth::AuthHash.new(
+        provider: "discord",
+        uid: "discord_789",
+        info: {
+          email: "discord@example.com",
+          name: "DiscordUser"
+        },
+        extra: {
+          raw_info: { verified: true }
+        }
+      )
+    end
+
+    after do
+      OmniAuth.config.mock_auth[:discord] = nil
+    end
+
+    context "when authentication succeeds" do
+      it "signs in and redirects" do
+        get "/users/auth/discord/callback"
+
+        expect(response).to redirect_to(profiles_path)
+        expect(controller.current_user).to be_present
+      end
+
+      it "creates a new user for first-time OAuth login" do
+        expect { get "/users/auth/discord/callback" }
+          .to change(User, :count).by(1)
+          .and change(SocialAccount, :count).by(1)
+      end
+    end
+
+    context "when email is not verified" do
+      before do
+        OmniAuth.config.mock_auth[:discord] = OmniAuth::AuthHash.new(
+          provider: "discord",
+          uid: "discord_789",
+          info: { email: "discord@example.com", name: "DiscordUser" },
+          extra: { raw_info: { verified: false } }
+        )
+      end
+
+      it "redirects to sign in page with error message" do
+        get "/users/auth/discord/callback"
+
+        expect(response).to redirect_to(new_user_session_path)
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
 end

--- a/spec/services/social_auth_service_spec.rb
+++ b/spec/services/social_auth_service_spec.rb
@@ -155,6 +155,55 @@ RSpec.describe SocialAuthService, type: :service do
       end
     end
 
+    context "with Discord provider" do
+      let(:discord_auth) do
+        OmniAuth::AuthHash.new(
+          provider: "discord",
+          uid: "discord_789",
+          info: {
+            email: "discord@example.com",
+            name: "DiscordUser"
+          },
+          extra: {
+            raw_info: {
+              verified: true
+            }
+          }
+        )
+      end
+
+      context "when email is verified" do
+        it "creates a new user successfully" do
+          result = described_class.call(discord_auth)
+
+          expect(result).to be_success
+          expect(result.user.email).to eq("discord@example.com")
+          expect(result.user.nickname).to eq("DiscordUser")
+        end
+      end
+
+      context "when email is not verified" do
+        it "returns failure" do
+          discord_auth.extra.raw_info.verified = false
+
+          result = described_class.call(discord_auth)
+
+          expect(result).not_to be_success
+          expect(result.error_message).to be_present
+        end
+      end
+
+      context "when verified is nil" do
+        it "returns failure" do
+          discord_auth.extra.raw_info.verified = nil
+
+          result = described_class.call(discord_auth)
+
+          expect(result).not_to be_success
+        end
+      end
+    end
+
     context "when RecordNotUnique is raised (race condition)" do
       it "retries and returns the existing SocialAccount user" do
         user = create(:user, email: "oauth@example.com")


### PR DESCRIPTION
## Summary
- omniauth-discord gemを追加し、Discord OAuthログイン機能を実装
- SocialAuthServiceの`email_verified?`をプロバイダー別分岐に変更（Google/Discord対応）
- OmniauthCallbacksControllerのOAuthコールバック処理を`handle_oauth`に共通化
- ログイン画面にDiscordログインボタンを追加

closes #122

## Test plan
- [x] RSpec全通過（27 examples, 0 failures）
- [x] RuboCopオフェンスなし
- [ ] Discordアカウントで新規登録・ログインできる
- [x] 既存のGoogleログイン・メール/パスワードログインが壊れない
- [x] メール未認証のDiscordアカウントではログイン失敗になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)