### PR TITLE
chore: 共有リンク部屋ページのレイアウト調整

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
     <div id="flash">
         <%= render 'shared/flash' %>
     </div>
-    <main class="container mx-auto mt-20 py-8 px-5 <%= content_for?(:no_center) ? '' : 'flex items-center justify-center' %>">
+    <main class="<%= content_for?(:full_width) ? 'mt-20 py-8 px-4' : "container mx-auto mt-20 py-8 px-5 #{content_for?(:no_center) ? '' : 'flex items-center justify-center'}" %>">
       <%= yield %>
     </main>
   </body>

--- a/app/views/rooms/members/show.html.erb
+++ b/app/views/rooms/members/show.html.erb
@@ -1,10 +1,13 @@
 <turbo-frame id="member_detail">
-  <div class="p-6 bg-white rounded-2xl border border-gray-200 shadow-sm">
-    <h2 class="text-xl font-bold text-gray-800 mb-4">
-      <%= @profile.user.nickname.presence || "no-name" %>
-    </h2>
+  <div class="bg-white rounded-xl shadow p-6 space-y-4">
+    <div>
+      <p class="text-sm text-gray-500">ユーザー名</p>
+      <p class="text-base font-medium text-gray-800">
+        <%= @profile.user.nickname.presence || "no-name" %>
+      </p>
+    </div>
 
-    <p class="text-sm text-gray-500 mb-2">この部屋での趣味</p>
+    <p class="text-sm text-gray-500 mb-1">この部屋での趣味</p>
     <% if @shared_hobbies.any? %>
       <div data-controller="tag-toggle">
         <%# 説明文データ（非表示） %>
@@ -32,7 +35,7 @@
         </ul>
 
         <div data-tag-toggle-target="panel"
-             class="hidden mt-3 px-3 py-2 rounded-lg bg-gray-50 border border-gray-200 text-sm text-gray-700 whitespace-pre-line">
+             class="hidden mt-3 px-3 py-2 rounded-lg bg-gray-50 border border-gray-200 text-sm text-gray-700 whitespace-pre-line break-words">
         </div>
       </div>
     <% else %>

--- a/app/views/shares/show.html.erb
+++ b/app/views/shares/show.html.erb
@@ -3,10 +3,12 @@
   <%= javascript_include_tag "jsmind_map", "data-turbo-track": "reload", type: "module" %>
 <% end %>
 
-<div class="w-full px-6 py-10">
+<% content_for :full_width, true %>
+
+<div class="w-full">
 
   <!-- 部屋名 -->
-  <h1 class="text-3xl font-bold mb-8 text-center">
+  <h1 class="text-3xl font-bold mb-8">
     <%= @room.label.presence || "名無しの部屋" %>
   </h1>
 
@@ -21,21 +23,21 @@
   <% end %>
 
   <!-- 2カラムレイアウト -->
-  <div class="flex flex-col md:flex-row gap-6">
+  <div class="flex flex-col md:flex-row gap-8">
 
     <!-- 左ペイン：jsMind マインドマップ -->
-    <div class="md:w-1/2">
+    <div class="md:w-[60%]">
       <div
         id="jsmind_container"
         data-jsmind="<%= @jsmind_data.to_json %>"
-        style="width: 100%; height: 500px; border: 1px solid #e5e7eb; border-radius: 0.5rem; overflow: hidden;"
+        style="width: 100%; height: 600px; border: 1px solid #e5e7eb; border-radius: 0.5rem; overflow: hidden;"
       ></div>
     </div>
 
     <!-- 右ペイン：メンバー詳細（Turbo Frame） -->
-    <div class="md:w-1/2">
+    <div class="md:w-[40%]">
       <turbo-frame id="member_detail">
-        <div class="p-6 bg-gray-50 rounded-2xl border border-gray-200 text-gray-400 text-sm flex items-center justify-center h-full">
+        <div class="bg-gray-50 rounded-xl shadow p-6 text-gray-400 text-sm flex items-center justify-center h-full">
           左のマインドマップからメンバーを選択してください
         </div>
       </turbo-frame>


### PR DESCRIPTION
## Summary
- マインドマップとプロフィールカードの比率を50:50から60:40に変更
- `content_for(:full_width)` を追加し、部屋ページのみフル幅レイアウトに変更
- 部屋名を左寄せに変更
- 右ペインのカードスタイルをプロフィール詳細ページと統一
- 説明文テキストに `break-words` を追加して折り返し対応

closes #124

## Test plan
- [x] RSpec全通過（10 examples, 0 failures）
- [x] 部屋ページのマインドマップが60%、プロフィールカードが40%で表示される
- [x] 左右の余白が適切に狭まっている
- [x] 他のページのレイアウトに影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)