### PR TITLE
feat: 部屋管理ページに共有URLコピーボタンを追加 (#132)

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { text: String }
+  static targets = ["button"]
+
+  copy() {
+    navigator.clipboard.writeText(this.textValue).then(() => {
+      const button = this.buttonTarget
+      const originalText = button.textContent
+      button.textContent = "Copied!"
+      setTimeout(() => {
+        button.textContent = originalText
+      }, 1500)
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -21,3 +21,6 @@ application.register("tag-toggle", TagToggleController)
 
 import InlineEditController from "./inline_edit_controller"
 application.register("inline-edit", InlineEditController)
+
+import ClipboardController from "./clipboard_controller"
+application.register("clipboard", ClipboardController)

--- a/app/views/mypage/rooms/_room.html.erb
+++ b/app/views/mypage/rooms/_room.html.erb
@@ -7,20 +7,20 @@
 
     <% if link.present? %>
       <%# 共有URL %>
-      <div class="text-sm break-all mb-2" data-controller="clipboard" data-clipboard-text-value="<%= share_url(link.token) %>">
-        <span class="text-gray-500 font-medium">共有URL</span><br>
-        <div class="flex items-center gap-2">
-          <%= link_to share_url(link.token),
-                      share_path(link.token),
-                      target: "_blank",
-                      class: "text-indigo-600 hover:underline" %>
+      <div class="text-base break-all mb-2" data-controller="clipboard" data-clipboard-text-value="<%= share_url(link.token) %>">
+        <div class="flex items-center gap-2 mb-1">
+          <span class="text-gray-500 font-medium text-sm">共有URL</span>
           <button type="button"
                   data-clipboard-target="button"
                   data-action="click->clipboard#copy"
-                  class="inline-flex items-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 border border-indigo-200 rounded hover:bg-indigo-100 transition-colors">
+                  class="inline-flex items-center px-2 py-0.5 text-xs font-medium text-indigo-600 bg-indigo-50 border border-indigo-200 rounded hover:bg-indigo-100 transition-colors">
             Copy
           </button>
         </div>
+        <%= link_to share_url(link.token),
+                    share_path(link.token),
+                    target: "_blank",
+                    class: "text-indigo-600 hover:underline" %>
       </div>
 
       <%# 有効期限 %>

--- a/app/views/mypage/rooms/_room.html.erb
+++ b/app/views/mypage/rooms/_room.html.erb
@@ -7,13 +7,21 @@
 
     <% if link.present? %>
       <%# 共有URL %>
-      <p class="text-sm break-all mb-2">
+      <div class="text-sm break-all mb-2" data-controller="clipboard" data-clipboard-text-value="<%= share_url(link.token) %>">
         <span class="text-gray-500 font-medium">共有URL</span><br>
-        <%= link_to share_url(link.token),
-                    share_path(link.token),
-                    target: "_blank",
-                    class: "text-indigo-600 hover:underline" %>
-      </p>
+        <div class="flex items-center gap-2">
+          <%= link_to share_url(link.token),
+                      share_path(link.token),
+                      target: "_blank",
+                      class: "text-indigo-600 hover:underline" %>
+          <button type="button"
+                  data-clipboard-target="button"
+                  data-action="click->clipboard#copy"
+                  class="inline-flex items-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 border border-indigo-200 rounded hover:bg-indigo-100 transition-colors">
+            Copy
+          </button>
+        </div>
+      </div>
 
       <%# 有効期限 %>
       <p class="text-sm mb-2">


### PR DESCRIPTION
## Summary
- Stimulus `ClipboardController` を新規作成し、`navigator.clipboard.writeText()` でコピー処理を実装
- 部屋管理ページの共有URL横に「Copy」ボタンを追加
- コピー後ボタンテキストが「Copied!」に変わり、1.5秒後に元に戻る

## Test plan
- [x] Copyボタンクリックで共有URLがクリップボードにコピーされる
- [x] コピー後ボタンが「Copied!」→元に戻る
- [x] RSpec 全通過（168 examples, 0 failures）
- [x] RuboCop 0 offenses
- [x] 既存機能に影響がないこと

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)