### PR TITLE
fix: プロフィール新規作成時のタグデータ保持修正 (#91)

### DIFF
--- a/app/controllers/my/profiles_controller.rb
+++ b/app/controllers/my/profiles_controller.rb
@@ -15,6 +15,7 @@ class My::ProfilesController < ApplicationController
       @profile.update_hobbies_from_json(@profile.hobbies_text)
       redirect_to profile_path(@profile), notice: "プロフィールを作成しました"
     else
+      @hobbies_text = @profile.hobbies_text
       flash.now[:alert] = "プロフィールを作成できませんでした"
       render :new, status: :unprocessable_entity
     end

--- a/spec/requests/my/profile_spec.rb
+++ b/spec/requests/my/profile_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe "My::Profile", type: :request do
     end
   end
 
+  describe "POST /my/profile" do
+    it "11個のタグで作成するとバリデーションエラーになりタグデータが保持される" do
+      hobbies_text = (1..11).map { |i| { name: "タグ#{i}", description: "" } }.to_json
+
+      post my_profile_path, params: { profile: { hobbies_text: } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("タグ1")
+    end
+  end
+
   describe "GET /my/profile/new" do
     it "作成済みなら一覧へリダイレクトしnoticeが出る" do
       create(:profile, user:)


### PR DESCRIPTION
## Summary
- `create` アクションのバリデーションエラー時に `@hobbies_text` が未設定だったため、再描画時にタグチップが消えていた
- `update` アクションと同じパターンで `@hobbies_text = @profile.hobbies_text` を追加
- request spec を追加し、エラー時にタグデータが保持されることを検証

## Test plan
- [x] 11個のタグでプロフィール新規作成 → バリデーションエラー後もタグが保持される
- [x] RSpec 全通過（169 examples, 0 failures）
- [x] RuboCop 0 offenses

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)