### PR TITLE
chore: レスポンシブ対応・jsMindレイアウト調整 (#66)

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_with scope: resource, as: resource_name, url: registration_path(resource_name), class: "space-y-6 w-3/4 max-w-lg bg-white p-6 rounded-lg shadow" ,local: true do |f| %>
+<%= form_with scope: resource, as: resource_name, url: registration_path(resource_name), class: "space-y-6 w-full sm:w-3/4 max-w-lg bg-white p-6 rounded-lg shadow" ,local: true do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
  
   <label class="block text-xl font-bold text-gray-700">ユーザー登録</label>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="flex flex-col w-3/4 max-w-lg bg-white p-6 rounded-lg shadow space-y-6">
+<div class="flex flex-col w-full sm:w-3/4 max-w-lg bg-white p-6 rounded-lg shadow space-y-6">
   <label class="block text-xl font-bold text-gray-700">ログイン</label>
 
   <%= form_with scope: resource, as: resource_name, url: session_path(resource_name), class: "space-y-6", local: true do |f| %>

--- a/app/views/mypage/rooms/_form.html.erb
+++ b/app/views/mypage/rooms/_form.html.erb
@@ -9,7 +9,7 @@
         <%= f.label :label, "部屋名", class: "sr-only" %>
         <%= f.text_field :label,
               placeholder: "名無しの部屋",
-              class: "w-64 max-w-full border border-gray-300 rounded-md px-3 py-2 text-sm shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
+              class: "w-full sm:w-64 max-w-full border border-gray-300 rounded-md px-3 py-2 text-sm shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
       </h3>
 
       <% if link.present? %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,4 +1,4 @@
-<div class="w-3/4 max-w-lg space-y-6">
+<div class="w-full sm:w-3/4 max-w-lg space-y-6">
 
   <!-- タイトル -->
   <h1 class="text-xl font-bold text-gray-700 border-b pb-2">

--- a/app/views/shares/show.html.erb
+++ b/app/views/shares/show.html.erb
@@ -5,7 +5,7 @@
 
 <% content_for :full_width, true %>
 
-<div class="w-full">
+<div class="container mx-auto">
 
   <!-- 部屋名 -->
   <h1 class="text-3xl font-bold mb-8">
@@ -26,7 +26,7 @@
   <div class="flex flex-col md:flex-row gap-8">
 
     <!-- 左ペイン：jsMind マインドマップ -->
-    <div class="md:w-[60%]">
+    <div class="md:w-[58%]">
       <div
         id="jsmind_container"
         data-jsmind="<%= @jsmind_data.to_json %>"
@@ -35,7 +35,7 @@
     </div>
 
     <!-- 右ペイン：メンバー詳細（Turbo Frame） -->
-    <div class="md:w-[40%]">
+    <div class="md:w-[42%]">
       <turbo-frame id="member_detail">
         <div class="bg-gray-50 rounded-xl shadow p-6 text-gray-400 text-sm flex items-center justify-center h-full">
           左のマインドマップからメンバーを選択してください


### PR DESCRIPTION
## Summary
- jsMindページに `container mx-auto` を追加しヘッダーと余白を統一、カラム比率を58:42に調整
- ログイン・新規登録・プロフィール詳細ページの `w-3/4` を `w-full sm:w-3/4` に変更
- 部屋名編集フィールドの `w-64` を `w-full sm:w-64` に変更

## Test plan
- [x] モバイル幅（< 640px）で各ページが画面幅いっぱいに表示される
- [x] デスクトップ表示が従来通り維持される
- [x] jsMindページの左右余白がヘッダーと揃っている
- [x] RSpec 全通過（169 examples, 0 failures）
- [x] RuboCop 0 offenses

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)