### PR TITLE
共通レイアウト・ナビバー・フラッシュのダークテーマ対応

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -17,6 +17,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     result = SocialAuthService.call(request.env["omniauth.auth"])
 
     if result.success?
+      set_flash_message(:notice, :signed_in) if is_navigational_format?
       sign_in_and_redirect result.user, event: :authentication
     else
       redirect_to new_user_session_path, alert: result.error_message

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,12 +2,12 @@ module ApplicationHelper
   def primary_btn_class(size: :lg)
     base = "inline-flex items-center justify-center rounded-lg font-semibold"
     padding = size == :lg ? "px-8 py-3 text-lg" : "px-4 py-2 text-sm"
-    "#{base} #{padding} bg-indigo-600 text-white hover:bg-indigo-700"
+    "#{base} #{padding} bg-blue-600 text-white hover:bg-blue-700"
   end
 
   def outline_btn_class(size: :lg)
     base = "inline-flex items-center justify-center rounded-lg font-semibold"
     padding = size == :lg ? "px-8 py-3 text-lg" : "px-4 py-2 text-sm"
-    "#{base} #{padding} border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+    "#{base} #{padding} border border-gray-600 text-gray-300 hover:bg-gray-800 hover:text-white"
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,12 +17,12 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body<%= content_for?(:landing) ? ' style="background: #0a0e1a; margin: 0;"'.html_safe : '' %>>
+  <body style="background: #0a0e1a; margin: 0; color: #d1d5db;">
     <%= render "shared/navbar" %>
-    <div id="flash">
+    <div id="flash" style="position: fixed; top: 3rem; left: 0; right: 0; z-index: 40; padding: 0.5rem 1rem;">
         <%= render 'shared/flash' %>
     </div>
-    <main class="<%= content_for?(:landing) ? '' : content_for?(:full_width) ? 'mt-20 py-8 px-4' : "container mx-auto mt-20 py-8 px-5 #{content_for?(:no_center) ? '' : 'flex items-center justify-center'}" %>"<%= content_for?(:landing) ? ' style="margin: 0; padding: 0;"'.html_safe : '' %>>
+    <main class="<%= content_for?(:landing) ? '' : content_for?(:full_width) ? 'py-8 px-4' : "container mx-auto py-8 px-5 #{content_for?(:no_center) ? '' : 'flex items-center justify-center'}" %>" style="<%= content_for?(:landing) ? '' : 'margin-top: 7rem;' %>">
       <%= yield %>
     </main>
   </body>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,15 +1,18 @@
 <% flash.each do |type, message| %>
   <% next if message.blank? %>
 
-  <% base = "rounded-lg px-4 py-3 text-sm mb-4" %>
-  <% color =
-      case type.to_s
-      when "notice" then "bg-green-50 text-green-800 border border-green-200"
-      when "alert"  then "bg-red-50 text-red-800 border border-red-200"
-      else               "bg-gray-50 text-gray-800 border border-gray-200"
-      end %>
+  <%
+    case type.to_s
+    when "notice"
+      bg = "background: rgba(34, 197, 94, 0.1); color: #86efac; border: 1px solid rgba(34, 197, 94, 0.3);"
+    when "alert"
+      bg = "background: rgba(239, 68, 68, 0.1); color: #fca5a5; border: 1px solid rgba(239, 68, 68, 0.3);"
+    else
+      bg = "background: rgba(156, 163, 175, 0.1); color: #d1d5db; border: 1px solid rgba(156, 163, 175, 0.3);"
+    end
+  %>
 
-  <div class="<%= "#{base} #{color}" %>">
+  <div style="border-radius: 0.5rem; padding: 0.75rem 1rem; font-size: 0.875rem; margin-bottom: 1rem; <%= bg %>">
     <%= message %>
   </div>
 <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,8 +1,11 @@
-<nav class="bg-gray-800 px-4 py-2.5">
+<nav style="background: linear-gradient(to right, #0f172a, #1e293b, #0f172a); padding: 0.625rem 1rem; position: fixed; top: 0; left: 0; right: 0; z-index: 50; border-bottom: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+  <!-- 装飾ライン -->
+  <div style="position: absolute; bottom: 0; left: 0; right: 0; height: 1px; background: linear-gradient(to right, transparent, rgba(96, 165, 250, 0.2), transparent);"></div>
+
   <div class="container mx-auto flex items-center justify-between">
     <!-- ロゴ -->
-    <%= link_to "Hobby Matching", user_signed_in? ? profiles_path : root_path, class: "text-white text-xl font-semibold whitespace-nowrap" %>
-
+    <%= link_to "Hobby Matching", user_signed_in? ? profiles_path : root_path,
+        style: "color: #ffffff; font-size: 1.25rem; font-weight: 700; white-space: nowrap; text-decoration: none; text-shadow: 0 0 20px rgba(96, 165, 250, 0.2);" %>
 
     <!-- 右側メニュー -->
     <div class="flex items-center gap-x-4">
@@ -11,28 +14,28 @@
         <% unless current_user.profile %>
           <%= link_to "プロフィール作成",
                       new_my_profile_path,
-                      class: "px-4 py-2 rounded-md bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition" %>
+                      style: "padding: 0.5rem 1rem; border-radius: 0.375rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; text-decoration: none; transition: all 0.3s; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);" %>
         <% end %>
 
         <%= link_to "マイページ",
                     mypage_root_path,
-                    class: "text-gray-300 text-sm hover:text-white transition" %>
+                    style: "color: #d1d5db; font-size: 0.875rem; text-decoration: none; transition: color 0.2s;" %>
 
         <%= button_to "ログアウト",
                       destroy_user_session_path,
                       method: :delete,
-                      class: "text-gray-300 text-sm hover:text-white transition leading-none",
+                      style: "color: #d1d5db; font-size: 0.875rem; background: none; border: none; cursor: pointer; transition: color 0.2s; line-height: 1;",
                       form_class: "m-0 flex items-center" %>
 
       <% else %>
 
         <%= link_to "ユーザー登録",
                     new_user_registration_path,
-                    class: "text-gray-300 text-sm hover:text-white transition" %>
+                    style: "color: #d1d5db; font-size: 0.875rem; text-decoration: none; transition: color 0.2s;" %>
 
         <%= link_to "ログイン",
                     new_user_session_path,
-                    class: "text-gray-300 text-sm hover:text-white transition" %>
+                    style: "color: #d1d5db; font-size: 0.875rem; text-decoration: none; transition: color 0.2s;" %>
 
       <% end %>
     </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -263,7 +263,7 @@ Devise.setup do |config|
   # should add them to the navigational formats lists.
   #
   # The "*/*" below is required to match Internet Explorer requests.
-  # config.navigational_formats = ['*/*', :html, :turbo_stream]
+  config.navigational_formats = [ "*/*", :html, :turbo_stream ]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -38,6 +38,8 @@ ja:
     registrations:
       user:
         signed_up: ユーザー登録に成功しました。
+    omniauth_callbacks:
+      signed_in: ログインしました。
     sessions:
       new:
         sign_in: ログイン


### PR DESCRIPTION
## Summary
- bodyの背景をダーク(#0a0e1a)に変更し、全ページにダークテーマを適用
- ナビバーをposition: fixedのダークグラデーションに変更（装飾ライン付き）
- フラッシュメッセージをダーク対応の半透明カラーに変更し、ナビバー下に固定表示
- ボタンヘルパー(primary/outline)をダークテーマ用に更新
- OAuthログイン時にフラッシュメッセージが表示されない既存バグを修正

Closes #140

## Test plan
- [x] RSpec全通過（182 examples, 0 failures）
- [x] RuboCop違反なし（110 files, no offenses）
- [x] ログイン/ログアウト時にフラッシュメッセージが表示される
- [x] Google/Discord OAuth ログイン時にフラッシュメッセージが日本語で表示される
- [x] ナビバーがスクロールしても固定表示される
- [x] LP（トップページ）のレイアウトに影響がない
- [x] プロフィール一覧・マイページのレイアウトが崩れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)