### PR TITLE
feat: 認証系+マイページのダークテーマ対応

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,20 @@
-<h2>Resend confirmation instructions</h2>
+<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+  <h1 style="font-size: 1.5rem; font-weight: 700; color: #ffffff; margin-bottom: 1.5rem;">確認メール再送</h1>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
-  </div>
+    <div style="margin-bottom: 1.5rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">メールアドレス</label>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
-  </div>
-<% end %>
+    <button type="submit" style="width: 100%; padding: 0.625rem 1rem; border-radius: 0.375rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);">
+      確認メールを再送する
+    </button>
+  <% end %>
 
-<%= render "devise/shared/links" %>
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,29 @@
-<h2>Change your password</h2>
+<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+  <h1 style="font-size: 1.5rem; font-weight: 700; color: #ffffff; margin-bottom: 1.5rem;">パスワード変更</h1>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
+    <div style="margin-bottom: 1.25rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">新しいパスワード</label>
+      <% if @minimum_password_length %>
+        <p style="font-size: 0.75rem; color: #6b7280; margin-bottom: 0.375rem;"><%= @minimum_password_length %>文字以上</p>
+      <% end %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+    <div style="margin-bottom: 1.5rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">確認用パスワード</label>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
+    <button type="submit" style="width: 100%; padding: 0.625rem 1rem; border-radius: 0.375rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);">
+      パスワードを変更する
+    </button>
+  <% end %>
 
-<%= render "devise/shared/links" %>
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,19 @@
-<h2>Forgot your password?</h2>
+<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+  <h1 style="font-size: 1.5rem; font-weight: 700; color: #ffffff; margin-bottom: 1.5rem;">パスワードをお忘れですか？</h1>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <div style="margin-bottom: 1.5rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">メールアドレス</label>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
+    <button type="submit" style="width: 100%; padding: 0.625rem 1rem; border-radius: 0.375rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);">
+      パスワード再設定メールを送信
+    </button>
+  <% end %>
 
-<%= render "devise/shared/links" %>
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,52 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+  <h1 style="font-size: 1.5rem; font-weight: 700; color: #ffffff; margin-bottom: 1.5rem;">アカウント設定</h1>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <div style="margin-bottom: 1.25rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">メールアドレス</label>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+    </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <p style="font-size: 0.875rem; color: #fbbf24; margin-bottom: 1rem;">確認待ち: <%= resource.unconfirmed_email %></p>
+    <% end %>
+
+    <div style="margin-bottom: 1.25rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">新しいパスワード <span style="color: #6b7280;">（変更しない場合は空欄）</span></label>
+      <%= f.password_field :password, autocomplete: "new-password",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+      <% if @minimum_password_length %>
+        <p style="font-size: 0.75rem; color: #6b7280; margin-top: 0.25rem;"><%= @minimum_password_length %>文字以上</p>
+      <% end %>
+    </div>
+
+    <div style="margin-bottom: 1.25rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">確認用パスワード</label>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+    </div>
+
+    <div style="margin-bottom: 1.5rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">現在のパスワード <span style="color: #6b7280;">（変更確認のため必須）</span></label>
+      <%= f.password_field :current_password, autocomplete: "current-password",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+    </div>
+
+    <button type="submit" style="width: 100%; padding: 0.625rem 1rem; border-radius: 0.375rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);">
+      更新する
+    </button>
   <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
+  <%# アカウント削除 %>
+  <div style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid rgba(55, 65, 81, 0.4);">
+    <h2 style="font-size: 1rem; font-weight: 600; color: #ef4444; margin-bottom: 0.75rem;">アカウント削除</h2>
+    <p style="font-size: 0.875rem; color: #6b7280; margin-bottom: 0.75rem;">アカウントを削除すると、すべてのデータが失われます。</p>
+    <%= button_to "アカウントを削除する", registration_path(resource_name),
+          method: :delete,
+          data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" },
+          style: "padding: 0.5rem 1rem; border-radius: 0.375rem; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); color: #ef4444; font-size: 0.875rem; cursor: pointer;" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,37 +1,39 @@
-<%= form_with scope: resource, as: resource_name, url: registration_path(resource_name), class: "space-y-6 w-full sm:w-3/4 max-w-lg bg-white p-6 rounded-lg shadow" ,local: true do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
- 
-  <label class="block text-xl font-bold text-gray-700">ユーザー登録</label>
- 
-  <div class="mt-1">
-    <label class="text-gray-700 text-md">
-      メールアドレス
-    </label>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 py-1 px-2 block w-full sm:text-sm placeholder-gray-400 border border-gray-300 rounded-md", placeholder: "test@exeample.com" %>
-  </div>
- 
-  <div class="mt-1">
-    <label class="text-gray-700 text-md">
-      ニックネーム
-    </label>
-    <%= f.text_field :nickname, autocomplete: "nickname", class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 py-1 px-2 block w-full sm:text-sm placeholder-gray-400 border border-gray-300 rounded-md", placeholder: "エンジニアの卵" %>
-  </div>
- 
-  <div class="mt-1">
-    <label class="text-gray-700 text-md">
-      パスワード (6文字以上)
-    </label>
-    <%= f.password_field :password, autocomplete: "new-password", class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 py-1 px-2 block w-full sm:text-sm placeholder-gray-400 border border-gray-300 rounded-md", placeholder: "pass1234" %>
-  </div>
- 
-  <div class="mt-1">
-    <label class="text-gray-700 text-md">
-      確認用パスワード
-    </label>
-    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 py-1 px-2 block w-full sm:text-sm placeholder-gray-400 border border-gray-300 rounded-md", placeholder: "pass1234" %>
-  </div>
- 
-  <button type="submit" class="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 hover:cursor-pointer">
-    <%= f.submit "ユーザー登録" %>
-  </button>
-<% end %>
+<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+  <h1 style="font-size: 1.5rem; font-weight: 700; color: #ffffff; margin-bottom: 1.5rem;">ユーザー登録</h1>
+
+  <%= form_with scope: resource, as: resource_name, url: registration_path(resource_name), local: true do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+
+    <div style="margin-bottom: 1.25rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">メールアドレス</label>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;",
+            placeholder: "test@example.com" %>
+    </div>
+
+    <div style="margin-bottom: 1.25rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">ニックネーム</label>
+      <%= f.text_field :nickname, autocomplete: "nickname",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;",
+            placeholder: "エンジニアの卵" %>
+    </div>
+
+    <div style="margin-bottom: 1.25rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">パスワード (6文字以上)</label>
+      <%= f.password_field :password, autocomplete: "new-password",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;",
+            placeholder: "pass1234" %>
+    </div>
+
+    <div style="margin-bottom: 1.5rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">確認用パスワード</label>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;",
+            placeholder: "pass1234" %>
+    </div>
+
+    <button type="submit" style="width: 100%; padding: 0.625rem 1rem; border-radius: 0.375rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);">
+      ユーザー登録
+    </button>
+  <% end %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,42 +1,53 @@
-<div class="flex flex-col w-full sm:w-3/4 max-w-lg bg-white p-6 rounded-lg shadow space-y-6">
-  <label class="block text-xl font-bold text-gray-700">ログイン</label>
+<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+  <h1 style="font-size: 1.5rem; font-weight: 700; color: #ffffff; margin-bottom: 1.5rem;">ログイン</h1>
 
-  <%= form_with scope: resource, as: resource_name, url: session_path(resource_name), class: "space-y-6", local: true do |f| %>
-    <div>
-      <label class="text-gray-700 text-md">メールアドレス</label>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 py-1 px-2 block w-full sm:text-sm placeholder-gray-400 border border-gray-300 rounded-md", placeholder: "test@example.com" %>
+  <%= form_with scope: resource, as: resource_name, url: session_path(resource_name), local: true do |f| %>
+    <div style="margin-bottom: 1.25rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">メールアドレス</label>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;",
+            placeholder: "test@example.com" %>
     </div>
 
-    <div>
-      <label class="text-gray-700 text-md">パスワード</label>
-      <%= f.password_field :password, autocomplete: "password", class: "shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 py-1 px-2 block w-full sm:text-sm placeholder-gray-400 border border-gray-300 rounded-md", placeholder: "pass1234" %>
+    <div style="margin-bottom: 1.5rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">パスワード</label>
+      <%= f.password_field :password, autocomplete: "password",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;",
+            placeholder: "pass1234" %>
     </div>
 
-    <button type="submit" class="w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 hover:cursor-pointer">
+    <button type="submit" style="width: 100%; padding: 0.625rem 1rem; border-radius: 0.375rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);">
       ログイン
     </button>
   <% end %>
 
-  <div class="relative flex items-center">
-    <div class="flex-grow border-t border-gray-300"></div>
-    <span class="mx-3 text-sm text-gray-500"></span>
-    <div class="flex-grow border-t border-gray-300"></div>
+  <%# 区切り線 %>
+  <div style="display: flex; align-items: center; margin: 1.5rem 0;">
+    <div style="flex: 1; height: 1px; background: rgba(55, 65, 81, 0.4);"></div>
+    <span style="margin: 0 0.75rem; font-size: 0.875rem; color: #6b7280;"></span>
+    <div style="flex: 1; height: 1px; background: rgba(55, 65, 81, 0.4);"></div>
   </div>
 
-  <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "w-full flex items-center justify-center gap-3 py-2 px-4 border border-gray-300 rounded-md bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 hover:cursor-pointer" do %>
+  <%# Google OAuth %>
+  <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false },
+        form: { style: "width: 100%; margin-bottom: 0.75rem;" },
+        style: "width: 100%; display: flex; align-items: center; justify-content: center; gap: 0.75rem; padding: 0.625rem 1rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); cursor: pointer;" do %>
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="20" height="20" style="min-width:20px">
       <path fill="#EA4335" d="M24 9.5c3.14 0 5.95 1.08 8.17 2.86l6.09-6.09C34.46 3.11 29.5 1 24 1 14.82 1 7.07 6.48 3.64 14.22l7.08 5.5C12.4 13.72 17.73 9.5 24 9.5z"/>
       <path fill="#4285F4" d="M46.5 24.5c0-1.64-.15-3.22-.42-4.75H24v9h12.7c-.55 2.98-2.2 5.5-4.67 7.2l7.17 5.57C43.26 37.27 46.5 31.36 46.5 24.5z"/>
       <path fill="#FBBC05" d="M10.72 28.28A14.6 14.6 0 0 1 9.5 24c0-1.49.26-2.94.72-4.28l-7.08-5.5A23.94 23.94 0 0 0 0 24c0 3.86.92 7.5 2.55 10.72l8.17-6.44z"/>
       <path fill="#34A853" d="M24 47c5.5 0 10.12-1.82 13.5-4.93l-7.17-5.57C28.6 38.1 26.42 39 24 39c-6.27 0-11.6-4.22-13.28-9.72l-8.17 6.44C6.07 43.52 14.45 47 24 47z"/>
     </svg>
-    <span class="text-sm font-medium text-gray-700">Sign in with Google</span>
+    <span style="font-size: 0.875rem; font-weight: 500; color: #d1d5db;">Sign in with Google</span>
   <% end %>
 
-  <%= button_to user_discord_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "w-full flex items-center justify-center gap-3 py-2 px-4 border border-gray-300 rounded-md bg-[#5865F2] hover:bg-[#4752C4] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#5865F2] hover:cursor-pointer" do %>
+  <%# Discord OAuth %>
+  <%= button_to user_discord_omniauth_authorize_path, method: :post, data: { turbo: false },
+        form: { style: "width: 100%;" },
+        style: "width: 100%; display: flex; align-items: center; justify-content: center; gap: 0.75rem; padding: 0.625rem 1rem; border-radius: 0.375rem; background: #5865F2; border: 1px solid transparent; cursor: pointer;" do %>
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 127.14 96.36" width="20" height="20" style="min-width:20px">
       <path fill="#ffffff" d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"/>
     </svg>
-    <span class="text-sm font-medium text-white">Sign in with Discord</span>
+    <span style="font-size: 0.875rem; font-weight: 500; color: #ffffff;">Sign in with Discord</span>
   <% end %>
 </div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,15 +1,16 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation">
-    <h2 class="text-lg text-gray-700 mb-3">
+  <div style="margin-bottom: 1.25rem; padding: 1rem; border-radius: 0.5rem; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3);">
+    <h2 style="font-size: 0.875rem; font-weight: 600; color: #fca5a5; margin-bottom: 0.5rem;">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
     </h2>
- 
-    <ul>
+    <ul style="list-style: none; padding: 0; margin: 0;">
       <% resource.errors.full_messages.each do |message| %>
-        <li class="leading-5 text-red-500 mb-2"><%= message %></li>
+        <li style="font-size: 0.875rem; color: #fca5a5; line-height: 1.5; padding-left: 0.75rem; position: relative;">
+          <span style="position: absolute; left: 0;">・</span><%= message %>
+        </li>
       <% end %>
     </ul>
   </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,33 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+<div style="margin-top: 1.5rem; text-align: center;">
+  <%- if controller_name != 'sessions' %>
+    <%= link_to "ログイン", new_session_path(resource_name), style: "font-size: 0.875rem; color: #60a5fa; text-decoration: none;" %>
+    <br />
   <% end %>
-<% end %>
+
+  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+    <%= link_to "ユーザー登録", new_registration_path(resource_name), style: "font-size: 0.875rem; color: #60a5fa; text-decoration: none;" %>
+    <br />
+  <% end %>
+
+  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+    <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name), style: "font-size: 0.875rem; color: #60a5fa; text-decoration: none;" %>
+    <br />
+  <% end %>
+
+  <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+    <%= link_to "確認メールが届きませんか？", new_confirmation_path(resource_name), style: "font-size: 0.875rem; color: #60a5fa; text-decoration: none;" %>
+    <br />
+  <% end %>
+
+  <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+    <%= link_to "ロック解除メールが届きませんか？", new_unlock_path(resource_name), style: "font-size: 0.875rem; color: #60a5fa; text-decoration: none;" %>
+    <br />
+  <% end %>
+
+  <%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false }, style: "font-size: 0.875rem; color: #60a5fa; background: none; border: none; cursor: pointer;" %>
+      <br />
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,16 +1,19 @@
-<h2>Resend unlock instructions</h2>
+<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+  <h1 style="font-size: 1.5rem; font-weight: 700; color: #ffffff; margin-bottom: 1.5rem;">ロック解除</h1>
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <div style="margin-bottom: 1.5rem;">
+      <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">メールアドレス</label>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email",
+            style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Resend unlock instructions" %>
-  </div>
-<% end %>
+    <button type="submit" style="width: 100%; padding: 0.625rem 1rem; border-radius: 0.375rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);">
+      ロック解除メールを再送する
+    </button>
+  <% end %>
 
-<%= render "devise/shared/links" %>
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,15 @@
     <div id="flash" style="position: fixed; top: 3rem; left: 0; right: 0; z-index: 40; padding: 0.5rem 1rem;">
         <%= render 'shared/flash' %>
     </div>
-    <main class="<%= content_for?(:landing) ? '' : content_for?(:full_width) ? 'py-8 px-4' : "container mx-auto py-8 px-5 #{content_for?(:no_center) ? '' : 'flex items-center justify-center'}" %>" style="<%= content_for?(:landing) ? '' : 'margin-top: 7rem;' %>">
+    <main class="<%= content_for?(:landing) ? '' : content_for?(:full_width) ? 'py-8 px-4' : "container mx-auto py-8 px-5 #{content_for?(:no_center) ? '' : 'flex items-center justify-center'}" %>" style="<%= content_for?(:landing) ? '' : 'margin-top: 7rem; position: relative; overflow: hidden; min-height: calc(100vh - 7rem);' %>">
+      <% unless content_for?(:landing) %>
+        <%# 背景の装飾 %>
+        <div style="position: absolute; inset: 0; opacity: 0.15; pointer-events: none; z-index: 0;">
+          <div style="position: absolute; top: 10%; left: 5%; width: 20rem; height: 20rem; background: #3b82f6; border-radius: 9999px; filter: blur(128px);"></div>
+          <div style="position: absolute; bottom: 10%; right: 5%; width: 28rem; height: 28rem; background: #6366f1; border-radius: 9999px; filter: blur(128px);"></div>
+          <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 40rem; height: 40rem; background: #1e40af; border-radius: 9999px; filter: blur(200px); opacity: 0.3;"></div>
+        </div>
+      <% end %>
       <%= yield %>
     </main>
   </body>

--- a/app/views/mypage/dashboards/_nickname.html.erb
+++ b/app/views/mypage/dashboards/_nickname.html.erb
@@ -2,11 +2,11 @@
   <div data-controller="inline-edit">
     <%# 表示状態 %>
     <div data-inline-edit-target="display" class="flex items-center gap-3">
-      <p class="text-2xl font-bold"><%= current_user.nickname %></p>
+      <p style="font-size: 1.5rem; font-weight: 700; color: #ffffff;"><%= current_user.nickname %></p>
       <button data-action="inline-edit#edit"
-              class="text-gray-400 hover:text-gray-600 transition"
+              style="color: #6b7280; background: none; border: none; cursor: pointer; transition: color 0.2s;"
               title="ニックネームを編集">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+        <svg xmlns="http://www.w3.org/2000/svg" style="height: 1.25rem; width: 1.25rem;" viewBox="0 0 20 20" fill="currentColor">
           <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
         </svg>
       </button>
@@ -14,22 +14,22 @@
 
     <%# 編集状態 %>
     <div data-inline-edit-target="form" class="hidden">
-      <%= form_with model: current_user, url: mypage_dashboard_path, method: :patch, class: "flex items-center gap-3" do |f| %>
+      <%= form_with model: current_user, url: mypage_dashboard_path, method: :patch, style: "display: flex; align-items: center; gap: 0.75rem;" do |f| %>
         <%= f.text_field :nickname,
               value: current_user.nickname,
-              class: "text-2xl font-bold border border-gray-300 rounded-md px-2 py-1 focus:ring-indigo-500 focus:border-indigo-500",
+              style: "font-size: 1.5rem; font-weight: 700; color: #ffffff; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); border-radius: 0.375rem; padding: 0.25rem 0.5rem; outline: none;",
               maxlength: 20 %>
         <%= f.submit "保存",
-              class: "bg-indigo-600 hover:bg-indigo-700 text-white text-sm px-3 py-1 rounded-md cursor-pointer" %>
+              style: "background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; padding: 0.25rem 0.75rem; border-radius: 0.375rem; border: none; cursor: pointer;" %>
         <button type="button"
                 data-action="inline-edit#cancel"
-                class="text-gray-500 hover:text-gray-700 text-sm">
+                style="color: #6b7280; font-size: 0.875rem; background: none; border: none; cursor: pointer;">
           キャンセル
         </button>
       <% end %>
 
       <% if current_user.errors[:nickname].any? %>
-        <p class="text-red-500 text-sm mt-1"><%= current_user.errors[:nickname].join(", ") %></p>
+        <p style="color: #fca5a5; font-size: 0.875rem; margin-top: 0.25rem;"><%= current_user.errors[:nickname].join(", ") %></p>
       <% end %>
     </div>
   </div>

--- a/app/views/mypage/dashboards/_nickname_form.html.erb
+++ b/app/views/mypage/dashboards/_nickname_form.html.erb
@@ -3,21 +3,21 @@
     <div data-inline-edit-target="display" class="hidden"></div>
 
     <div data-inline-edit-target="form">
-      <%= form_with model: current_user, url: mypage_dashboard_path, method: :patch, class: "flex items-center gap-3" do |f| %>
+      <%= form_with model: current_user, url: mypage_dashboard_path, method: :patch, style: "display: flex; align-items: center; gap: 0.75rem;" do |f| %>
         <div>
           <%= f.text_field :nickname,
                 value: current_user.nickname,
-                class: "text-2xl font-bold border border-red-300 rounded-md px-2 py-1 focus:ring-red-500 focus:border-red-500",
+                style: "font-size: 1.5rem; font-weight: 700; color: #ffffff; background: rgba(255,255,255,0.05); border: 1px solid rgba(239, 68, 68, 0.5); border-radius: 0.375rem; padding: 0.25rem 0.5rem; outline: none;",
                 maxlength: 20 %>
           <% if current_user.errors[:nickname].any? %>
-            <p class="text-red-500 text-sm mt-1"><%= current_user.errors[:nickname].join(", ") %></p>
+            <p style="color: #fca5a5; font-size: 0.875rem; margin-top: 0.25rem;"><%= current_user.errors[:nickname].join(", ") %></p>
           <% end %>
         </div>
         <%= f.submit "保存",
-              class: "bg-indigo-600 hover:bg-indigo-700 text-white text-sm px-3 py-1 rounded-md cursor-pointer" %>
+              style: "background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; padding: 0.25rem 0.75rem; border-radius: 0.375rem; border: none; cursor: pointer;" %>
         <button type="button"
                 data-action="inline-edit#cancel"
-                class="text-gray-500 hover:text-gray-700 text-sm">
+                style="color: #6b7280; font-size: 0.875rem; background: none; border: none; cursor: pointer;">
           キャンセル
         </button>
       <% end %>

--- a/app/views/mypage/dashboards/show.html.erb
+++ b/app/views/mypage/dashboards/show.html.erb
@@ -1,11 +1,11 @@
 <% content_for :no_center, true %>
 
-<div class="max-w-3xl mx-auto px-6 py-10">
-  <h1 class="text-3xl font-bold mb-8">マイページ</h1>
+<div style="max-width: 48rem; margin: 0 auto; padding: 2.5rem 1.5rem;">
+  <h1 style="font-size: 1.875rem; font-weight: 700; color: #ffffff; margin-bottom: 2rem;">マイページ</h1>
 
   <%# ニックネーム %>
-  <div class="bg-white shadow-md rounded-xl p-6 mb-6">
-    <h2 class="text-sm font-medium text-gray-500 mb-2">ニックネーム</h2>
+  <div style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); margin-bottom: 1.5rem;">
+    <h2 style="font-size: 0.875rem; font-weight: 500; color: #6b7280; margin-bottom: 0.5rem;">ニックネーム</h2>
     <%= render "mypage/dashboards/nickname" %>
   </div>
 
@@ -14,33 +14,33 @@
     <%# 趣味プロフィール %>
     <% if current_user.profile %>
       <%= link_to edit_my_profile_path,
-                  class: "bg-white shadow-md rounded-xl p-6 hover:shadow-lg transition flex flex-col items-center gap-3" do %>
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  style: "display: flex; flex-direction: column; align-items: center; gap: 0.75rem; padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); text-decoration: none; transition: all 0.3s;" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" style="height: 2rem; width: 2rem; color: #60a5fa;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
         </svg>
-        <span class="text-sm font-medium text-gray-700">趣味プロフィール編集</span>
+        <span style="font-size: 0.875rem; font-weight: 500; color: #d1d5db;">趣味プロフィール編集</span>
       <% end %>
     <% end %>
 
     <%# 部屋管理 %>
     <% rooms_count = current_user.profile&.issued_rooms&.count || 0 %>
     <%= link_to mypage_rooms_path,
-                class: "bg-white shadow-md rounded-xl p-6 hover:shadow-lg transition flex flex-col items-center gap-3" do %>
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                style: "display: flex; flex-direction: column; align-items: center; gap: 0.75rem; padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); text-decoration: none; transition: all 0.3s;" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" style="height: 2rem; width: 2rem; color: #60a5fa;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1" />
       </svg>
-      <span class="text-sm font-medium text-gray-700">部屋管理</span>
-      <span class="text-xs text-gray-400"><%= rooms_count %> 部屋</span>
+      <span style="font-size: 0.875rem; font-weight: 500; color: #d1d5db;">部屋管理</span>
+      <span style="font-size: 0.75rem; color: #6b7280;"><%= rooms_count %> 部屋</span>
     <% end %>
 
     <%# 設定 %>
     <%= link_to mypage_settings_path,
-                class: "bg-white shadow-md rounded-xl p-6 hover:shadow-lg transition flex flex-col items-center gap-3" do %>
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                style: "display: flex; flex-direction: column; align-items: center; gap: 0.75rem; padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); text-decoration: none; transition: all 0.3s;" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" style="height: 2rem; width: 2rem; color: #60a5fa;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
         <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
       </svg>
-      <span class="text-sm font-medium text-gray-700">設定</span>
+      <span style="font-size: 0.875rem; font-weight: 500; color: #d1d5db;">設定</span>
     <% end %>
   </div>
 </div>

--- a/app/views/mypage/rooms/_form.html.erb
+++ b/app/views/mypage/rooms/_form.html.erb
@@ -1,37 +1,37 @@
 <%= turbo_frame_tag dom_id(room) do %>
   <% link = room.share_link %>
 
-  <div class="bg-white rounded-xl shadow-md p-6 border border-gray-200">
+  <div style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
     <%= form_with model: room, url: mypage_room_path(room), method: :patch do |f| %>
 
       <%# 部屋名（編集） %>
-      <h3 class="text-lg font-semibold mb-3 flex items-center gap-2">
+      <div style="margin-bottom: 0.75rem;">
         <%= f.label :label, "部屋名", class: "sr-only" %>
         <%= f.text_field :label,
               placeholder: "名無しの部屋",
-              class: "w-full sm:w-64 max-w-full border border-gray-300 rounded-md px-3 py-2 text-sm shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
-      </h3>
+              style: "width: 100%; max-width: 16rem; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+      </div>
 
       <% if link.present? %>
-        <p class="text-sm text-gray-600 break-all mb-2">
+        <p style="font-size: 0.875rem; color: #6b7280; word-break: break-all; margin-bottom: 0.5rem;">
           共有URL:<br>
           <%= link_to share_url(link.token),
                       share_path(link.token),
                       target: "_blank",
-                      class: "text-indigo-600 hover:underline" %>
+                      style: "color: #60a5fa; text-decoration: none;" %>
         </p>
 
-        <p class="text-sm mb-2">
+        <p style="font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.5rem;">
           有効期限:
           <%= link.expires_at.strftime("%Y/%m/%d %H:%M") if link.expires_at.present? %>
 
           <% if link.expires_at.present? %>
             <% if link.expires_at <= Time.current %>
-              <span class="ml-2 inline-block bg-red-100 text-red-600 text-xs px-2 py-1 rounded-full">
+              <span style="margin-left: 0.5rem; display: inline-block; background: rgba(239, 68, 68, 0.15); color: #fca5a5; font-size: 0.75rem; padding: 0.125rem 0.5rem; border-radius: 9999px;">
                 期限切れ
               </span>
             <% else %>
-              <span class="ml-2 inline-block bg-green-100 text-green-600 text-xs px-2 py-1 rounded-full">
+              <span style="margin-left: 0.5rem; display: inline-block; background: rgba(34, 197, 94, 0.15); color: #86efac; font-size: 0.75rem; padding: 0.125rem 0.5rem; border-radius: 9999px;">
                 有効
               </span>
             <% end %>
@@ -39,17 +39,17 @@
         </p>
       <% end %>
 
-      <p class="text-sm text-gray-600 mb-4">
+      <p style="font-size: 0.875rem; color: #6b7280; margin-bottom: 1rem;">
         参加人数: <%= room.room_memberships.size %> 人
       </p>
 
-      <div class="flex justify-between text-sm">
+      <div style="display: flex; justify-content: space-between; font-size: 0.875rem;">
         <span></span>
-        <div class="flex gap-4">
-          <%= f.submit "更新", class: "text-blue-600 hover:underline cursor-pointer" %>
+        <div style="display: flex; gap: 1rem;">
+          <%= f.submit "更新", style: "color: #60a5fa; background: none; border: none; cursor: pointer; font-size: 0.875rem;" %>
           <%= link_to "キャンセル",
                       mypage_rooms_path,
-                      class: "text-gray-600 hover:underline" %>
+                      style: "color: #6b7280; text-decoration: none;" %>
         </div>
       </div>
 

--- a/app/views/mypage/rooms/_room.html.erb
+++ b/app/views/mypage/rooms/_room.html.erb
@@ -1,39 +1,39 @@
 <%= turbo_frame_tag dom_id(room) do %>
-  <div class="bg-white rounded-xl shadow-md p-6 border border-gray-200 flex flex-col">
+  <div style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); display: flex; flex-direction: column;">
     <%# 部屋名 %>
-    <h3 class="text-lg font-semibold mb-3">
+    <h3 style="font-size: 1.125rem; font-weight: 600; color: #ffffff; margin-bottom: 0.75rem;">
       <%= room.label.presence || "名無しの部屋" %>
     </h3>
 
     <% if link.present? %>
       <%# 共有URL %>
-      <div class="text-base break-all mb-2" data-controller="clipboard" data-clipboard-text-value="<%= share_url(link.token) %>">
-        <div class="flex items-center gap-2 mb-1">
-          <span class="text-gray-500 font-medium text-sm">共有URL</span>
+      <div style="word-break: break-all; margin-bottom: 0.5rem;" data-controller="clipboard" data-clipboard-text-value="<%= share_url(link.token) %>">
+        <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.25rem;">
+          <span style="color: #6b7280; font-weight: 500; font-size: 0.875rem;">共有URL</span>
           <button type="button"
                   data-clipboard-target="button"
                   data-action="click->clipboard#copy"
-                  class="inline-flex items-center px-2 py-0.5 text-xs font-medium text-indigo-600 bg-indigo-50 border border-indigo-200 rounded hover:bg-indigo-100 transition-colors">
+                  style="display: inline-flex; align-items: center; padding: 0.125rem 0.5rem; font-size: 0.75rem; font-weight: 500; color: #60a5fa; background: rgba(96, 165, 250, 0.1); border: 1px solid rgba(96, 165, 250, 0.3); border-radius: 0.25rem; cursor: pointer;">
             Copy
           </button>
         </div>
         <%= link_to share_url(link.token),
                     share_path(link.token),
                     target: "_blank",
-                    class: "text-indigo-600 hover:underline" %>
+                    style: "color: #60a5fa; text-decoration: none; font-size: 0.875rem;" %>
       </div>
 
       <%# 有効期限 %>
-      <p class="text-sm mb-2">
-        <span class="text-gray-500 font-medium">有効期限</span>
+      <p style="font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.5rem;">
+        <span style="color: #6b7280; font-weight: 500;">有効期限</span>
         <%= link.expires_at.strftime("%Y/%m/%d %H:%M") if link.expires_at.present? %>
 
         <% if link.expires_at <= Time.current %>
-          <span class="ml-2 inline-block bg-red-100 text-red-600 text-xs px-2 py-1 rounded-full">
+          <span style="margin-left: 0.5rem; display: inline-block; background: rgba(239, 68, 68, 0.15); color: #fca5a5; font-size: 0.75rem; padding: 0.125rem 0.5rem; border-radius: 9999px;">
             期限切れ
           </span>
         <% else %>
-          <span class="ml-2 inline-block bg-green-100 text-green-600 text-xs px-2 py-1 rounded-full">
+          <span style="margin-left: 0.5rem; display: inline-block; background: rgba(34, 197, 94, 0.15); color: #86efac; font-size: 0.75rem; padding: 0.125rem 0.5rem; border-radius: 9999px;">
             有効
           </span>
         <% end %>
@@ -41,21 +41,21 @@
     <% end %>
 
     <%# 参加人数 %>
-    <p class="text-sm text-gray-600 mb-4">
+    <p style="font-size: 0.875rem; color: #6b7280; margin-bottom: 1rem;">
       参加人数: <%= room.room_memberships.size %> 人
     </p>
 
     <%# 操作 %>
-    <div class="flex justify-end gap-4 text-sm w-full">
+    <div style="display: flex; justify-content: flex-end; gap: 1rem; font-size: 0.875rem; width: 100%;">
       <%= link_to "編集",
                   edit_mypage_room_path(room),
                   data: { turbo_frame: dom_id(room) },
-                  class: "text-blue-600 hover:underline" %>
+                  style: "color: #60a5fa; text-decoration: none;" %>
 
       <%= link_to "削除",
                   mypage_room_path(room),
                   data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
-                  class: "text-red-600 hover:underline" %>
+                  style: "color: #ef4444; text-decoration: none;" %>
     </div>
   </div>
 <% end %>

--- a/app/views/mypage/rooms/index.html.erb
+++ b/app/views/mypage/rooms/index.html.erb
@@ -1,21 +1,21 @@
 <% content_for :no_center, true %>
 
-<div class="max-w-6xl mx-auto px-6 py-10">
-  <h1 class="text-3xl font-bold mb-8">部屋管理</h1>
+<div style="max-width: 72rem; margin: 0 auto; padding: 2.5rem 1.5rem;">
+  <h1 style="font-size: 1.875rem; font-weight: 700; color: #ffffff; margin-bottom: 2rem;">部屋管理</h1>
 
   <%# 作成フォーム %>
-  <div class="bg-white shadow-md rounded-xl p-6 mb-10 max-w-lg">
-    <h2 class="text-xl font-semibold mb-4">+ 部屋を新規作成</h2>
+  <div style="max-width: 28rem; padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); margin-bottom: 2.5rem;">
+    <h2 style="font-size: 1.25rem; font-weight: 600; color: #ffffff; margin-bottom: 1rem;">+ 部屋を新規作成</h2>
 
-    <%= form_with model: Room.new, url: mypage_rooms_path, class: "space-y-4" do |f| %>
-      <div>
-        <%= f.label :label, "部屋名（任意）", class: "block text-sm font-medium text-gray-700" %>
+    <%= form_with model: Room.new, url: mypage_rooms_path do |f| %>
+      <div style="margin-bottom: 1rem;">
+        <%= f.label :label, "部屋名（任意）", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
         <%= f.text_field :label,
-              class: "mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
+              style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
       </div>
 
       <%= f.submit "部屋を作成",
-            class: "bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg shadow cursor-pointer" %>
+            style: "padding: 0.5rem 1rem; border-radius: 0.5rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);" %>
     <% end %>
   </div>
 
@@ -26,7 +26,7 @@
     <% end %>
   </div>
 
-  <div class="mt-6">
-    <%= link_to "マイページに戻る", mypage_root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+  <div style="margin-top: 1.5rem;">
+    <%= link_to "マイページに戻る", mypage_root_path, style: "font-size: 0.875rem; color: #6b7280; text-decoration: none;" %>
   </div>
 </div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,51 +1,53 @@
 <% content_for :no_center, true %>
 
-<div class="max-w-xl mx-auto px-6 py-10">
-  <h1 class="text-3xl font-bold mb-8">設定</h1>
+<div style="max-width: 36rem; margin: 0 auto; padding: 2.5rem 1.5rem;">
+  <h1 style="font-size: 1.875rem; font-weight: 700; color: #ffffff; margin-bottom: 2rem;">設定</h1>
 
   <%# パスワード変更 %>
-  <div class="bg-white shadow-md rounded-xl p-6 mb-6">
-    <h2 class="text-xl font-semibold mb-4">パスワード変更</h2>
+  <div style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); margin-bottom: 1.5rem;">
+    <h2 style="font-size: 1.25rem; font-weight: 600; color: #d1d5db; margin-bottom: 1rem;">パスワード変更</h2>
 
-    <%= form_for(resource, as: resource_name, url: mypage_settings_path, html: { method: :patch, class: "space-y-4" }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: mypage_settings_path, html: { method: :patch }) do |f| %>
       <% if resource.errors.any? %>
-        <div class="bg-red-50 border border-red-200 rounded-md p-4">
-          <ul class="text-red-600 text-sm list-disc list-inside">
+        <div style="margin-bottom: 1.25rem; padding: 1rem; border-radius: 0.5rem; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3);">
+          <ul style="list-style: none; padding: 0; margin: 0;">
             <% resource.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
+              <li style="font-size: 0.875rem; color: #fca5a5; line-height: 1.5; padding-left: 0.75rem; position: relative;">
+                <span style="position: absolute; left: 0;">・</span><%= message %>
+              </li>
             <% end %>
           </ul>
         </div>
       <% end %>
 
-      <div>
-        <%= f.label :current_password, "現在のパスワード", class: "block text-sm font-medium text-gray-700" %>
+      <div style="margin-bottom: 1.25rem;">
+        <%= f.label :current_password, "現在のパスワード", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
         <%= f.password_field :current_password,
               autocomplete: "current-password",
-              class: "mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
+              style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
       </div>
 
-      <div>
-        <%= f.label :password, "新しいパスワード", class: "block text-sm font-medium text-gray-700" %>
+      <div style="margin-bottom: 1.25rem;">
+        <%= f.label :password, "新しいパスワード", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
         <%= f.password_field :password,
               autocomplete: "new-password",
-              class: "mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
-        <p class="text-xs text-gray-400 mt-1"><%= @minimum_password_length %>文字以上</p>
+              style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+        <p style="font-size: 0.75rem; color: #6b7280; margin-top: 0.25rem;"><%= @minimum_password_length %>文字以上</p>
       </div>
 
-      <div>
-        <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "block text-sm font-medium text-gray-700" %>
+      <div style="margin-bottom: 1.5rem;">
+        <%= f.label :password_confirmation, "新しいパスワード（確認）", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
         <%= f.password_field :password_confirmation,
               autocomplete: "new-password",
-              class: "mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:ring-indigo-500 focus:border-indigo-500" %>
+              style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
       </div>
 
       <%= f.submit "パスワードを変更",
-            class: "w-full bg-blue-600 hover:bg-blue-700 text-white text-lg font-semibold px-4 py-3 rounded-lg shadow cursor-pointer" %>
+            style: "width: 100%; padding: 0.625rem 1rem; border-radius: 0.375rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);" %>
     <% end %>
   </div>
 
-  <div class="mt-6">
-    <%= link_to "マイページに戻る", mypage_root_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+  <div style="margin-top: 1.5rem;">
+    <%= link_to "マイページに戻る", mypage_root_path, style: "font-size: 0.875rem; color: #6b7280; text-decoration: none;" %>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- 認証系Deviseビュー（ログイン・登録・アカウント設定・パスワードリセット・確認メール・ロック解除）をダークテーマに対応し、日本語化
- マイページ（ダッシュボード・ニックネーム編集・部屋管理・設定）をダークテーマに対応
- 共通レイアウトにLP同様の青ぼかし背景装飾を追加

## 変更ファイル（17ファイル）
- `layouts/application.html.erb` - 背景装飾追加
- `devise/` 配下 9ファイル - ダーク化・日本語化
- `mypage/dashboards/` 配下 3ファイル - ダーク化
- `mypage/rooms/` 配下 3ファイル - ダーク化
- `users/registrations/edit.html.erb` - 設定ページのダーク化

## Test plan
- [x] RSpec 182 examples, 0 failures
- [x] RuboCop 0 offenses
- [x] ログインページ目視確認
- [x] ユーザー登録ページ目視確認
- [x] マイページ目視確認（3カラムグリッド、ニックネーム編集）
- [x] 部屋管理ページ目視確認
- [x] 設定ページ目視確認

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)