### PR TITLE
feat: プロフィール・部屋メンバー・共有パーツのダークテーマ対応

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -17,8 +17,8 @@
     padding: 0.25rem 0.75rem;
     font-size: 0.875rem;
     line-height: 1.25rem;
-    background: #dbeafe; /* blue-100 */
-    color: #1e40af; /* blue-800 */
+    background: rgba(96, 165, 250, 0.15);
+    color: #60a5fa;
   }
 
   .tag-empty {

--- a/app/javascript/controllers/profile_search_controller.js
+++ b/app/javascript/controllers/profile_search_controller.js
@@ -21,13 +21,14 @@ export default class extends Controller {
     const mode = event.params.mode
     this.modeTarget.value = mode
 
-    const active   = "bg-blue-600 text-white border-blue-600"
-    const inactive = "bg-white text-gray-600 border-gray-300 hover:bg-gray-50"
     const andBtn = this.element.querySelector("[data-profile-search-mode-param='and']")
     const orBtn  = this.element.querySelector("[data-profile-search-mode-param='or']")
 
-    andBtn.className = `px-3 py-1.5 rounded-l-lg border text-sm font-medium ${mode === "and" ? active : inactive}`
-    orBtn.className  = `px-3 py-1.5 rounded-r-lg border-t border-b border-r text-sm font-medium ${mode === "or" ? active : inactive}`
+    const activeStyle = "background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; border-color: #2563eb;"
+    const inactiveStyle = "background: rgba(255,255,255,0.05); color: #9ca3af; border-color: rgba(55, 65, 81, 0.6);"
+
+    andBtn.style.cssText = `padding: 0.375rem 0.75rem; border-radius: 0.5rem 0 0 0.5rem; border: 1px solid; font-size: 0.875rem; font-weight: 500; cursor: pointer; ${mode === "and" ? activeStyle : inactiveStyle}`
+    orBtn.style.cssText  = `padding: 0.375rem 0.75rem; border-radius: 0 0.5rem 0.5rem 0; border: 1px solid; border-left: none; font-size: 0.875rem; font-weight: 500; cursor: pointer; ${mode === "or" ? activeStyle : inactiveStyle}`
 
     this.formTarget.requestSubmit()
   }

--- a/app/javascript/controllers/tag_autocomplete_controller.js
+++ b/app/javascript/controllers/tag_autocomplete_controller.js
@@ -114,12 +114,12 @@ export default class extends Controller {
   #renderChips() {
     this.chipListTarget.innerHTML = this.#chips.map(chip => `
       <span data-testid="chip"
-            class="inline-flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-800">
+            style="display: inline-flex; align-items: center; gap: 0.25rem; border-radius: 9999px; background: rgba(96, 165, 250, 0.15); padding: 0.25rem 0.75rem; font-size: 0.875rem; color: #60a5fa;">
         ${this.#escapeHtml(chip.name)}
         <button type="button"
                 data-action="click->tag-autocomplete#removeChip"
                 data-name="${this.#escapeHtml(chip.name)}"
-                class="ml-1 text-blue-500 hover:text-blue-700 leading-none"
+                style="margin-left: 0.25rem; color: #60a5fa; background: none; border: none; cursor: pointer; line-height: 1;"
                 aria-label="${this.#escapeHtml(chip.name)}を削除">×</button>
       </span>
     `).join("")
@@ -158,7 +158,9 @@ export default class extends Controller {
       <li data-testid="autocomplete-item"
           data-name="${this.#escapeHtml(name)}"
           data-action="click->tag-autocomplete#selectSuggestion"
-          class="cursor-pointer px-4 py-2 hover:bg-blue-50 text-sm text-gray-800">
+          style="cursor: pointer; padding: 0.5rem 1rem; font-size: 0.875rem; color: #d1d5db; transition: background 0.15s;"
+          onmouseenter="this.style.background='rgba(96, 165, 250, 0.15)'"
+          onmouseleave="this.style.background='transparent'">
         ${this.#escapeHtml(name)}
       </li>
     `).join("")
@@ -174,11 +176,9 @@ export default class extends Controller {
   #updateActiveItem(items) {
     items.forEach((item, i) => {
       if (i === this.#activeIndex) {
-        item.classList.add("bg-blue-100")
-        item.classList.remove("hover:bg-blue-50")
+        item.style.background = "rgba(96, 165, 250, 0.15)"
       } else {
-        item.classList.remove("bg-blue-100")
-        item.classList.add("hover:bg-blue-50")
+        item.style.background = "transparent"
       }
     })
   }

--- a/app/javascript/controllers/tag_description_controller.js
+++ b/app/javascript/controllers/tag_description_controller.js
@@ -26,10 +26,10 @@ export default class extends Controller {
       return
     }
     this.containerTarget.innerHTML = chips.map(chip => `
-      <div class="mt-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
-        <label class="block text-sm font-semibold text-blue-700 mb-1">
+      <div style="margin-top: 0.75rem; border-radius: 0.5rem; border: 1px solid rgba(55, 65, 81, 0.6); background: rgba(255,255,255,0.05); padding: 0.75rem 1rem;">
+        <label style="display: block; font-size: 0.875rem; font-weight: 600; color: #60a5fa; margin-bottom: 0.25rem;">
           # ${this.#escapeHtml(chip.name)}
-          <span class="ml-1 text-xs font-normal text-gray-400">の説明（任意・200字以内）</span>
+          <span style="margin-left: 0.25rem; font-size: 0.75rem; font-weight: 400; color: #6b7280;">の説明（任意・200字以内）</span>
         </label>
         <textarea data-testid="description-input"
                   data-name="${this.#escapeHtml(chip.name)}"
@@ -37,9 +37,7 @@ export default class extends Controller {
                   placeholder="例：\nマイクラ歴3年で、建築メインで遊んでいます！最近はサバイバルモードにハマっています。"
                   maxlength="200"
                   rows="3"
-                  class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-800
-                         focus:border-blue-500 focus:ring-2 focus:ring-blue-200 focus:outline-none
-                         resize-none bg-white">${this.#escapeHtml(chip.description || "")}</textarea>
+                  style="width: 100%; border-radius: 0.5rem; border: 1px solid rgba(55, 65, 81, 0.6); background: rgba(255,255,255,0.05); color: #ffffff; padding: 0.5rem 0.75rem; font-size: 0.875rem; outline: none; resize: none; box-sizing: border-box;">${this.#escapeHtml(chip.description || "")}</textarea>
       </div>
     `).join("")
   }

--- a/app/javascript/controllers/tag_toggle_controller.js
+++ b/app/javascript/controllers/tag_toggle_controller.js
@@ -19,8 +19,8 @@ export default class extends Controller {
     // 一旦、全タグを非アクティブに戻す
     this.tagTargets.forEach(tag => {
       tag.dataset.active = "false"
-      tag.classList.remove("bg-blue-600", "text-white")
-      tag.classList.add("bg-blue-100", "text-blue-800")
+      tag.style.background = "rgba(96, 165, 250, 0.15)"
+      tag.style.color = "#60a5fa"
     })
 
     // 同じタグを再クリックしたかで分岐する
@@ -39,8 +39,8 @@ export default class extends Controller {
   #openTag(tagEl) {
     const name = tagEl.dataset.name
     tagEl.dataset.active = "true"
-    tagEl.classList.remove("bg-blue-100", "text-blue-800")
-    tagEl.classList.add("bg-blue-600", "text-white")
+    tagEl.style.background = "linear-gradient(135deg, #2563eb, #1d4ed8)"
+    tagEl.style.color = "#ffffff"
 
     const desc = this.descriptionTargets.find(el => el.dataset.name === name)
     this.panelTarget.textContent = desc ? desc.textContent.trim() : ""

--- a/app/views/my/profiles/_form.html.erb
+++ b/app/views/my/profiles/_form.html.erb
@@ -1,28 +1,25 @@
 <%= form_with model: profile,
-              url: my_profile_path,
-
-              class: "space-y-6" do |f| %>
-
+              url: my_profile_path do |f| %>
 
   <% if profile.errors.any? %>
-    <div class="rounded-lg border border-red-300 bg-red-50 p-4">
-      <ul class="list-disc list-inside text-sm text-red-700 space-y-1">
+    <div style="margin-bottom: 1.25rem; padding: 1rem; border-radius: 0.5rem; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3);">
+      <ul style="list-style: none; padding: 0; margin: 0;">
         <% profile.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
+          <li style="font-size: 0.875rem; color: #fca5a5; line-height: 1.5; padding-left: 0.75rem; position: relative;">
+            <span style="position: absolute; left: 0;">・</span><%= msg %>
+          </li>
         <% end %>
       </ul>
     </div>
   <% end %>
 
-  <div>
+  <div style="margin-bottom: 1.5rem;">
     <%= f.label :bio, "自己紹介",
-          class: "block text-sm font-semibold text-gray-700" %>
+          style: "display: block; font-size: 0.875rem; font-weight: 600; color: #d1d5db; margin-bottom: 0.375rem;" %>
     <%= f.text_area :bio,
           rows: 5,
           placeholder: "例：\nインドア派で、ゲームやアニメが好きです！\n同じ趣味の人と気軽に話したいです。",
-          class: "w-full rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-800
-                 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 focus:outline-none
-                 resize-none" %>
+          style: "width: 100%; border-radius: 0.5rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; padding: 0.5rem 1rem; font-size: 0.875rem; outline: none; resize: none; box-sizing: border-box;" %>
   </div>
 
   <div class="relative"
@@ -32,7 +29,7 @@
        data-action="chips-changed->tag-description#onChipsChanged tag-description-update->tag-autocomplete#updateDescription">
 
     <%= f.label :hobbies_text, "タグ",
-          class: "block text-sm font-semibold text-gray-700" %>
+          style: "display: block; font-size: 0.875rem; font-weight: 600; color: #d1d5db; margin-bottom: 0.375rem;" %>
 
     <%# hidden field: サーバーに送信される値 %>
     <input type="hidden"
@@ -52,23 +49,20 @@
            data-testid="tag-input"
            data-tag-autocomplete-target="input"
            data-action="input->tag-autocomplete#onInput keydown->tag-autocomplete#onKeydown"
-           class="w-full rounded-lg border border-gray-300 px-4 py-2 text-gray-800
-                  focus:border-blue-500 focus:ring-2 focus:ring-blue-200 focus:outline-none">
+           style="width: 100%; border-radius: 0.5rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; padding: 0.5rem 1rem; font-size: 0.875rem; outline: none; box-sizing: border-box;">
 
     <%# オートコンプリート候補ドロップダウン %>
     <ul data-tag-autocomplete-target="dropdown"
-        class="hidden absolute z-10 mt-1 w-full rounded-lg border border-gray-200
-               bg-white shadow-lg max-h-60 overflow-auto"></ul>
+        class="hidden absolute z-10 mt-1 w-full rounded-lg max-h-60 overflow-auto"
+        style="background: #1e293b; border: 1px solid rgba(55, 65, 81, 0.6); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);"></ul>
 
     <%# 説明文入力エリア（tag-descriptionコントローラが管理）%>
     <div data-tag-description-target="container"></div>
   </div>
 
-  <div class="pt-4">
+  <div style="padding-top: 1rem;">
     <%= f.submit submit_label,
-          class: "w-full rounded-lg bg-blue-600 px-6 py-3
-                 text-white font-semibold text-base
-                 hover:bg-blue-700 transition-colors",
+          style: "width: 100%; border-radius: 0.5rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; padding: 0.75rem 1.5rem; font-size: 1rem; font-weight: 600; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);",
           data: { turbo_submits_with: "送信中..." } %>
   </div>
 

--- a/app/views/my/profiles/edit.html.erb
+++ b/app/views/my/profiles/edit.html.erb
@@ -1,11 +1,11 @@
-<div class="w-full max-w-xl bg-white rounded-2xl shadow-lg p-8">
+<div style="width: 100%; max-width: 36rem; padding: 2rem; border-radius: 1rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
 
-  <h1 class="text-2xl font-bold text-center text-gray-800 mb-4">
+  <h1 style="font-size: 1.5rem; font-weight: 700; text-align: center; color: #ffffff; margin-bottom: 1rem;">
     プロフィール編集
   </h1>
 
-  <p class="text-center text-gray-600 mb-8">
-    <span class="font-semibold text-gray-800">
+  <p style="text-align: center; color: #9ca3af; margin-bottom: 2rem;">
+    <span style="font-weight: 600; color: #ffffff;">
       <%= current_user.nickname.presence || current_user.email %>
     </span>
     さんのプロフィール
@@ -14,18 +14,17 @@
   <%= render "form",
         profile: @profile,
         submit_label: "更新する" %>
-  
-  <hr>
 
-  <div class="mt-6 pt-4 border-t border-gray-200">
+  <%# プロフィール削除 %>
+  <div style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid rgba(55, 65, 81, 0.4);">
     <%= button_to "プロフィールを削除する",
       my_profile_path,
       method: :delete,
       data: { turbo_confirm: "本当に削除しますか？" },
-      class: "w-full bg-red-50 text-red-600 py-2 rounded-lg text-sm hover:bg-red-100 transition" %>
+      style: "width: 100%; padding: 0.5rem 1rem; border-radius: 0.5rem; background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); color: #ef4444; font-size: 0.875rem; cursor: pointer;" %>
   </div>
 
   <br>
 
-  <%= link_to "プロフィール一覧へ戻る", profiles_path, class: "text-sm text-gray-600 hover:underline" %>
+  <%= link_to "プロフィール一覧へ戻る", profiles_path, style: "font-size: 0.875rem; color: #6b7280; text-decoration: none;" %>
 </div>

--- a/app/views/my/profiles/new.html.erb
+++ b/app/views/my/profiles/new.html.erb
@@ -1,11 +1,11 @@
-<div class="w-full max-w-xl bg-white rounded-2xl shadow-lg p-8">
+<div style="width: 100%; max-width: 36rem; padding: 2rem; border-radius: 1rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
 
-  <h1 class="text-2xl font-bold text-center text-gray-800 mb-4">
+  <h1 style="font-size: 1.5rem; font-weight: 700; text-align: center; color: #ffffff; margin-bottom: 1rem;">
     プロフィール作成
   </h1>
 
-  <p class="text-center text-gray-600 mb-8">
-    <span class="font-semibold text-gray-800">
+  <p style="text-align: center; color: #9ca3af; margin-bottom: 2rem;">
+    <span style="font-weight: 600; color: #ffffff;">
       <%= current_user.nickname.presence || current_user.email %>
     </span>
     さんのプロフィール
@@ -16,6 +16,6 @@
         submit_label: "作成する" %>
   <br>
 
-  <%= link_to "プロフィール一覧へ戻る", profiles_path, class: "text-sm text-gray-600 hover:underline" %>
+  <%= link_to "プロフィール一覧へ戻る", profiles_path, style: "font-size: 0.875rem; color: #6b7280; text-decoration: none;" %>
 
 </div>

--- a/app/views/profiles/_profile_card.html.erb
+++ b/app/views/profiles/_profile_card.html.erb
@@ -1,32 +1,31 @@
-<div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+<div style="border-radius: 1rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); padding: 1.5rem; box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
 
   <!-- ユーザー名 -->
-  <p class="text-sm font-medium text-gray-600 mb-2 truncate">
+  <p style="font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.5rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
     <%= profile.user.nickname %>
   </p>
 
-  <!-- タグ（一覧では多すぎると崩れるので limit 推奨） -->
-  <div class="mt-3">
+  <!-- タグ -->
+  <div style="margin-top: 0.75rem;">
     <%= render "shared/hobby_tags", hobbies: profile.hobbies, limit: 5 %>
   </div>
 
-
   <!-- 自己紹介 -->
-  <p class="text-gray-600 text-sm leading-relaxed whitespace-pre-line line-clamp-3 mt-2">
+  <p class="line-clamp-3" style="color: #9ca3af; font-size: 0.875rem; line-height: 1.5; white-space: pre-line; margin-top: 0.5rem;">
     <%= profile.bio.presence || "説明文は未入力です" %>
   </p>
 
-  <div class="mt-4 flex items-center gap-4">
+  <div style="margin-top: 1rem; display: flex; align-items: center; gap: 1rem;">
     <%= link_to "詳細を見る",
                 profile_path(profile),
                 data: { turbo_frame: "_top" },
-                class: "text-blue-600 hover:underline text-sm font-medium" %>
+                style: "color: #60a5fa; text-decoration: none; font-size: 0.875rem; font-weight: 500;" %>
 
     <% if current_user.own?(profile) %>
       <%= link_to "編集する",
                   edit_my_profile_path,
                   data: { turbo_frame: "_top" },
-                  class: "text-blue-600 hover:underline text-sm font-medium" %>
+                  style: "color: #60a5fa; text-decoration: none; font-size: 0.875rem; font-weight: 500;" %>
     <% end %>
   </div>
 

--- a/app/views/profiles/_search_form.html.erb
+++ b/app/views/profiles/_search_form.html.erb
@@ -1,12 +1,12 @@
 <%= form_with url: profiles_path,
-      method: :get,
-      local: false,
-      data: {
-        controller: "profile-search",
-        profile_search_target: "form",
-        turbo_frame: "profile_list"
-      },
-      class: "flex flex-col gap-4" do |f| %>
+     method: :get,
+     local: false,
+     data: {
+       controller: "profile-search",
+       profile_search_target: "form",
+       turbo_frame: "profile_list"
+     },
+     class: "flex flex-col gap-4" do |f| %>
 
   <!-- AND/OR hidden フィールド -->
   <% current_mode = params[:mode] == "or" ? "or" : "and" %>
@@ -16,38 +16,38 @@
 
     <!-- 検索ワード入力 -->
     <div class="flex-1">
-      <%= f.label :q, "検索（趣味タグ・ユーザー名）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.label :q, "検索（趣味タグ・ユーザー名）", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.25rem;" %>
       <%= f.text_field :q,
             value: params[:q],
             placeholder: "例：ゲーム, 釣り",
             data: { action: "input->profile-search#search" },
-            class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+            style: "width: 100%; border-radius: 0.5rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; padding: 0.5rem 0.75rem; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
     </div>
 
     <!-- AND/OR トグル -->
     <div class="flex items-center gap-2">
-      <span class="text-sm font-medium text-gray-700">検索モード：</span>
+      <span style="font-size: 0.875rem; font-weight: 500; color: #d1d5db;">検索モード：</span>
 
       <button type="button"
               data-action="click->profile-search#setMode"
               data-profile-search-mode-param="and"
-              class="px-3 py-1.5 rounded-l-lg border text-sm font-medium <%= current_mode == 'and' ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50' %>">
-        AND
+              style="padding: 0.375rem 0.75rem; border-radius: 0.5rem 0 0 0.5rem; font-size: 0.875rem; font-weight: 500; cursor: pointer; <%= current_mode == 'and' ? 'background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; border: 1px solid #2563eb;' : 'background: rgba(255,255,255,0.05); color: #9ca3af; border: 1px solid rgba(55, 65, 81, 0.6);' %>">
+        絞り込み
       </button>
       <button type="button"
               data-action="click->profile-search#setMode"
               data-profile-search-mode-param="or"
-              class="px-3 py-1.5 rounded-r-lg border-t border-b border-r text-sm font-medium <%= current_mode == 'or' ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50' %>">
-        OR
+              style="padding: 0.375rem 0.75rem; border-radius: 0 0.5rem 0.5rem 0; font-size: 0.875rem; font-weight: 500; cursor: pointer; <%= current_mode == 'or' ? 'background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; border: 1px solid #2563eb;' : 'background: rgba(255,255,255,0.05); color: #9ca3af; border: 1px solid rgba(55, 65, 81, 0.6);' %>">
+        いずれか
       </button>
     </div>
 
     <!-- 検索ボタン -->
     <%= f.submit "検索",
-          class: "px-4 py-1.5 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg cursor-pointer" %>
+          style: "padding: 0.375rem 1rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border-radius: 0.5rem; border: none; cursor: pointer;" %>
 
     <!-- リセット -->
     <%= link_to "クリア", profiles_path,
-          class: "px-4 py-1.5 bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm font-medium rounded-lg" %>
+          style: "padding: 0.375rem 1rem; background: rgba(255,255,255,0.05); color: #9ca3af; font-size: 0.875rem; font-weight: 500; border-radius: 0.5rem; text-decoration: none;" %>
   </div>
 <% end %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,8 +1,8 @@
 <div class="w-full max-w-7xl mx-auto flex flex-col gap-6">
-  <h1 class="text-2xl font-semibold text-gray-800 mb-4">プロフィール一覧</h1>
+  <h1 style="font-size: 1.5rem; font-weight: 600; color: #ffffff; margin-bottom: 1rem;">プロフィール一覧</h1>
 
   <!-- 検索フォーム -->
-  <div class="w-full rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+  <div style="width: 100%; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); padding: 1rem;">
     <%= render "search_form" %>
   </div>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,24 +1,24 @@
-<div class="w-full sm:w-3/4 max-w-lg space-y-6">
+<div style="width: 100%; max-width: 32rem; margin: 0 auto;">
 
   <!-- タイトル -->
-  <h1 class="text-xl font-bold text-gray-700 border-b pb-2">
+  <h1 style="font-size: 1.25rem; font-weight: 700; color: #ffffff; border-bottom: 1px solid rgba(55, 65, 81, 0.4); padding-bottom: 0.5rem; margin-bottom: 1.5rem;">
     プロフィール詳細
   </h1>
 
   <!-- プロフィールカード -->
-  <div class="bg-white rounded-xl shadow p-6 space-y-4">
+  <div style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
 
     <!-- ユーザー名 -->
-    <div>
-      <p class="text-sm text-gray-500">ユーザー名</p>
-      <p class="text-base font-medium text-gray-800">
+    <div style="margin-bottom: 1rem;">
+      <p style="font-size: 0.875rem; color: #6b7280;">ユーザー名</p>
+      <p style="font-size: 1rem; font-weight: 500; color: #ffffff;">
         <%= @profile.user.nickname %>
       </p>
     </div>
 
     <!-- タグ -->
-    <section>
-      <p class="text-sm text-gray-500 mb-1">趣味</p>
+    <section style="margin-bottom: 1rem;">
+      <p style="font-size: 0.875rem; color: #6b7280; margin-bottom: 0.25rem;">趣味</p>
       <% if @profile.profile_hobbies.any? %>
         <div data-controller="tag-toggle"
              data-tag-toggle-bio-value="<%= @profile.bio.presence || '未入力' %>">
@@ -38,7 +38,7 @@
                         data-action="click->tag-toggle#toggle"
                         data-name="<%= ph.hobby.name %>"
                         data-active="false"
-                        class="bg-blue-100 text-blue-800 text-sm px-3 py-1 rounded-full cursor-pointer hover:bg-blue-200 transition-colors">
+                        style="background: rgba(96, 165, 250, 0.15); color: #60a5fa; font-size: 0.875rem; padding: 0.25rem 0.75rem; border-radius: 9999px; cursor: pointer; border: none; transition: background 0.2s;">
                   <%= ph.hobby.name %>
                 </button>
               </li>
@@ -46,7 +46,7 @@
           </ul>
 
           <div data-tag-toggle-target="panel"
-               class="hidden mt-3 px-3 py-2 rounded-lg bg-gray-50 border border-gray-200 text-sm text-gray-700 whitespace-pre-line">
+               class="hidden" style="margin-top: 0.75rem; padding: 0.75rem; border-radius: 0.5rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.4); font-size: 0.875rem; color: #d1d5db; white-space: pre-line;">
           </div>
         </div>
       <% else %>
@@ -55,25 +55,26 @@
     </section>
 
     <% if current_user != @profile.user %>
-      <section>
-        <p class="text-sm text-gray-500 mb-1">共通の趣味</p>
+      <section style="margin-bottom: 1rem;">
+        <p style="font-size: 0.875rem; color: #6b7280; margin-bottom: 0.25rem;">共通の趣味</p>
 
         <% if @shared_hobbies.any? %>
           <%= render "shared/hobby_tags", hobbies: @shared_hobbies %>
         <% else %>
-          <p class="text-sm text-gray-600">共通の趣味はまだありません</p>
+          <p style="font-size: 0.875rem; color: #6b7280;">共通の趣味はまだありません</p>
         <% end %>
       </section>
     <% end %>
 
-    <div class="mt-8 flex flex-col gap-3 items-center">
+    <div style="margin-top: 2rem; display: flex; flex-direction: column; gap: 0.75rem; align-items: center;">
       <% if current_user == @profile.user %>
-          <%= link_to "編集する", edit_my_profile_path, class: "w-full max-w-xs px-4 py-2 rounded bg-blue-600 text-white text-center hover:bg-blue-700" %>
+        <%= link_to "編集する", edit_my_profile_path,
+              style: "width: 100%; max-width: 20rem; padding: 0.5rem 1rem; border-radius: 0.375rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; text-align: center; text-decoration: none; font-size: 0.875rem;" %>
       <% end %>
 
       <%= link_to "プロフィール一覧へ戻る",
               profiles_path,
-              class: "text-sm text-gray-600 hover:underline" %>
+              style: "font-size: 0.875rem; color: #6b7280; text-decoration: none;" %>
     </div>
   </div>
 

--- a/app/views/rooms/members/show.html.erb
+++ b/app/views/rooms/members/show.html.erb
@@ -1,13 +1,13 @@
 <turbo-frame id="member_detail">
-  <div class="bg-white rounded-xl shadow p-6 space-y-4">
-    <div>
-      <p class="text-sm text-gray-500">ユーザー名</p>
-      <p class="text-base font-medium text-gray-800">
+  <div style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+    <div style="margin-bottom: 1rem;">
+      <p style="font-size: 0.875rem; color: #6b7280;">ユーザー名</p>
+      <p style="font-size: 1rem; font-weight: 500; color: #ffffff;">
         <%= @profile.user.nickname.presence || "no-name" %>
       </p>
     </div>
 
-    <p class="text-sm text-gray-500 mb-1">この部屋での趣味</p>
+    <p style="font-size: 0.875rem; color: #6b7280; margin-bottom: 0.25rem;">この部屋での趣味</p>
     <% if @shared_hobbies.any? %>
       <div data-controller="tag-toggle"
            data-tag-toggle-bio-value="<%= @profile.bio.presence || '未入力' %>">
@@ -28,7 +28,7 @@
                       data-action="click->tag-toggle#toggle"
                       data-name="<%= hobby.name %>"
                       data-active="false"
-                      class="bg-blue-100 text-blue-800 text-sm px-3 py-1 rounded-full cursor-pointer hover:bg-blue-200 transition-colors">
+                      style="background: rgba(96, 165, 250, 0.15); color: #60a5fa; font-size: 0.875rem; padding: 0.25rem 0.75rem; border-radius: 9999px; cursor: pointer; border: none; transition: background 0.2s;">
                 <%= hobby.name %>
               </button>
             </li>
@@ -36,11 +36,11 @@
         </ul>
 
         <div data-tag-toggle-target="panel"
-             class="hidden mt-3 px-3 py-2 rounded-lg bg-gray-50 border border-gray-200 text-sm text-gray-700 whitespace-pre-line break-words">
+             class="hidden" style="margin-top: 0.75rem; padding: 0.75rem; border-radius: 0.5rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.4); font-size: 0.875rem; color: #d1d5db; white-space: pre-line; word-break: break-word;">
         </div>
       </div>
     <% else %>
-      <p class="text-gray-400 text-sm">趣味が登録されていません</p>
+      <p style="color: #6b7280; font-size: 0.875rem;">趣味が登録されていません</p>
     <% end %>
   </div>
 </turbo-frame>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,7 @@
     
     <!-- ロゴ / アプリ名（左） -->
     <div class="text-xl font-bold">
-      <%= link_to "MyApp", root_path, class: "hover:opacity-80" %>
+      <%= link_to "Hobby Matching", root_path, class: "hover:opacity-80" %>
     </div>
 
     <!-- ボタン群（右） -->

--- a/app/views/shared/_login_cta.html.erb
+++ b/app/views/shared/_login_cta.html.erb
@@ -1,13 +1,13 @@
-<div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
-  <p class="text-sm text-gray-700">
+<div style="border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); padding: 1rem;">
+  <p style="font-size: 0.875rem; color: #d1d5db;">
     共通の趣味の表示や「趣味追加」などの機能は、ログイン後に利用できます。
   </p>
 
-  <div class="mt-3 flex flex-col sm:flex-row gap-2">
+  <div class="flex flex-col sm:flex-row gap-2" style="margin-top: 0.75rem;">
     <%= link_to "ログイン", new_user_session_path,
-          class: "inline-flex items-center justify-center rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white" %>
+          style: "display: inline-flex; align-items: center; justify-content: center; border-radius: 0.5rem; border: 1px solid rgba(55, 65, 81, 0.6); padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 500; color: #d1d5db; text-decoration: none;" %>
 
     <%= link_to "新規登録", new_user_registration_path,
-          class: "inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700" %>
+          style: "display: inline-flex; align-items: center; justify-content: center; border-radius: 0.5rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); padding: 0.5rem 1rem; font-size: 0.875rem; font-weight: 600; color: #ffffff; text-decoration: none;" %>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- プロフィール一覧・詳細・作成・編集ページをダークテーマに対応
- 検索フォームのAND/ORトグルを日本語化（絞り込み/いずれか）
- Stimulusコントローラ（tag-autocomplete, tag-description, tag-toggle, profile-search）の動的生成要素をダークテーマ対応
- 部屋メンバー詳細・ログインCTA・タグチップCSSをダークテーマ対応

closes #144

## Test plan
- [x] プロフィール一覧ページがダークテーマで表示される
- [x] 検索フォームの絞り込み/いずれかトグルが動作する
- [x] プロフィール作成・編集フォームのタグ入力・説明文がダークテーマで表示される
- [x] 部屋メンバー詳細のタグクリックで選択状態が視覚的にわかる
- [x] RSpec 182 examples, 0 failures
- [x] RuboCop 110 files, no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)