### PR TITLE
feat: ApplicationMailerの送信元を環境変数で管理する #151

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch("MAILER_FROM", "from@example.com")
   layout "mailer"
 end


### PR DESCRIPTION
## Summary
- `ApplicationMailer` の `default from:` を `ENV.fetch("MAILER_FROM", "from@example.com")` に変更
- 本番環境では環境変数 `MAILER_FROM` で送信元アドレスを管理できるようにした

## 変更内容
- `app/mailers/application_mailer.rb`: 送信元をハードコードから環境変数に変更

## Test plan
- [x] RSpec 全通過（206 examples, 0 failures）
- [x] RuboCop 全通過（118 files, no offenses）

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)