### PR TITLE
feat: 本番環境のメール配信をSendGrid SMTP経由に設定 #152

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,6 +78,18 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: ENV.fetch("MAILER_HOST", "hobby-matching-app.com"), protocol: "https" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.sendgrid.net",
+    port: 587,
+    domain: "hobby-matching-app.com",
+    user_name: "apikey",
+    password: ENV.fetch("SENDGRID_API_KEY"),
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
## 概要
- 本番環境（Render）でSendGrid SMTP経由のメール配信を有効化

## 変更内容
- `config/environments/production.rb` に `action_mailer` のSMTP設定を追加
- SendGrid API Key は環境変数 `SENDGRID_API_KEY` で管理
- メール内リンクのホストは環境変数 `MAILER_HOST` で管理

## Render環境変数（設定済み）
- `SENDGRID_API_KEY`
- `MAILER_FROM` (`noreply@hobby-matching-app.com`)
- `MAILER_HOST` (`hobby-matching-app.com`)

## テスト計画
- [ ] デプロイ後、パスワードリセットメールが送信されることを確認
- [ ] メールの送信元が `noreply@hobby-matching-app.com` であることを確認

Closes #152