### PR TITLE
feat: 認証画面のUI改善・パスワードリセットメール日本語化 #156

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,9 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>こんにちは、<%= @resource.email %> さん</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワード再設定のリクエストを受け付けました。</p>
+<p>下記のリンクからパスワードを変更してください。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワードを変更する', edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>このメールに心当たりがない場合は、このメールを無視してください。</p>
+<p>上記のリンクにアクセスしない限り、パスワードは変更されません。</p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); align-self: flex-start;">
   <h1 style="font-size: 1.5rem; font-weight: 700; color: #ffffff; margin-bottom: 1.5rem;">パスワード変更</h1>
 
   <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
@@ -24,6 +24,4 @@
       パスワードを変更する
     </button>
   <% end %>
-
-  <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); align-self: flex-start;">
   <h1 style="font-size: 1.5rem; font-weight: 700; color: #ffffff; margin-bottom: 1.5rem;">パスワードをお忘れですか？</h1>
 
   <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
@@ -15,5 +15,8 @@
     </button>
   <% end %>
 
-  <%= render "devise/shared/links" %>
+  <div style="margin-top: 1.5rem; text-align: center;">
+    <%= link_to "ログインに戻る", new_session_path(resource_name),
+          style: "font-size: 0.875rem; color: #60a5fa; text-decoration: none;" %>
+  </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); align-self: flex-start;">
   <h1 style="font-size: 1.5rem; font-weight: 700; color: #ffffff; margin-bottom: 1.5rem;">ユーザー登録</h1>
 
   <%= form_with scope: resource, as: resource_name, url: registration_path(resource_name), local: true do |f| %>
@@ -36,4 +36,41 @@
       ユーザー登録
     </button>
   <% end %>
+
+  <%# 区切り線 %>
+  <div style="display: flex; align-items: center; margin: 1.5rem 0;">
+    <div style="flex: 1; height: 1px; background: rgba(55, 65, 81, 0.4);"></div>
+    <span style="margin: 0 0.75rem; font-size: 0.875rem; color: #6b7280;">または</span>
+    <div style="flex: 1; height: 1px; background: rgba(55, 65, 81, 0.4);"></div>
+  </div>
+
+  <%# Google OAuth %>
+  <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false },
+        form: { style: "width: 100%; margin-bottom: 0.75rem;" },
+        style: "width: 100%; display: flex; align-items: center; justify-content: center; gap: 0.75rem; padding: 0.625rem 1rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); cursor: pointer;" do %>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="20" height="20" style="min-width:20px">
+      <path fill="#EA4335" d="M24 9.5c3.14 0 5.95 1.08 8.17 2.86l6.09-6.09C34.46 3.11 29.5 1 24 1 14.82 1 7.07 6.48 3.64 14.22l7.08 5.5C12.4 13.72 17.73 9.5 24 9.5z"/>
+      <path fill="#4285F4" d="M46.5 24.5c0-1.64-.15-3.22-.42-4.75H24v9h12.7c-.55 2.98-2.2 5.5-4.67 7.2l7.17 5.57C43.26 37.27 46.5 31.36 46.5 24.5z"/>
+      <path fill="#FBBC05" d="M10.72 28.28A14.6 14.6 0 0 1 9.5 24c0-1.49.26-2.94.72-4.28l-7.08-5.5A23.94 23.94 0 0 0 0 24c0 3.86.92 7.5 2.55 10.72l8.17-6.44z"/>
+      <path fill="#34A853" d="M24 47c5.5 0 10.12-1.82 13.5-4.93l-7.17-5.57C28.6 38.1 26.42 39 24 39c-6.27 0-11.6-4.22-13.28-9.72l-8.17 6.44C6.07 43.52 14.45 47 24 47z"/>
+    </svg>
+    <span style="font-size: 0.875rem; font-weight: 500; color: #d1d5db;">Googleで登録</span>
+  <% end %>
+
+  <%# Discord OAuth %>
+  <%= button_to user_discord_omniauth_authorize_path, method: :post, data: { turbo: false },
+        form: { style: "width: 100%;" },
+        style: "width: 100%; display: flex; align-items: center; justify-content: center; gap: 0.75rem; padding: 0.625rem 1rem; border-radius: 0.375rem; background: #5865F2; border: 1px solid transparent; cursor: pointer;" do %>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 127.14 96.36" width="20" height="20" style="min-width:20px">
+      <path fill="#ffffff" d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"/>
+    </svg>
+    <span style="font-size: 0.875rem; font-weight: 500; color: #ffffff;">Discordで登録</span>
+  <% end %>
+
+  <%# ログインリンク %>
+  <div style="margin-top: 1.5rem; text-align: center; border-top: 1px solid rgba(55, 65, 81, 0.4); padding-top: 1.5rem;">
+    <p style="font-size: 0.875rem; color: #9ca3af; margin-bottom: 0.5rem;">すでにアカウントをお持ちの方</p>
+    <%= link_to "ログインはこちら", new_session_path(resource_name),
+          style: "font-size: 0.875rem; color: #60a5fa; text-decoration: none; font-weight: 500;" %>
+  </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+<div style="width: 100%; max-width: 28rem; padding: 2rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); align-self: flex-start;">
   <h1 style="font-size: 1.5rem; font-weight: 700; color: #ffffff; margin-bottom: 1.5rem;">ログイン</h1>
 
   <%= form_with scope: resource, as: resource_name, url: session_path(resource_name), local: true do |f| %>
@@ -9,11 +9,16 @@
             placeholder: "test@example.com" %>
     </div>
 
-    <div style="margin-bottom: 1.5rem;">
+    <div style="margin-bottom: 0.5rem;">
       <label style="display: block; font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.375rem;">パスワード</label>
       <%= f.password_field :password, autocomplete: "password",
             style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;",
             placeholder: "pass1234" %>
+    </div>
+
+    <div style="margin-bottom: 1.5rem; text-align: right;">
+      <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name),
+            style: "font-size: 0.75rem; color: #60a5fa; text-decoration: none;" %>
     </div>
 
     <button type="submit" style="width: 100%; padding: 0.625rem 1rem; border-radius: 0.375rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);">
@@ -24,7 +29,7 @@
   <%# 区切り線 %>
   <div style="display: flex; align-items: center; margin: 1.5rem 0;">
     <div style="flex: 1; height: 1px; background: rgba(55, 65, 81, 0.4);"></div>
-    <span style="margin: 0 0.75rem; font-size: 0.875rem; color: #6b7280;"></span>
+    <span style="margin: 0 0.75rem; font-size: 0.875rem; color: #6b7280;">または</span>
     <div style="flex: 1; height: 1px; background: rgba(55, 65, 81, 0.4);"></div>
   </div>
 
@@ -38,7 +43,7 @@
       <path fill="#FBBC05" d="M10.72 28.28A14.6 14.6 0 0 1 9.5 24c0-1.49.26-2.94.72-4.28l-7.08-5.5A23.94 23.94 0 0 0 0 24c0 3.86.92 7.5 2.55 10.72l8.17-6.44z"/>
       <path fill="#34A853" d="M24 47c5.5 0 10.12-1.82 13.5-4.93l-7.17-5.57C28.6 38.1 26.42 39 24 39c-6.27 0-11.6-4.22-13.28-9.72l-8.17 6.44C6.07 43.52 14.45 47 24 47z"/>
     </svg>
-    <span style="font-size: 0.875rem; font-weight: 500; color: #d1d5db;">Sign in with Google</span>
+    <span style="font-size: 0.875rem; font-weight: 500; color: #d1d5db;">Googleでログイン</span>
   <% end %>
 
   <%# Discord OAuth %>
@@ -48,6 +53,13 @@
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 127.14 96.36" width="20" height="20" style="min-width:20px">
       <path fill="#ffffff" d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"/>
     </svg>
-    <span style="font-size: 0.875rem; font-weight: 500; color: #ffffff;">Sign in with Discord</span>
+    <span style="font-size: 0.875rem; font-weight: 500; color: #ffffff;">Discordでログイン</span>
   <% end %>
+
+  <%# ユーザー登録リンク %>
+  <div style="margin-top: 1.5rem; text-align: center; border-top: 1px solid rgba(55, 65, 81, 0.4); padding-top: 1.5rem;">
+    <p style="font-size: 0.875rem; color: #9ca3af; margin-bottom: 0.5rem;">アカウントをお持ちでない方</p>
+    <%= link_to "ユーザー登録はこちら", new_registration_path(resource_name),
+          style: "font-size: 0.875rem; color: #60a5fa; text-decoration: none; font-weight: 500;" %>
+  </div>
 </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = ENV.fetch("MAILER_FROM", "noreply@example.com")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -40,6 +40,12 @@ ja:
         signed_up: ユーザー登録に成功しました。
     omniauth_callbacks:
       signed_in: ログインしました。
+    passwords:
+      no_token: "パスワードリセットトークンがありません。パスワードリセットメールのリンクからアクセスしてください。"
+      send_instructions: "パスワードリセット用のメールを送信しました。"
+      send_paranoid_instructions: "メールアドレスが登録済みの場合、パスワードリセット用のメールを送信しました。"
+      updated: "パスワードが正しく変更されました。"
+      updated_not_active: "パスワードが正しく変更されました。ログインしてください。"
     sessions:
       new:
         sign_in: ログイン

--- a/spec/mailers/devise_password_reset_spec.rb
+++ b/spec/mailers/devise_password_reset_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Devise::Mailer, type: :mailer do
+  describe "reset_password_instructions" do
+    let(:user) { create(:user) }
+    let(:token) { "test-reset-token" }
+    let(:mail) { Devise::Mailer.reset_password_instructions(user, token) }
+
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("MAILER_FROM", anything).and_return("noreply@example.com")
+    end
+
+    it "送信元がMAILER_FROMになる" do
+      expect(mail.from).to include("noreply@example.com")
+    end
+
+    it "本文に日本語の案内が含まれる" do
+      expect(mail.body.decoded).to include("パスワード再設定")
+    end
+
+    it "本文に「パスワードを変更する」リンクテキストが含まれる" do
+      expect(mail.body.decoded).to include("パスワードを変更する")
+    end
+  end
+end

--- a/spec/system/auth/login_spec.rb
+++ b/spec/system/auth/login_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "ログイン画面", type: :system do
+  before { visit new_user_session_path }
+
+  it "「パスワードをお忘れですか？」リンクが表示される" do
+    expect(page).to have_link("パスワードをお忘れですか？", href: new_user_password_path)
+  end
+
+  it "「ユーザー登録はこちら」リンクが表示される" do
+    expect(page).to have_link("ユーザー登録はこちら", href: new_user_registration_path)
+  end
+end

--- a/spec/system/auth/password_reset_spec.rb
+++ b/spec/system/auth/password_reset_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "パスワードリセット画面", type: :system do
+  describe "パスワードリセット申請画面" do
+    before { visit new_user_password_path }
+
+    it "「ログインに戻る」リンクが表示される" do
+      expect(page).to have_link("ログインに戻る", href: new_user_session_path)
+    end
+
+    it "OAuthボタンが表示されない" do
+      expect(page).not_to have_button("Google")
+      expect(page).not_to have_button("Discord")
+    end
+
+    it "フォーム内に「ユーザー登録」リンクが表示されない" do
+      within("div[style*='max-width: 28rem']") do
+        expect(page).not_to have_link("ユーザー登録")
+      end
+    end
+  end
+
+  describe "パスワード変更画面" do
+    before do
+      user = create(:user)
+      token = user.send_reset_password_instructions
+      visit edit_user_password_path(reset_password_token: token)
+    end
+
+    it "OAuthボタンが表示されない" do
+      expect(page).not_to have_button("Google")
+      expect(page).not_to have_button("Discord")
+    end
+
+    it "フォーム内に「ログイン」リンクが表示されない" do
+      within("div[style*='max-width: 28rem']") do
+        expect(page).not_to have_link("ログイン")
+      end
+    end
+  end
+end

--- a/spec/system/auth/registration_spec.rb
+++ b/spec/system/auth/registration_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "ユーザー登録画面", type: :system do
+  before { visit new_user_registration_path }
+
+  it "「ログインはこちら」リンクが表示される" do
+    expect(page).to have_link("ログインはこちら", href: new_user_session_path)
+  end
+end

--- a/spec/system/my/profile_tag_description_spec.rb
+++ b/spec/system/my/profile_tag_description_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe "タグ説明文入力UI", type: :system, js: true do
       find("[data-testid='description-input']").fill_in with: "毎日やってます"
       click_button "更新する"
 
-      expect(page).to have_text("プロフィールを更新しました")
+      expect(page).to have_current_path(profile_path(profile))
+      within("#flash") { expect(page).to have_text("プロフィールを更新しました") }
 
       ph = profile.reload.profile_hobbies.joins(:hobby).find_by(hobbies: { name: "ゲーム" })
       expect(ph.description).to eq("毎日やってます")
@@ -47,7 +48,8 @@ RSpec.describe "タグ説明文入力UI", type: :system, js: true do
       find("[data-testid='tag-input']").send_keys(:return)
       click_button "更新する"
 
-      expect(page).to have_text("プロフィールを更新しました")
+      expect(page).to have_current_path(profile_path(profile))
+      within("#flash") { expect(page).to have_text("プロフィールを更新しました") }
 
       ph = profile.reload.profile_hobbies.joins(:hobby).find_by(hobbies: { name: "ゲーム" })
       expect(ph).not_to be_nil
@@ -85,7 +87,7 @@ RSpec.describe "タグ説明文入力UI", type: :system, js: true do
       click_button "更新する"
 
       expect(page).to have_current_path(profile_path(profile))
-      expect(page).to have_text("プロフィールを更新しました")
+      within("#flash") { expect(page).to have_text("プロフィールを更新しました") }
       expect(profile.reload.bio).to eq("テスト自己紹介です")
     end
   end


### PR DESCRIPTION
## Summary
- ログイン画面に「パスワードをお忘れですか？」「ユーザー登録はこちら」リンクを追加
- ユーザー登録画面にOAuthボタンと「ログインはこちら」リンクを追加
- パスワードリセット画面から不要なリンク・OAuthボタンを削除
- パスワードリセットメールを日本語化
- Devise送信元をMAILER_FROM環境変数に統一
- devise.ja.ymlにパスワードリセット系メッセージを追加
- 認証画面のカード位置を上寄せに変更

## Test plan
- [x] ログイン画面に「パスワードをお忘れですか？」「ユーザー登録はこちら」リンクが表示される
- [x] ユーザー登録画面にOAuthボタンと「ログインはこちら」リンクが表示される
- [x] パスワードリセット申請画面に「ログインに戻る」のみ表示される
- [x] パスワード変更画面にリンク・OAuthボタンが表示されない
- [x] パスワードリセットメールが日本語で届く
- [x] RSpec 217 examples, 0 failures
- [x] RuboCop no offenses

## Related
- Closes #156