### PR TITLE
feat: OAuth認証時のプロフィール画像自動保存 #160

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "minitest", "~> 5.20"
+  gem "webmock"
 end
 
 # deviseを追加

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,9 @@ GEM
       ostruct
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
@@ -154,6 +157,7 @@ GEM
     ffi (1.17.3-x86_64-linux-musl)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hashdiff (1.2.1)
     hashie (5.1.0)
       logger
     i18n (1.14.8)
@@ -445,6 +449,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -500,6 +508,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webmock
 
 CHECKSUMS
   actioncable (7.2.3) sha256=e15d17b245f1dfe7cafdda4a0c6f7ba8ebaab1af33884415e09cfef4e93ad4f9
@@ -530,6 +539,7 @@ CHECKSUMS
   cloudinary (2.4.4) sha256=a458a837e9ddb69b12f009496c09557f16db4244466530e02136541408d85efc
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   cssbundling-rails (1.4.3) sha256=53aecd5a7d24ac9c8fcd92975acd0e830fead4ee4583d3d3d49bb64651946e41
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
@@ -554,6 +564,7 @@ CHECKSUMS
   ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
   ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
@@ -671,6 +682,7 @@ CHECKSUMS
   version_gem (1.1.9) sha256=0c1a0962ae543c84a00889bb018d9f14d8f8af6029d26b295d98774e3d2eb9a4
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   web-console (4.2.1) sha256=e7bcf37a10ea2b4ec4281649d1cee461b32232d0a447e82c786e6841fd22fe20
+  webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241

--- a/app/services/oauth_avatar_download_service.rb
+++ b/app/services/oauth_avatar_download_service.rb
@@ -1,0 +1,40 @@
+class OauthAvatarDownloadService
+  def self.call(user:, auth:)
+    new(user: user, auth: auth).call
+  end
+
+  def initialize(user:, auth:)
+    @user = user
+    @auth = auth
+  end
+
+  def call
+    return if @user.avatar.attached?
+
+    image_url = @auth.info&.image
+    return if image_url.blank?
+
+    download_and_attach(image_url)
+  rescue StandardError
+    # DL失敗時も認証を妨げない
+    nil
+  end
+
+  private
+
+  def download_and_attach(url)
+    uri = URI.parse(url)
+    response = Net::HTTP.get_response(uri)
+    return unless response.is_a?(Net::HTTPSuccess)
+
+    content_type = response["Content-Type"]
+    extension = content_type&.split("/")&.last || "jpg"
+    filename = "oauth_avatar.#{extension}"
+
+    @user.avatar.attach(
+      io: StringIO.new(response.body),
+      filename: filename,
+      content_type: content_type
+    )
+  end
+end

--- a/app/services/social_auth_service.rb
+++ b/app/services/social_auth_service.rb
@@ -23,11 +23,13 @@ class SocialAuthService
 
     if user
       user.social_accounts.create!(provider: provider, uid: uid)
+      OauthAvatarDownloadService.call(user: user, auth: @auth)
       return success(user)
     end
 
     # 4. 新規ユーザー + SocialAccount を作成
     user = create_user_with_social_account
+    OauthAvatarDownloadService.call(user: user, auth: @auth)
     success(user)
   rescue ActiveRecord::RecordNotUnique
     # 5. 競合時: 再取得

--- a/spec/services/oauth_avatar_download_service_spec.rb
+++ b/spec/services/oauth_avatar_download_service_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe OauthAvatarDownloadService, type: :service do
+  let(:user) { create(:user) }
+
+  describe ".call" do
+    context "with Google OAuth" do
+      let(:auth) do
+        OmniAuth::AuthHash.new(
+          provider: "google_oauth2",
+          info: { image: "https://lh3.googleusercontent.com/photo.jpg" }
+        )
+      end
+
+      it "downloads and attaches avatar to user" do
+        stub_request(:get, "https://lh3.googleusercontent.com/photo.jpg")
+          .to_return(status: 200, body: file_fixture("valid_avatar.jpg").read, headers: { "Content-Type" => "image/jpeg" })
+
+        described_class.call(user: user, auth: auth)
+
+        expect(user.avatar).to be_attached
+      end
+    end
+
+    context "with Discord OAuth" do
+      let(:auth) do
+        OmniAuth::AuthHash.new(
+          provider: "discord",
+          uid: "123456789",
+          info: { image: "https://cdn.discordapp.com/avatars/123456789/abc123.png" }
+        )
+      end
+
+      it "downloads and attaches avatar to user" do
+        stub_request(:get, "https://cdn.discordapp.com/avatars/123456789/abc123.png")
+          .to_return(status: 200, body: file_fixture("valid_avatar.jpg").read, headers: { "Content-Type" => "image/png" })
+
+        described_class.call(user: user, auth: auth)
+
+        expect(user.avatar).to be_attached
+      end
+    end
+
+    context "when user already has an avatar" do
+      it "does not overwrite the existing avatar" do
+        user.avatar.attach(io: file_fixture("valid_avatar.jpg").open, filename: "existing.jpg", content_type: "image/jpeg")
+
+        auth = OmniAuth::AuthHash.new(
+          provider: "google_oauth2",
+          info: { image: "https://example.com/photo.jpg" }
+        )
+
+        described_class.call(user: user, auth: auth)
+
+        expect(user.avatar.filename.to_s).to eq("existing.jpg")
+      end
+    end
+
+    context "when image URL is blank" do
+      it "does nothing and does not raise" do
+        auth = OmniAuth::AuthHash.new(provider: "google_oauth2", info: { image: nil })
+
+        expect { described_class.call(user: user, auth: auth) }.not_to raise_error
+        expect(user.avatar).not_to be_attached
+      end
+    end
+
+    context "when download fails" do
+      it "does not raise and leaves avatar unattached" do
+        auth = OmniAuth::AuthHash.new(
+          provider: "google_oauth2",
+          info: { image: "https://example.com/broken.jpg" }
+        )
+
+        stub_request(:get, "https://example.com/broken.jpg").to_return(status: 500)
+
+        expect { described_class.call(user: user, auth: auth) }.not_to raise_error
+        expect(user.avatar).not_to be_attached
+      end
+    end
+  end
+end

--- a/spec/services/social_auth_service_spec.rb
+++ b/spec/services/social_auth_service_spec.rb
@@ -224,5 +224,40 @@ RSpec.describe SocialAuthService, type: :service do
         expect(result.user).to eq(user)
       end
     end
+
+    context "avatar download" do
+      it "calls OauthAvatarDownloadService for new user" do
+        allow(OauthAvatarDownloadService).to receive(:call)
+
+        described_class.call(auth)
+
+        expect(OauthAvatarDownloadService).to have_received(:call).with(
+          user: an_instance_of(User),
+          auth: auth
+        )
+      end
+
+      it "does not call OauthAvatarDownloadService for existing SocialAccount" do
+        user = create(:user)
+        create(:social_account, user: user, provider: "google_oauth2", uid: "123456")
+        allow(OauthAvatarDownloadService).to receive(:call)
+
+        described_class.call(auth)
+
+        expect(OauthAvatarDownloadService).not_to have_received(:call)
+      end
+
+      it "calls OauthAvatarDownloadService when linking to existing email user" do
+        create(:user, email: "oauth@example.com")
+        allow(OauthAvatarDownloadService).to receive(:call)
+
+        described_class.call(auth)
+
+        expect(OauthAvatarDownloadService).to have_received(:call).with(
+          user: an_instance_of(User),
+          auth: auth
+        )
+      end
+    end
   end
 end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,2 @@
+require "webmock/rspec"
+WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
## Summary
- `OauthAvatarDownloadService` を新規作成し、OAuth認証時にプロバイダの画像を自動DL → `User#avatar` にattach
- `SocialAuthService` の新規ユーザー作成時・既存メールユーザー紐付け時に呼び出しを追加
- 外部HTTP通信テスト用に WebMock gem を導入

## 変更内容
- **WebMock gem 追加**: 外部HTTP通信のスタブ基盤
- **OauthAvatarDownloadService**: `auth.info.image` から画像DL、既存avatar保護、エラー時rescue
- **SocialAuthService**: SocialAccount新規作成時にavatar DLを呼び出し

## Test plan
- [x] Google OAuth認証 → 画像自動保存
- [x] Discord OAuth認証 → 画像自動保存
- [x] 既存アバターがある場合 → 上書きしない
- [x] 画像DL失敗 → 認証成功、デフォルトアイコン表示
- [x] 画像URLが空 → 認証成功、デフォルトアイコン表示
- [x] 既存SocialAccountでのログイン → avatar DL呼ばれない
- [x] RSpec 238 examples, 0 failures
- [x] RuboCop 0 offenses

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)