### PR TITLE
feat: rooms テーブルに room_type カラムを追加 #176

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,4 +1,6 @@
 class Room < ApplicationRecord
+  enum :room_type, { chat: 0, study: 1, game: 2 }
+
   belongs_to :issuer_profile, class_name: "Profile", foreign_key: :issuer_profile_id, inverse_of: :issued_rooms
 
   has_many :room_memberships, dependent: :destroy

--- a/db/migrate/20260328101759_add_room_type_to_rooms.rb
+++ b/db/migrate/20260328101759_add_room_type_to_rooms.rb
@@ -1,0 +1,5 @@
+class AddRoomTypeToRooms < ActiveRecord::Migration[7.2]
+  def change
+    add_column :rooms, :room_type, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_25_151541) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_28_101759) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -83,6 +83,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_25_151541) do
     t.string "label"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "room_type", default: 0, null: false
     t.index ["issuer_profile_id"], name: "index_rooms_on_issuer_profile_id"
   end
 

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -7,6 +7,44 @@ RSpec.describe Room, type: :model do
     expect(room).not_to be_valid
   end
 
+  describe "room_type enum" do
+    it "デフォルト値が chat である" do
+      room = create(:room)
+
+      expect(room.room_type).to eq("chat")
+    end
+
+    it "study に変更できる" do
+      room = create(:room)
+
+      room.study!
+
+      expect(room).to be_study
+    end
+
+    it "game に変更できる" do
+      room = create(:room)
+
+      room.game!
+
+      expect(room).to be_game
+    end
+
+    it "スコープで絞り込みできる" do
+      chat_room = create(:room)
+      study_room = create(:room)
+      study_room.study!
+
+      expect(described_class.chat).to include(chat_room)
+      expect(described_class.chat).not_to include(study_room)
+      expect(described_class.study).to include(study_room)
+    end
+
+    it "不正な値で ArgumentError が発生する" do
+      expect { create(:room).room_type = "invalid" }.to raise_error(ArgumentError)
+    end
+  end
+
   it "has associations" do
     room = described_class.reflect_on_association(:issuer_profile)
 


### PR DESCRIPTION
## Summary
- `rooms` テーブルに `room_type` カラム（integer, NOT NULL, default: 0）を追加
- Rails enum で `chat: 0`, `study: 1`, `game: 2` を定義
- モデルスペック5件追加（デフォルト値・変更・スコープ・不正値）

## Test plan
- [x] RSpec 全255件通過（0 failures）
- [x] RuboCop 0 offenses
- [x] 既存テストへの影響なし

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)