### PR TITLE
feat: 親タグテーブル追加と hobbies 拡張 #168

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby "3.2.4"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.3"
+gem "rails-i18n", "~> 7.0"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 # Use postgresql as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,6 +322,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.3)
       actionpack (= 7.2.3)
       activesupport (= 7.2.3)
@@ -494,6 +497,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3)
+  rails-i18n (~> 7.0)
   rspec-rails
   rubocop
   rubocop-performance
@@ -636,6 +640,7 @@ CHECKSUMS
   rails (7.2.3) sha256=9a9812eb131189676e64665f6883fc9c4051f412cc87ef9e3fa242a09c609bff
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.6.2) sha256=35fce2ca8242da8775c83b6ba9c1bcaad6751d9eb73c1abaa8403475ab89a560
+  rails-i18n (7.0.10) sha256=efae16e0ac28c0f42e98555c8db1327d69ab02058c8b535e0933cb106dd931ca
   railties (7.2.3) sha256=6eb010a6bfe6f223e783f739ddfcbdb5b88b1f3a87f7739f0a0685e466250422
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -10,7 +10,7 @@ class ProfilesController < ApplicationController
   end
 
   def show
-    @profile = Profile.includes(profile_hobbies: :hobby, user: { avatar_attachment: :blob }).find_by(id: params[:id])
+    @profile = Profile.includes(profile_hobbies: { hobby: :parent_tag }, user: { avatar_attachment: :blob }).find_by(id: params[:id])
     return redirect_to profiles_path, alert: "プロフィールが見つかりません" unless @profile
 
     @profile_hobby_map = @profile.profile_hobbies.index_by(&:hobby_id)

--- a/app/controllers/rooms/members_controller.rb
+++ b/app/controllers/rooms/members_controller.rb
@@ -20,7 +20,7 @@ module Rooms
       # 1. 表示対象プロフィールを取得
       # user / hobbies を eager load して N+1 クエリを防ぐ
       # --------------------------------------------------
-      @profile = Profile.includes(:user, profile_hobbies: :hobby).find(params[:id])
+      @profile = Profile.includes(:user, profile_hobbies: { hobby: :parent_tag }).find(params[:id])
       @profile_hobby_map = @profile.profile_hobbies.index_by(&:hobby_id)
 
       # --------------------------------------------------

--- a/app/controllers/shares_controller.rb
+++ b/app/controllers/shares_controller.rb
@@ -37,7 +37,7 @@ class SharesController < ApplicationController
     # includes により N+1 クエリを防止
     # --------------------------------------------------
     @memberships = @room.room_memberships
-                        .includes(profile: [ :user, { profile_hobbies: :hobby } ])
+                        .includes(profile: [ :user, { profile_hobbies: { hobby: :parent_tag } } ])
                         .order(created_at: :asc)
 
     # --------------------------------------------------

--- a/app/models/hobby.rb
+++ b/app/models/hobby.rb
@@ -1,6 +1,20 @@
 class Hobby < ApplicationRecord
+  belongs_to :parent_tag, optional: true
+
   has_many :profile_hobbies, dependent: :destroy
   has_many :profiles, through: :profile_hobbies
 
   validates :name, presence: true, uniqueness: true
+
+  before_save :set_normalized_name
+
+  def self.normalize(name)
+    name.to_s.unicode_normalize(:nfkc).strip.downcase
+  end
+
+  private
+
+  def set_normalized_name
+    self.normalized_name = self.class.normalize(name)
+  end
 end

--- a/app/models/parent_tag.rb
+++ b/app/models/parent_tag.rb
@@ -1,0 +1,8 @@
+class ParentTag < ApplicationRecord
+  enum :room_type, { chat: 0, study: 1, game: 2 }
+
+  has_many :hobbies, dependent: :restrict_with_error
+
+  validates :name, presence: true
+  validates :slug, presence: true, uniqueness: { scope: :room_type }
+end

--- a/app/queries/profile_search_query.rb
+++ b/app/queries/profile_search_query.rb
@@ -41,7 +41,7 @@ class ProfileSearchQuery
   end
 
   def base_scope
-    Profile.includes(:hobbies, profile_hobbies: :hobby, user: { avatar_attachment: :blob }).order(created_at: :desc)
+    Profile.includes(profile_hobbies: { hobby: :parent_tag }, user: { avatar_attachment: :blob }).order(created_at: :desc)
   end
 
   def sanitize_sql_like(str)

--- a/db/migrate/20260330054256_create_parent_tags.rb
+++ b/db/migrate/20260330054256_create_parent_tags.rb
@@ -1,0 +1,14 @@
+class CreateParentTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :parent_tags do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.integer :room_type
+      t.integer :position, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :parent_tags, %i[room_type slug], unique: true
+  end
+end

--- a/db/migrate/20260330070618_add_parent_tag_id_and_normalized_name_to_hobbies.rb
+++ b/db/migrate/20260330070618_add_parent_tag_id_and_normalized_name_to_hobbies.rb
@@ -1,0 +1,7 @@
+class AddParentTagIdAndNormalizedNameToHobbies < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :hobbies, :parent_tag, null: true, foreign_key: true
+    add_column :hobbies, :normalized_name, :string
+    add_index :hobbies, :normalized_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_28_101759) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_30_070618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,7 +46,21 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_28_101759) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "parent_tag_id"
+    t.string "normalized_name"
     t.index ["name"], name: "index_hobbies_on_name", unique: true
+    t.index ["normalized_name"], name: "index_hobbies_on_normalized_name"
+    t.index ["parent_tag_id"], name: "index_hobbies_on_parent_tag_id"
+  end
+
+  create_table "parent_tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.integer "room_type"
+    t.integer "position", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["room_type", "slug"], name: "index_parent_tags_on_room_type_and_slug", unique: true
   end
 
   create_table "profile_hobbies", force: :cascade do |t|
@@ -123,6 +137,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_28_101759) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "hobbies", "parent_tags"
   add_foreign_key "profile_hobbies", "hobbies"
   add_foreign_key "profile_hobbies", "profiles"
   add_foreign_key "profiles", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,34 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# 親タグの初期データ
+parent_tags = [
+  # 雑談系（chat）
+  { name: "アニメ", slug: "anime", room_type: :chat, position: 0 },
+  { name: "ゲーム", slug: "game", room_type: :chat, position: 1 },
+  { name: "音楽", slug: "music", room_type: :chat, position: 2 },
+  { name: "カフェ", slug: "cafe", room_type: :chat, position: 3 },
+  # 勉強系（study）
+  { name: "プログラミング", slug: "programming", room_type: :study, position: 0 },
+  { name: "デザイン", slug: "design", room_type: :study, position: 1 },
+  { name: "学習スタイル", slug: "learning-style", room_type: :study, position: 2 },
+  # ゲーム系（game）
+  { name: "協力ゲーム", slug: "coop", room_type: :game, position: 0 },
+  { name: "対戦ゲーム", slug: "versus", room_type: :game, position: 1 },
+  { name: "カジュアル", slug: "casual", room_type: :game, position: 2 },
+  # 共通（未分類）
+  { name: "未分類", slug: "uncategorized", room_type: nil, position: 0 }
+]
+
+parent_tags.each do |attrs|
+  ParentTag.find_or_create_by!(slug: attrs[:slug], room_type: attrs[:room_type]) do |pt|
+    pt.name = attrs[:name]
+    pt.position = attrs[:position]
+  end
+end
+
+puts "ParentTags: #{ParentTag.count} 件"
+
+# 既存 hobbies の normalized_name を一括設定
+Hobby.where(normalized_name: nil).find_each do |hobby|
+  hobby.update_columns(normalized_name: Hobby.normalize(hobby.name))
+end
+
+puts "Hobbies normalized: #{Hobby.where.not(normalized_name: nil).count} 件"

--- a/spec/models/hobby_spec.rb
+++ b/spec/models/hobby_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Hobby, type: :model do
 
   describe "関連" do
     it "parent_tag に属することができる" do
-      parent_tag = ParentTag.create!(name: "アニメ", slug: "anime", room_type: :chat)
-      hobby = described_class.create!(name: "呪術廻戦", parent_tag: parent_tag)
+      parent_tag = ParentTag.create!(name: "テスト親タグ", slug: "test-parent", room_type: :chat)
+      hobby = described_class.create!(name: "テスト趣味D", parent_tag: parent_tag)
       expect(hobby.parent_tag).to eq(parent_tag)
     end
 

--- a/spec/models/hobby_spec.rb
+++ b/spec/models/hobby_spec.rb
@@ -15,4 +15,29 @@ RSpec.describe Hobby, type: :model do
       expect(hobby).to be_invalid
     end
   end
+
+  describe "関連" do
+    it "parent_tag に属することができる" do
+      parent_tag = ParentTag.create!(name: "アニメ", slug: "anime", room_type: :chat)
+      hobby = described_class.create!(name: "呪術廻戦", parent_tag: parent_tag)
+      expect(hobby.parent_tag).to eq(parent_tag)
+    end
+
+    it "parent_tag が nil でも有効（optional）" do
+      hobby = described_class.new(name: "その他の趣味", parent_tag: nil)
+      expect(hobby).to be_valid
+    end
+  end
+
+  describe "normalized_name" do
+    it "保存時に正規化される（全角→半角、大文字→小文字、前後空白除去）" do
+      hobby = described_class.create!(name: "　Ｒｕｂｙ　")
+      expect(hobby.normalized_name).to eq("ruby")
+    end
+
+    it "日本語の全角カナはそのまま保持される" do
+      hobby = described_class.create!(name: "プログラミング")
+      expect(hobby.normalized_name).to eq("プログラミング")
+    end
+  end
 end

--- a/spec/models/parent_tag_spec.rb
+++ b/spec/models/parent_tag_spec.rb
@@ -15,20 +15,20 @@ RSpec.describe ParentTag, type: :model do
     end
 
     it "同じ room_type + slug の組み合わせは重複して保存できない" do
-      described_class.create!(name: "アニメ", slug: "anime", room_type: :chat)
-      parent_tag = described_class.new(name: "アニメ2", slug: "anime", room_type: :chat)
+      described_class.create!(name: "テスト重複A", slug: "test-dup", room_type: :chat)
+      parent_tag = described_class.new(name: "テスト重複B", slug: "test-dup", room_type: :chat)
       expect(parent_tag).to be_invalid
     end
 
     it "room_type が nil 同士でも同じ slug は重複して保存できない" do
-      described_class.create!(name: "未分類", slug: "uncategorized", room_type: nil)
-      parent_tag = described_class.new(name: "未分類2", slug: "uncategorized", room_type: nil)
+      described_class.create!(name: "テスト未分類A", slug: "test-uncat", room_type: nil)
+      parent_tag = described_class.new(name: "テスト未分類B", slug: "test-uncat", room_type: nil)
       expect(parent_tag).to be_invalid
     end
 
     it "room_type が異なれば同じ slug で保存できる" do
-      described_class.create!(name: "アニメ", slug: "anime", room_type: :chat)
-      parent_tag = described_class.new(name: "アニメ", slug: "anime", room_type: :study)
+      described_class.create!(name: "テスト異種A", slug: "test-cross", room_type: :chat)
+      parent_tag = described_class.new(name: "テスト異種B", slug: "test-cross", room_type: :study)
       expect(parent_tag).to be_valid
     end
   end
@@ -41,15 +41,15 @@ RSpec.describe ParentTag, type: :model do
 
   describe "関連" do
     it "hobbies を複数持てる" do
-      parent_tag = described_class.create!(name: "アニメ", slug: "anime", room_type: :chat)
-      parent_tag.hobbies.create!(name: "呪術廻戦")
-      parent_tag.hobbies.create!(name: "ワンピース")
+      parent_tag = described_class.create!(name: "テスト関連", slug: "test-assoc", room_type: :chat)
+      parent_tag.hobbies.create!(name: "テスト趣味A")
+      parent_tag.hobbies.create!(name: "テスト趣味B")
       expect(parent_tag.hobbies.count).to eq(2)
     end
 
     it "子 hobby がある場合は削除できない" do
-      parent_tag = described_class.create!(name: "アニメ", slug: "anime", room_type: :chat)
-      parent_tag.hobbies.create!(name: "呪術廻戦")
+      parent_tag = described_class.create!(name: "テスト削除", slug: "test-delete", room_type: :chat)
+      parent_tag.hobbies.create!(name: "テスト趣味C")
       expect { parent_tag.destroy }.not_to change(described_class, :count)
       expect(parent_tag.errors[:base]).to be_present
     end
@@ -57,7 +57,7 @@ RSpec.describe ParentTag, type: :model do
 
   describe "デフォルト値" do
     it "position のデフォルト値が 0 になる" do
-      parent_tag = described_class.create!(name: "アニメ", slug: "anime", room_type: :chat)
+      parent_tag = described_class.create!(name: "テスト位置", slug: "test-pos", room_type: :chat)
       expect(parent_tag.position).to eq(0)
     end
   end

--- a/spec/models/parent_tag_spec.rb
+++ b/spec/models/parent_tag_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ParentTag, type: :model do
+  describe "バリデーション" do
+    it "name が空だと無効になる" do
+      parent_tag = described_class.new(name: nil, slug: "test")
+      expect(parent_tag).to be_invalid
+    end
+
+    it "slug が空だと無効になる" do
+      parent_tag = described_class.new(name: "テスト", slug: nil)
+      expect(parent_tag).to be_invalid
+    end
+
+    it "同じ room_type + slug の組み合わせは重複して保存できない" do
+      described_class.create!(name: "アニメ", slug: "anime", room_type: :chat)
+      parent_tag = described_class.new(name: "アニメ2", slug: "anime", room_type: :chat)
+      expect(parent_tag).to be_invalid
+    end
+
+    it "room_type が nil 同士でも同じ slug は重複して保存できない" do
+      described_class.create!(name: "未分類", slug: "uncategorized", room_type: nil)
+      parent_tag = described_class.new(name: "未分類2", slug: "uncategorized", room_type: nil)
+      expect(parent_tag).to be_invalid
+    end
+
+    it "room_type が異なれば同じ slug で保存できる" do
+      described_class.create!(name: "アニメ", slug: "anime", room_type: :chat)
+      parent_tag = described_class.new(name: "アニメ", slug: "anime", room_type: :study)
+      expect(parent_tag).to be_valid
+    end
+  end
+
+  describe "enum" do
+    it "room_type が chat/study/game を持つ" do
+      expect(described_class.room_types).to eq("chat" => 0, "study" => 1, "game" => 2)
+    end
+  end
+
+  describe "関連" do
+    it "hobbies を複数持てる" do
+      parent_tag = described_class.create!(name: "アニメ", slug: "anime", room_type: :chat)
+      parent_tag.hobbies.create!(name: "呪術廻戦")
+      parent_tag.hobbies.create!(name: "ワンピース")
+      expect(parent_tag.hobbies.count).to eq(2)
+    end
+
+    it "子 hobby がある場合は削除できない" do
+      parent_tag = described_class.create!(name: "アニメ", slug: "anime", room_type: :chat)
+      parent_tag.hobbies.create!(name: "呪術廻戦")
+      expect { parent_tag.destroy }.not_to change(described_class, :count)
+      expect(parent_tag.errors[:base]).to be_present
+    end
+  end
+
+  describe "デフォルト値" do
+    it "position のデフォルト値が 0 になる" do
+      parent_tag = described_class.create!(name: "アニメ", slug: "anime", room_type: :chat)
+      expect(parent_tag.position).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `parent_tags` テーブルを新規作成（name, slug, room_type, position）
- `hobbies` テーブルに `parent_tag_id`（FK）と `normalized_name` カラムを追加
- `ParentTag` モデル作成（`has_many :hobbies, dependent: :restrict_with_error`）
- `Hobby` モデルに `belongs_to :parent_tag, optional: true` と正規化ロジック追加
- 初期親タグ 11件の seed データ投入、既存 hobbies の `normalized_name` 一括設定
- N+1 予防のため4箇所のコントローラ/クエリで `includes` に `parent_tag` を追加

## Test plan
- [x] `parent_tags` テーブルが作成されている
- [x] `hobbies` に `parent_tag_id` と `normalized_name` が追加されている
- [x] `[:room_type, :slug]` に unique index、`normalized_name` に通常 index
- [x] 子 hobby がある親タグは削除できない（`restrict_with_error`）
- [x] `room_type: nil` 同士の slug 重複がバリデーションで弾かれる
- [x] 初期親タグ 11件が seed で投入できる
- [x] 既存 hobbies の `normalized_name` が正規化される
- [x] RSpec 270 examples, 0 failures
- [x] RuboCop no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)