### PR TITLE
feat: 部屋管理UIを「管理中の部屋」「参加中の部屋」に分割 #166

### DIFF
--- a/.claude/skills/execute/SKILL.md
+++ b/.claude/skills/execute/SKILL.md
@@ -157,3 +157,14 @@ Phase 2 で合意した計画に従い、以下のサイクルを繰り返す：
 - 途中で方針が分岐したら停止してAskUserQuestionで確認する
 - 高リスク操作（DB変更・既存テスト修正など）前は必ず確認する
 - TDD省略条件（CLAUDE.md参照）に該当する場合のみ省略可
+
+## テストの書き方ルール
+
+- ログインユーザーの変数名は `current_user`、そのプロフィールは `current_profile` とする
+- その他の変数も役割が伝わる名前にする。命名の基本方針：
+  - 所有関係を `_の所有者名_` でつなぐ（例: `room_owners_room`, `room_owners_membership`）
+  - 自分自身に関するものは `own_` プレフィックス（例: `own_room`, `own_membership`）
+  - 他のメンバーに関するものは `other_member_` / `other_members_` プレフィックス（例: `other_member_profile`, `other_members_membership`）
+  - 部屋の作成者は `room_owner` / `room_owner_profile`
+- `user`, `profile`, `room`, `membership` などの汎用名は使わない
+- 各セットアップ・リクエスト・アサーションには日本語コメントで意図を明記する

--- a/app/controllers/mypage/room_memberships_controller.rb
+++ b/app/controllers/mypage/room_memberships_controller.rb
@@ -1,0 +1,32 @@
+class Mypage::RoomMembershipsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_membership
+
+  def destroy
+    # 自分が作成した部屋からは退出できないようにする
+    if @membership.room.issuer_profile == current_user.profile
+      redirect_to mypage_rooms_path, alert: "作成した部屋からは退出できません"
+      return
+    end
+
+    # membership（部屋参加者） を削除して退出する
+    if @membership.destroy
+      respond_to do |format|
+        format.turbo_stream { flash.now[:notice] = "部屋から退出しました" }
+        format.html { redirect_to mypage_rooms_path, notice: "部屋から退出しました" }
+      end
+    else
+      redirect_to mypage_rooms_path, alert: "退出に失敗しました"
+    end
+  end
+
+  private
+
+  # 自分の membership のみ取得（他者の membership は RecordNotFound になる）
+  # room を eager load して N+1 を防ぐ
+  def set_membership
+    @membership = current_user.profile.room_memberships.includes(:room).find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to mypage_rooms_path, alert: "参加している部屋が見つかりません"
+  end
+end

--- a/app/controllers/mypage/rooms_controller.rb
+++ b/app/controllers/mypage/rooms_controller.rb
@@ -4,31 +4,32 @@ class Mypage::RoomsController < ApplicationController
 
   def index
     profile = current_user.profile
-    if profile
-      # 自分が作成した部屋一覧
-      @rooms = profile.issued_rooms
-                      .includes(:share_link, :room_memberships)
-                      .order(created_at: :desc)
-
-      # 自分が参加中の部屋（自分が作成者の部屋は除く）
-      @memberships = profile.room_memberships
-                            .joins(:room)
-                            .where.not(rooms: { issuer_profile_id: profile.id })
-                            .includes(room: [ { issuer_profile: :user }, :room_memberships, :share_link ])
-                            .order("rooms.created_at DESC")
-    else
+    unless profile
       @rooms = Room.none
       @memberships = RoomMembership.none
+      return
     end
+
+    # 自分が作成した部屋一覧
+    @rooms = profile.issued_rooms
+                    .includes(:share_link, :room_memberships)
+                    .order(created_at: :desc)
+
+    # 自分が参加中の部屋（自分が作成者の部屋は除く）
+    @memberships = profile.room_memberships
+                          .joins(:room)
+                          .where.not(rooms: { issuer_profile_id: profile.id })
+                          .includes(room: [ { issuer_profile: :user }, :room_memberships, :share_link ])
+                          .order("rooms.created_at DESC")
   end
 
   def create
     issuer_profile = current_user.profile
+    return redirect_to mypage_root_path unless issuer_profile
 
     Room.transaction do
       @room = Room.create!(
-        issuer_profile: issuer_profile,
-        label: params.dig(:room, :label)
+        room_params.merge(issuer_profile: issuer_profile)
       )
 
       RoomMembership.create!(room: @room, profile: issuer_profile)
@@ -73,6 +74,6 @@ class Mypage::RoomsController < ApplicationController
   end
 
   def room_params
-    params.require(:room).permit(:label)
+    params.require(:room).permit(:label, :room_type)
   end
 end

--- a/app/controllers/mypage/rooms_controller.rb
+++ b/app/controllers/mypage/rooms_controller.rb
@@ -4,10 +4,21 @@ class Mypage::RoomsController < ApplicationController
 
   def index
     profile = current_user.profile
-    @rooms = if profile
-      profile.issued_rooms.includes(:share_link, :room_memberships).order(created_at: :desc)
+    if profile
+      # 自分が作成した部屋一覧
+      @rooms = profile.issued_rooms
+                      .includes(:share_link, :room_memberships)
+                      .order(created_at: :desc)
+
+      # 自分が参加中の部屋（自分が作成者の部屋は除く）
+      @memberships = profile.room_memberships
+                            .joins(:room)
+                            .where.not(rooms: { issuer_profile_id: profile.id })
+                            .includes(room: [ { issuer_profile: :user }, :room_memberships, :share_link ])
+                            .order("rooms.created_at DESC")
     else
-      Room.none
+      @rooms = Room.none
+      @memberships = RoomMembership.none
     end
   end
 

--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -1,0 +1,11 @@
+module RoomsHelper
+  ROOM_TYPE_BADGES = {
+    "chat"  => { label: "雑談",   color: "rgba(37, 99, 235, 0.2)",  border: "rgba(96, 165, 250, 0.4)",  text: "#93c5fd" },
+    "study" => { label: "勉強",   color: "rgba(22, 163, 74, 0.2)",  border: "rgba(74, 222, 128, 0.4)",  text: "#86efac" },
+    "game"  => { label: "ゲーム", color: "rgba(124, 58, 237, 0.2)", border: "rgba(167, 139, 250, 0.4)", text: "#c4b5fd" }
+  }.freeze
+
+  def room_type_badge(room_type)
+    ROOM_TYPE_BADGES[room_type]
+  end
+end

--- a/app/views/mypage/room_memberships/destroy.turbo_stream.erb
+++ b/app/views/mypage/room_memberships/destroy.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%# 退出した部屋のカードを一覧から削除する %>
+<%= turbo_stream.remove dom_id(@membership) %>
+
+<%# フラッシュメッセージを更新する %>
+<%= turbo_stream.update "flash", partial: "shared/flash" %>

--- a/app/views/mypage/rooms/_joined_room.html.erb
+++ b/app/views/mypage/rooms/_joined_room.html.erb
@@ -24,6 +24,11 @@
     </div>
   <% end %>
 
+  <%# 参加人数 %>
+  <p style="font-size: 0.875rem; color: #6b7280; margin-bottom: 1rem;">
+    参加人数: <%= room.room_memberships.size %> 人
+  </p>
+
   <%# 操作 %>
   <div style="display: flex; justify-content: flex-end; align-items: center; gap: 1rem; font-size: 0.875rem; width: 100%; margin-top: auto;">
     <% if link.present? %>

--- a/app/views/mypage/rooms/_joined_room.html.erb
+++ b/app/views/mypage/rooms/_joined_room.html.erb
@@ -1,0 +1,42 @@
+<% room = membership.room %>
+<% issuer = room.issuer_profile&.user %>
+<% link = room.share_link %>
+<% badge = room_type_badge(room.room_type) %>
+
+<div id="<%= dom_id(membership) %>" style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); display: flex; flex-direction: column;">
+  <%# 部屋タイプバッジ %>
+  <% if badge %>
+    <span style="display: inline-block; align-self: flex-start; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; margin-bottom: 0.5rem; background: <%= badge[:color] %>; border: 1px solid <%= badge[:border] %>; color: <%= badge[:text] %>;">
+      <%= badge[:label] %>
+    </span>
+  <% end %>
+
+  <%# 部屋名 %>
+  <h3 style="font-size: 1.125rem; font-weight: 600; color: #ffffff; margin-bottom: 0.75rem;">
+    <%= room.label.presence || "名無しの部屋" %>
+  </h3>
+
+  <%# 作成者 %>
+  <% if issuer %>
+    <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem;">
+      <%= avatar_image_tag(issuer, size: :small) %>
+      <span style="font-size: 0.875rem; color: #d1d5db;"><%= issuer.nickname %></span>
+    </div>
+  <% end %>
+
+  <%# 操作 %>
+  <div style="display: flex; justify-content: flex-end; align-items: center; gap: 1rem; font-size: 0.875rem; width: 100%; margin-top: auto;">
+    <% if link.present? %>
+      <%= link_to "部屋を見る",
+                  share_path(link.token),
+                  target: "_blank",
+                  style: "color: #a78bfa; text-decoration: none;" %>
+    <% end %>
+
+    <%= button_to "退出",
+                  mypage_room_membership_path(membership),
+                  method: :delete,
+                  data: { turbo_confirm: "本当に退出しますか？" },
+                  style: "padding: 0.25rem 0.75rem; border-radius: 0.375rem; background: rgba(239, 68, 68, 0.15); border: 1px solid rgba(239, 68, 68, 0.3); color: #fca5a5; font-size: 0.875rem; cursor: pointer;" %>
+  </div>
+</div>

--- a/app/views/mypage/rooms/_room.html.erb
+++ b/app/views/mypage/rooms/_room.html.erb
@@ -1,5 +1,14 @@
+<% badge = room_type_badge(room.room_type) %>
+
 <%= turbo_frame_tag dom_id(room) do %>
   <div style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); display: flex; flex-direction: column;">
+    <%# 部屋タイプバッジ %>
+    <% if badge %>
+      <span style="display: inline-block; align-self: flex-start; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; margin-bottom: 0.5rem; background: <%= badge[:color] %>; border: 1px solid <%= badge[:border] %>; color: <%= badge[:text] %>;">
+        <%= badge[:label] %>
+      </span>
+    <% end %>
+
     <%# 部屋名 %>
     <h3 style="font-size: 1.125rem; font-weight: 600; color: #ffffff; margin-bottom: 0.75rem;">
       <%= room.label.presence || "名無しの部屋" %>
@@ -47,6 +56,13 @@
 
     <%# 操作 %>
     <div style="display: flex; justify-content: flex-end; gap: 1rem; font-size: 0.875rem; width: 100%;">
+      <% if link.present? %>
+        <%= link_to "部屋を見る",
+                    share_path(link.token),
+                    target: "_blank",
+                    style: "color: #a78bfa; text-decoration: none;" %>
+      <% end %>
+
       <%= link_to "編集",
                   edit_mypage_room_path(room),
                   data: { turbo_frame: dom_id(room) },

--- a/app/views/mypage/rooms/index.html.erb
+++ b/app/views/mypage/rooms/index.html.erb
@@ -14,6 +14,14 @@
               style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
       </div>
 
+      <div style="margin-bottom: 1rem;">
+        <%= f.label :room_type, "タイプ", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
+        <%= f.select :room_type,
+              [["雑談", "chat"], ["勉強", "study"], ["ゲーム", "game"]],
+              { selected: "chat" },
+              style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+      </div>
+
       <%= f.submit "部屋を作成",
             style: "padding: 0.5rem 1rem; border-radius: 0.5rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);" %>
     <% end %>
@@ -36,7 +44,7 @@
     </div>
   </section>
 
-  <%# 参加中の部屋（Task4で専用パーシャルに移行予定） %>
+  <%# 参加中の部屋 %>
   <section style="min-height: 24rem;">
     <h2 style="font-size: 1.25rem; font-weight: 600; color: #ffffff; margin-bottom: 1rem;">参加中の部屋</h2>
     <div id="memberships_list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -46,7 +54,7 @@
         </p>
       <% else %>
         <% @memberships.each do |membership| %>
-          <div><%= membership.room.label.presence || "名無しの部屋" %></div>
+          <%= render "mypage/rooms/joined_room", membership: membership %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/mypage/rooms/index.html.erb
+++ b/app/views/mypage/rooms/index.html.erb
@@ -19,12 +19,38 @@
     <% end %>
   </div>
 
-  <%# 部屋一覧 %>
-  <div id="rooms_list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-    <% @rooms.each do |room| %>
-      <%= render "mypage/rooms/room", room: room, link: room.share_link %>
-    <% end %>
-  </div>
+  <%# 作成済みの部屋 %>
+  <section style="margin-bottom: 3rem; min-height: 24rem;">
+    <h2 style="font-size: 1.25rem; font-weight: 600; color: #ffffff; margin-bottom: 1rem;">作成済みの部屋</h2>
+    <%# rooms_list は常に DOM に存在させる（create.turbo_stream.erb の prepend 先） %>
+    <div id="rooms_list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <% if @rooms.empty? %>
+        <p style="color: #6b7280; font-size: 0.875rem; grid-column: 1 / -1;">
+          まだ部屋を作成していません。上のフォームから部屋を作成してみましょう。
+        </p>
+      <% else %>
+        <% @rooms.each do |room| %>
+          <%= render "mypage/rooms/room", room: room, link: room.share_link %>
+        <% end %>
+      <% end %>
+    </div>
+  </section>
+
+  <%# 参加中の部屋（Task4で専用パーシャルに移行予定） %>
+  <section style="min-height: 24rem;">
+    <h2 style="font-size: 1.25rem; font-weight: 600; color: #ffffff; margin-bottom: 1rem;">参加中の部屋</h2>
+    <div id="memberships_list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <% if @memberships.empty? %>
+        <p style="color: #6b7280; font-size: 0.875rem; grid-column: 1 / -1;">
+          参加中の部屋はありません。招待URLから部屋に参加できます。
+        </p>
+      <% else %>
+        <% @memberships.each do |membership| %>
+          <div><%= membership.room.label.presence || "名無しの部屋" %></div>
+        <% end %>
+      <% end %>
+    </div>
+  </section>
 
   <div style="margin-top: 1.5rem;">
     <%= link_to "マイページに戻る", mypage_root_path, style: "font-size: 0.875rem; color: #6b7280; text-decoration: none;" %>

--- a/app/views/mypage/rooms/index.html.erb
+++ b/app/views/mypage/rooms/index.html.erb
@@ -29,7 +29,8 @@
 
   <%# 作成済みの部屋 %>
   <section style="margin-bottom: 3rem; min-height: 24rem;">
-    <h2 style="font-size: 1.25rem; font-weight: 600; color: #ffffff; margin-bottom: 1rem;">作成済みの部屋</h2>
+    <h2 style="font-size: 1.25rem; font-weight: 600; color: #ffffff; margin-bottom: 0.25rem;">管理中の部屋</h2>
+    <p style="font-size: 0.8125rem; color: #6b7280; margin-bottom: 1rem;">自分が作成・管理する部屋です。編集や削除ができます。</p>
     <%# rooms_list は常に DOM に存在させる（create.turbo_stream.erb の prepend 先） %>
     <div id="rooms_list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       <% if @rooms.empty? %>
@@ -46,7 +47,8 @@
 
   <%# 参加中の部屋 %>
   <section style="min-height: 24rem;">
-    <h2 style="font-size: 1.25rem; font-weight: 600; color: #ffffff; margin-bottom: 1rem;">参加中の部屋</h2>
+    <h2 style="font-size: 1.25rem; font-weight: 600; color: #ffffff; margin-bottom: 0.25rem;">参加中の部屋</h2>
+    <p style="font-size: 0.8125rem; color: #6b7280; margin-bottom: 1rem;">他のユーザーが作成した部屋に参加しています。退出できます。</p>
     <div id="memberships_list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       <% if @memberships.empty? %>
         <p style="color: #6b7280; font-size: 0.875rem; grid-column: 1 / -1;">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
     root to: "dashboards#show"
     resource :dashboard, only: [ :update ]
     resources :rooms, only: %i[index create edit update destroy]
+    resources :room_memberships, only: [:destroy]
   end
 
   devise_scope :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
     root to: "dashboards#show"
     resource :dashboard, only: [ :update ]
     resources :rooms, only: %i[index create edit update destroy]
-    resources :room_memberships, only: [:destroy]
+    resources :room_memberships, only: [ :destroy ]
   end
 
   devise_scope :user do

--- a/docs/designs/2026-04-03-room-management-ui.md
+++ b/docs/designs/2026-04-03-room-management-ui.md
@@ -1,0 +1,339 @@
+# 部屋管理UI更新（作成済み / 参加中の分割） 設計書
+
+**日付:** 2026-04-03
+**Issue:** #166
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+
+- `Mypage::RoomsController#index` に `@memberships`（参加中）クエリ追加
+- `Mypage::RoomMembershipsController#destroy`（退出機能）新規作成
+- `app/views/mypage/rooms/index.html.erb` を「作成済み」「参加中」2セクションに更新
+- `app/views/mypage/rooms/_room.html.erb` に部屋タイプバッジ・「部屋を見る」リンク追加
+- `app/views/mypage/rooms/_joined_room.html.erb` 新規作成（部屋名・部屋タイプバッジ・参加人数・作成者名・「部屋を見る」リンク・退出ボタン）
+- `app/views/mypage/room_memberships/destroy.turbo_stream.erb` 新規作成
+- ルーティングに `resources :room_memberships, only: [:destroy]` 追加
+
+後続 Issue:
+- **新 Issue A**: ロック機能（`rooms.locked` カラム追加）
+- **新 Issue B**: 部屋作成フォーム改善（`rooms.description` カラム追加・有効期限選択）
+- **新 Issue C**: 招待リンク再発行機能
+
+---
+
+## 2. 目的
+
+- 「自分が作った部屋」と「招待で参加している部屋」を区別して管理できる
+- 参加中の部屋から退出できる
+- 「部屋を見る」で共有ページ（share_path）に飛べる
+
+---
+
+## 3. スコープ
+
+### 含むもの
+
+- 「作成済み」「参加中」の2セクション表示
+- 部屋タイプバッジ（雑談/勉強/ゲーム）
+- 参加中の部屋：部屋名・参加人数・作成者名（nickname）・「部屋を見る」・退出ボタン
+- 退出後 turbo_stream でカード削除
+- 空状態UI（0件時）
+- 「部屋を見る」= `share_path(token)` リンク（作成済み・参加中の両方）
+- 作成者が自分の部屋を退出しようとした場合のサーバー側ガード
+- N+1 対策（preload）
+
+### 含まないもの
+
+- ロック機能（→ 新 Issue A）
+- 部屋の説明・公開設定フォーム（→ 新 Issue B）
+- 有効期限選択（→ 新 Issue B）
+- 再発行機能（→ 新 Issue C）
+- Room show ページ（「部屋を見る」は share_path で代替）
+
+---
+
+## 4. 設計方針
+
+### 退出コントローラの配置
+
+| 方式 | 責務の明確さ | ルーティングの自然さ | 現状との相性 |
+|---|---|---|---|
+| `RoomsController#leave` | △（部屋削除との混同） | △（member action が増える） | △ |
+| `RoomMembershipsController#destroy` | ◎（membership の削除） | ◎（RESTful） | ◎ |
+
+**採用理由:** 退出は「部屋本体の削除」ではなく「参加関係（RoomMembership）の削除」であるため、`RoomMembershipsController#destroy` が責務として自然。
+
+### ビューに渡す変数
+
+| 方式 | メリット | デメリット |
+|---|---|---|
+| `@joined_rooms`（Room配列） | シンプル | 退出ボタン用に Partial で membership ID を別途取得が必要 |
+| `@memberships`（RoomMembership配列） | membership ID をそのまま使える | `membership.room.xxx` のアクセスになる |
+
+**採用理由:** 退出ボタンの `DELETE /mypage/room_memberships/:id` に membership ID が必要なため、`@memberships` を渡す方が自然で N+1 も一括 includes で解決しやすい。
+
+---
+
+## 5. データ設計
+
+**変更なし**（DB マイグレーション不要）
+
+既存の `room_memberships` テーブルで「参加中」の定義が成立する：
+- `joined_rooms`（参加中）: `room_memberships` に存在し、かつ `rooms.issuer_profile_id != current_user.profile.id`
+- `issued_rooms`（作成済み）: `rooms.issuer_profile_id == current_user.profile.id`
+
+### DB 制約（変更なし）
+
+| カラム | 制約 | 理由 |
+|---|---|---|
+| `room_memberships(room_id, profile_id)` | unique | 既存制約で重複参加を防止 |
+| `rooms.issuer_profile_id` | FK | 既存制約 |
+
+### ER 図
+
+```mermaid
+erDiagram
+  users {
+    bigint id PK
+    string nickname
+    string email
+  }
+  profiles {
+    bigint id PK
+    bigint user_id FK "unique"
+    text bio
+  }
+  rooms {
+    bigint id PK
+    bigint issuer_profile_id FK
+    string label
+    integer room_type
+  }
+  room_memberships {
+    bigint id PK
+    bigint room_id FK
+    bigint profile_id FK "(room_id, profile_id) unique"
+  }
+  share_links {
+    bigint id PK
+    bigint room_id FK "unique"
+    string token "unique"
+    datetime expires_at
+  }
+
+  users ||--|| profiles : "has one"
+  profiles ||--o{ rooms : "issues (issuer_profile_id)"
+  profiles ||--o{ room_memberships : "has many"
+  rooms ||--o{ room_memberships : "has many"
+  rooms ||--o| share_links : "has one"
+```
+
+---
+
+## 6. 画面・アクセス制御の流れ
+
+- 「作成済み」: `issuer_profile_id == current_user.profile.id` の部屋のみ表示
+- 「参加中」: membership が存在し `issuer_profile_id != current_user.profile.id` の部屋のみ表示
+- 退出: `current_user.profile.room_memberships.find(params[:id])` でガード（他者の membership は 404）
+- 作成者退出ガード: サーバー側で `@membership.room.issuer_profile == current_user.profile` をチェック
+
+### シーケンス図（退出フロー）
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant C as RoomMembershipsController
+  participant M as RoomMembership
+  participant R as Room
+
+  U->>C: DELETE /mypage/room_memberships/:id
+  C->>M: current_user.profile.room_memberships.find(id)
+  alt 見つからない
+    M-->>C: RecordNotFound
+    C-->>U: redirect mypage_rooms_path + alert
+  end
+  C->>R: @membership.room.issuer_profile
+  alt 自分が作成者
+    R-->>C: issuer == current_user.profile
+    C-->>U: redirect mypage_rooms_path + alert
+  end
+  C->>M: @membership.destroy!
+  C-->>U: turbo_stream remove card
+```
+
+---
+
+## 7. アプリケーション設計
+
+### `Mypage::RoomsController#index`（既存変更）
+
+```ruby
+def index
+  profile = current_user.profile
+  unless profile
+    @rooms = Room.none
+    @memberships = RoomMembership.none
+    return
+  end
+
+  @rooms = profile.issued_rooms
+                  .includes(:share_link, :room_memberships)
+                  .order(created_at: :desc)
+  @memberships = profile.room_memberships
+                        .joins(:room)
+                        .where.not(rooms: { issuer_profile_id: profile.id })
+                        .includes(room: [{ issuer_profile: :user }, :room_memberships, :share_link])
+                        .order("rooms.created_at DESC")
+end
+
+def create
+  issuer_profile = current_user.profile
+  return redirect_to mypage_root_path unless issuer_profile
+  # ... Room.transaction { ... }
+end
+```
+
+**設計変更（REFACTOR時）:**
+- `if profile ... else` のネスト → `unless profile ... return` のガード節に変更（可読性向上）
+- `create` にプロフィール未作成ユーザーのガードを追加（422 例外防止）
+
+### `Mypage::RoomMembershipsController`（新規）
+
+```ruby
+class Mypage::RoomMembershipsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_membership
+
+  def destroy
+    if @membership.room.issuer_profile == current_user.profile
+      redirect_to mypage_rooms_path, alert: "作成した部屋からは退出できません"
+      return
+    end
+    @membership.destroy!
+    respond_to do |format|
+      format.turbo_stream { flash.now[:notice] = "部屋から退出しました" }
+      format.html { redirect_to mypage_rooms_path, notice: "部屋から退出しました" }
+    end
+  end
+
+  private
+
+  def set_membership
+    @membership = current_user.profile.room_memberships.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to mypage_rooms_path, alert: "参加している部屋が見つかりません"
+  end
+end
+```
+
+**設計意図:** `find` を `current_user.profile.room_memberships` のスコープ内で行うことで、他者の membership へのアクセスを 404 で自動的に拒否できる。
+
+---
+
+## 8. ルーティング設計
+
+```ruby
+namespace :mypage do
+  resources :rooms, only: %i[index create edit update destroy]
+  resources :room_memberships, only: [:destroy]   # 追加
+end
+```
+
+生成されるパス: `DELETE /mypage/room_memberships/:id` → `mypage_room_membership_path(membership)`
+
+**設計意図:** `rooms` にネストせず独立させることで、REST 的にシンプルなパスを維持する。
+
+---
+
+## 9. レイアウト / UI 設計
+
+`index.html.erb` の構成（ワイヤーに基づく）:
+
+```
+# 部屋管理
+
+[＋ 新しい部屋を作成]
+  - 部屋名（任意）
+  - タイプ選択（雑談 / 勉強 / ゲーム、デフォルト: 雑談）
+
+## 管理中の部屋
+自分が作成・管理する部屋です。編集や削除ができます。
+（0件のとき：空状態UI）
+[_room.html.erb × n]
+  - [部屋タイプ] 部屋名
+  - 参加人数
+  - 招待URL / 有効期限 / 状態バッジ
+  - [部屋を見る] [編集] [削除]
+
+## 参加中の部屋
+他のユーザーが作成した部屋に参加しています。退出できます。
+（0件のとき：空状態UI）
+[_joined_room.html.erb × n]
+  - [部屋タイプ] 部屋名
+  - 参加人数
+  - 作成者アイコン + {nickname}
+  - [部屋を見る] [退出する]
+```
+
+- 「部屋を見る」= `share_path(room.share_link.token)` (target: _blank)
+- `_joined_room.html.erb` の turbo_frame ID = `dom_id(membership)`
+- `destroy.turbo_stream.erb` で `turbo_stream.remove dom_id(@membership)`
+
+---
+
+## 10. クエリ・性能面
+
+| クエリ対象 | preload |
+|---|---|
+| 作成済み部屋（`@rooms`） | `includes(:share_link, :room_memberships)` |
+| 参加中（`@memberships`） | `includes(room: [{ issuer_profile: :user }, :room_memberships, :share_link])` |
+
+追加インデックス不要（既存の `room_memberships(room_id, profile_id)` unique index で十分）。
+
+---
+
+## 11. トランザクション / Service 分離
+
+**トランザクション:** 不要（単一レコード `room_membership` の削除のみ）
+**Service 分離:** 不要（単一モデル操作、条件分岐も少ない）
+
+---
+
+## 12. 実装対象一覧
+
+| # | 対象 | 内容 |
+|---|---|---|
+| 1 | Controller（既存変更） | `Mypage::RoomsController#index` に `@memberships` 追加・ガード節に変更 |
+| 2 | Controller（既存変更） | `Mypage::RoomsController#create` にプロフィールガード追加・`room_params` 経由に修正 |
+| 3 | Controller（新規） | `Mypage::RoomMembershipsController#destroy` |
+| 4 | Helper（新規） | `app/helpers/rooms_helper.rb` — `room_type_badge` ヘルパー（雑談/勉強/ゲームのバッジ定義を一元管理） |
+| 5 | View（既存変更） | `mypage/rooms/index.html.erb` を「管理中」「参加中」2セクションに更新・部屋タイプ選択セレクトボックス追加 |
+| 6 | View（既存変更） | `mypage/rooms/_room.html.erb` に部屋タイプバッジ・「部屋を見る」追加 |
+| 7 | View（新規） | `mypage/rooms/_joined_room.html.erb` |
+| 8 | View（新規） | `mypage/room_memberships/destroy.turbo_stream.erb` |
+| 9 | Routes | `resources :room_memberships, only: [ :destroy ]` 追加 |
+
+---
+
+## 13. 受入条件
+
+- [ ] 「管理中の部屋」セクションに `issuer_profile = 自分` の部屋が表示される
+- [ ] 「参加中の部屋」セクションに `issuer_profile != 自分` かつ `room_memberships` に存在する部屋が表示される
+- [ ] 参加中の部屋には部屋名・部屋タイプバッジ・参加人数・作成者名（nickname）・「部屋を見る」リンク・退出ボタンが表示される
+- [ ] 参加中の部屋には編集・削除ボタンが表示されない
+- [ ] 「部屋を見る」は `share_path(token)` にリンクする（作成済み・参加中の両方）
+- [ ] 退出後、turbo_stream で該当カードが削除される
+- [ ] 空状態（0件）のとき空状態 UI が表示される
+- [ ] 部屋タイプバッジ（雑談/勉強/ゲーム）が表示される
+- [ ] 作成者が自分の部屋を退出しようとしたら alert でリダイレクトされる
+- [ ] 他者の membership ID で直接アクセスしても 404（リダイレクト）になる
+- [ ] N+1 が発生しない
+- [ ] RSpec / RuboCop 全通過
+
+---
+
+## 14. この設計の結論
+
+「参加関係の削除は RoomMembershipsController が責任を持つ」という RESTful な責務分割で、既存の DB 構造を変えずに実装できる。「部屋を見る」は現時点で共有ページ（share_path）への動線として機能させ、将来チャット等を作る際にリンク先を差し替えるだけでよい設計にする。

--- a/spec/requests/mypage/room_memberships_spec.rb
+++ b/spec/requests/mypage/room_memberships_spec.rb
@@ -1,0 +1,110 @@
+require "rails_helper"
+
+RSpec.describe "Mypage::RoomMemberships", type: :request do
+  # 退出機能のリクエストスペック
+  describe "DELETE /mypage/room_memberships/:id" do
+    context "ログインしている場合" do
+      it "参加中の部屋から退出できる（turbo_stream）" do
+        # 退出する本人（ログインユーザー）を作成
+        current_user = create(:user)
+        current_profile = create(:profile, user: current_user)
+
+        # 部屋の作成者を作成
+        room_owner = create(:user)
+        room_owner_profile = create(:profile, user: room_owner)
+
+        # 作成者が作成した部屋を用意
+        room_owners_room = create(:room, issuer_profile: room_owner_profile)
+
+        # 本人がその部屋に参加している状態を作る
+        own_membership = create(:room_membership, room: room_owners_room, profile: current_profile)
+
+        # 本人でログイン
+        sign_in current_user
+
+        # Turbo Stream形式で退出リクエストを送る
+        delete mypage_room_membership_path(own_membership),
+               headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        # 正常に処理されること
+        expect(response).to have_http_status(:ok)
+
+        # 参加情報が削除され、退出できていること
+        expect(RoomMembership.exists?(own_membership.id)).to be false
+      end
+
+      it "自分が作成した部屋からは退出できない" do
+        # 本人を作成
+        current_user = create(:user)
+        current_profile = create(:profile, user: current_user)
+
+        # 本人が作成した部屋を用意
+        own_room = create(:room, issuer_profile: current_profile)
+
+        # 作成者自身も membership を持っている状態を作る
+        own_membership = create(:room_membership, room: own_room, profile: current_profile)
+
+        # 本人でログイン
+        sign_in current_user
+
+        # 自分が作成した部屋に対して退出リクエストを送る
+        delete mypage_room_membership_path(own_membership),
+               headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        # 退出は許可されず、部屋一覧へリダイレクトされること
+        expect(response).to redirect_to(mypage_rooms_path)
+
+        # membership は削除されず、そのまま残ること
+        expect(RoomMembership.exists?(own_membership.id)).to be true
+      end
+
+      it "他のメンバーの membership を削除しようとすると部屋一覧にリダイレクトされる" do
+        # ログインする本人を作成
+        current_user = create(:user)
+        create(:profile, user: current_user)
+
+        # 他のメンバー（membership の持ち主）を作成
+        other_member = create(:user)
+        other_member_profile = create(:profile, user: other_member)
+
+        # 部屋の作成者を別で作成
+        room_owner = create(:user)
+        room_owner_profile = create(:profile, user: room_owner)
+
+        # 作成者が作成した部屋を用意
+        room_owners_room = create(:room, issuer_profile: room_owner_profile)
+
+        # 本人ではなく、他のメンバーが参加している membership を作成
+        other_members_membership = create(:room_membership, room: room_owners_room, profile: other_member_profile)
+
+        # 本人でログイン
+        sign_in current_user
+
+        # 他のメンバーの membership に対して削除リクエストを送る
+        delete mypage_room_membership_path(other_members_membership)
+
+        # 不正な削除は許可されず、部屋一覧へリダイレクトされること
+        expect(response).to redirect_to(mypage_rooms_path)
+
+        # 他のメンバーの membership は削除されないこと
+        expect(RoomMembership.exists?(other_members_membership.id)).to be true
+      end
+    end
+
+    context "未ログインの場合" do
+      it "ログイン画面にリダイレクトされる" do
+        # 部屋の作成者と membership を用意
+        room_owner = create(:user)
+        room_owner_profile = create(:profile, user: room_owner)
+        room_owners_room = create(:room, issuer_profile: room_owner_profile)
+        room_owners_membership = create(:room_membership, room: room_owners_room, profile: room_owner_profile)
+
+        # ログインせずに退出リクエストを送る
+        delete mypage_room_membership_path(room_owners_membership)
+
+        # 認証が必要なため、ログイン画面にリダイレクトされること
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/requests/mypage/rooms_spec.rb
+++ b/spec/requests/mypage/rooms_spec.rb
@@ -40,6 +40,33 @@ RSpec.describe "Mypage::Rooms", type: :request do
 
         expect(response.body).not_to include("他人の部屋")
       end
+
+      it "参加中の部屋（他者が作成・自分がメンバー）が一覧に含まれる" do
+        # ログインユーザーを作成
+        current_user = create(:user)
+        current_profile = create(:profile, user: current_user)
+
+        # 部屋の作成者を作成
+        room_owner = create(:user)
+        room_owner_profile = create(:profile, user: room_owner)
+
+        # 作成者が作成した部屋を用意
+        room_owners_room = create(:room, issuer_profile: room_owner_profile, label: "参加中テスト部屋")
+        create(:share_link, room: room_owners_room)
+
+        # ログインユーザーがその部屋に参加している状態を作る
+        create(:room_membership, room: room_owners_room, profile: current_profile)
+
+        # ログインしてアクセス
+        sign_in current_user
+        get mypage_rooms_path
+
+        # 正常に表示されること
+        expect(response).to have_http_status(:ok)
+
+        # 参加中の部屋名が表示されること
+        expect(response.body).to include("参加中テスト部屋")
+      end
     end
 
     context "未ログインの場合" do

--- a/spec/requests/mypage/rooms_spec.rb
+++ b/spec/requests/mypage/rooms_spec.rb
@@ -100,6 +100,35 @@ RSpec.describe "Mypage::Rooms", type: :request do
 
       expect(response).to redirect_to(mypage_rooms_path)
     end
+
+    it "room_type を指定して部屋を作成できる" do
+      user = create(:user)
+      create(:profile, user: user)
+      sign_in user
+
+      post mypage_rooms_path, params: { room: { label: "ゲーム部屋", room_type: "game" } }
+
+      expect(Room.last.room_type).to eq("game")
+    end
+
+    it "room_type を指定しない場合は chat になる" do
+      user = create(:user)
+      create(:profile, user: user)
+      sign_in user
+
+      post mypage_rooms_path, params: { room: { label: "デフォルト部屋" } }
+
+      expect(Room.last.room_type).to eq("chat")
+    end
+
+    it "プロフィール未作成のユーザーが部屋を作成しようとするとリダイレクトされる" do
+      user = create(:user)
+      sign_in user
+
+      post mypage_rooms_path, params: { room: { label: "部屋" } }
+
+      expect(response).to redirect_to(mypage_root_path)
+    end
   end
 
   describe "PATCH /mypage/rooms/:id" do


### PR DESCRIPTION
## Summary
- 部屋管理画面を「管理中の部屋」「参加中の部屋」の2セクションに分割
- 作成フォームに部屋タイプ選択（雑談/勉強/ゲーム）を追加
- 各部屋カードに部屋タイプバッジを表示
- 参加中の部屋カードに作成者アイコン・ニックネーム・参加人数・退出ボタン・「部屋を見る」リンクを追加
- `RoomsHelper#room_type_badge` ヘルパーでバッジ定義を一元管理
- `create` アクションにプロフィール未作成ユーザーのガードを追加

## Test plan
- [ ] 作成フォームで部屋タイプを選択して部屋を作成できる
- [ ] 「管理中の部屋」に自分が作成した部屋のみ表示される
- [ ] 「参加中の部屋」に他者が作成した部屋（自分がメンバー）のみ表示される
- [ ] 各部屋カードに部屋タイプバッジが表示される
- [ ] 参加中の部屋カードに作成者名・参加人数・退出ボタンが表示される
- [ ] 「部屋を見る」リンクが共有ページ（share_path）に遷移する
- [ ] 部屋がない場合に空状態メッセージが表示される
- [ ] RSpec 287 examples, 0 failures
- [ ] RuboCop no offenses

## Related
- Issue: #166
- 退出機能: `Mypage::RoomMembershipsController#destroy`（本PRに含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)