### PR TITLE
feat: ロック機能（公開状態の追加）#187

### DIFF
--- a/app/controllers/mypage/rooms_controller.rb
+++ b/app/controllers/mypage/rooms_controller.rb
@@ -1,6 +1,6 @@
 class Mypage::RoomsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_room, only: %i[edit update destroy]
+  before_action :set_room, only: %i[edit update destroy lock unlock]
 
   def index
     profile = current_user.profile
@@ -59,6 +59,14 @@ class Mypage::RoomsController < ApplicationController
     end
   end
 
+  def lock
+    update_lock(true, "部屋をロックしました")
+  end
+
+  def unlock
+    update_lock(false, "部屋のロックを解除しました")
+  end
+
   def destroy
     @room.destroy!
     respond_to do |format|
@@ -75,5 +83,13 @@ class Mypage::RoomsController < ApplicationController
 
   def room_params
     params.require(:room).permit(:label, :room_type)
+  end
+
+  def update_lock(state, message)
+    @room.update!(locked: state)
+    respond_to do |format|
+      format.turbo_stream { flash.now[:notice] = message }
+      format.html { redirect_to mypage_rooms_path, notice: message }
+    end
   end
 end

--- a/app/controllers/shares_controller.rb
+++ b/app/controllers/shares_controller.rb
@@ -1,107 +1,94 @@
 # 共有リンク（token）から部屋ページを表示するコントローラ
-# - トークン検証
-# - 部屋参加処理
-# - マインドマップ表示用データの準備
+# 主な責務：
+#   1. トークンの有効性検証（存在・有効期限）
+#   2. ロック状態に応じた参加制御
+#   3. 入室処理（RoomMembership の作成）
+#   4. マインドマップ表示用データの準備
 class SharesController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    # --------------------------------------------------
-    # 1. 共有リンク取得（存在しない場合は 404）
-    # --------------------------------------------------
-    share_link = ShareLink.includes(:room).find_by!(token: params[:token])
+    share_link      = ShareLink.includes(:room).find_by!(token: params[:token])
+    @room           = share_link.room
     @viewer_profile = current_user.profile
 
-    # --------------------------------------------------
-    # 2. 有効期限チェック
-    # 期限切れ かつ 未参加ユーザー → 410 Gone
-    # 期限切れ かつ 既存メンバー → 通過（閲覧OK）
-    # --------------------------------------------------
+    # 期限切れの場合は未参加者のみ 410 Gone を返す。
+    # 既存メンバーはリンクが切れていても閲覧を継続できる。
     if share_link.expired?
-      return head :gone unless @viewer_profile && RoomMembership.exists?(room: share_link.room, profile: @viewer_profile)
+      return head :gone unless @viewer_profile && RoomMembership.exists?(room: @room, profile: @viewer_profile)
     end
 
-    # --------------------------------------------------
-    # 3. 表示対象の部屋を取得
-    # --------------------------------------------------
-    @room = share_link.room
+    # ロック中の部屋は未参加・非オーナーの入室を拒否する。
+    # ページ自体は表示し、flash で理由を伝える（完全な 403 ではなく閲覧は許容）。
+    # 既存メンバー・オーナーはロック状態に関わらず通過する。
+    if @room.locked?
+      already_member = @viewer_profile && RoomMembership.exists?(room: @room, profile: @viewer_profile)
+      is_owner       = @viewer_profile&.id == @room.issuer_profile_id
 
-    # --------------------------------------------------
-    # 4. 共有リンク閲覧を「部屋参加」として扱う
-    # 未参加の場合のみ RoomMembership を作成
-    # --------------------------------------------------
+      unless already_member || is_owner
+        flash.now[:alert] = "この部屋は現在ロック中のため参加できません"
+        @memberships = memberships_for_display
+        @jsmind_data = build_jsmind_data(@room, @memberships)
+        return render :show
+      end
+    end
+
+    # 初回アクセス時に入室処理を行う。
+    # find_or_create_by! により二重参加は発生しない。
     RoomMembership.find_or_create_by!(room: @room, profile: @viewer_profile) if @viewer_profile
 
-    # --------------------------------------------------
-    # 5. マインドマップ表示用データ取得
-    # includes により N+1 クエリを防止
-    # --------------------------------------------------
-    @memberships = @room.room_memberships
-                        .includes(profile: [ :user, { profile_hobbies: { hobby: :parent_tag } } ])
-                        .order(created_at: :asc)
-
-    # --------------------------------------------------
-    # 6. jsMind 用データ生成
-    # --------------------------------------------------
+    @memberships = memberships_for_display
     @jsmind_data = build_jsmind_data(@room, @memberships)
   end
 
   private
 
-  # --------------------------------------------------
-  # jsMind 用の node_tree 形式データを生成
+  # マインドマップ表示に必要な membership 一覧を取得する。
+  # includes で N+1 を防止する。
+  def memberships_for_display
+    @room.room_memberships
+         .includes(profile: [ :user, { profile_hobbies: { hobby: :parent_tag } } ])
+         .order(created_at: :asc)
+  end
+
+  # jsMind 用の node_tree 形式データを生成する。
   #
-  # 構造
-  #   趣味（親ノード）
-  #      └ ユーザー（子ノード）
+  # ノード構造:
+  #   root
+  #   └ 趣味ノード（hobby_#{id}）
+  #       └ ユーザーノード（p_#{profile_id}_h_#{hobby_id}）
   #
-  # ユーザーノードには member 詳細ページのURLを持たせ、
-  # クリック時に Turbo Frame で右ペインを更新できるようにする
-  # --------------------------------------------------
+  # ユーザーノードの data.url はクリック時に Turbo Frame で
+  # 右ペインのメンバー詳細を更新するために使用する。
   def build_jsmind_data(room, memberships)
-    # --------------------------------------------------
-    # 趣味 => その趣味を持つプロフィール一覧
-    # --------------------------------------------------
     hobby_to_profiles = {}
 
     memberships.each do |membership|
-      # 表示順を安定させるため趣味名でソート
+      # 趣味名でソートして表示順を安定させる
       membership.profile.hobbies.sort_by(&:name).each do |hobby|
         (hobby_to_profiles[hobby] ||= []) << membership.profile
       end
     end
 
-    # --------------------------------------------------
-    # jsMind ノード生成
-    # - 趣味名順
-    # - プロフィールID順
-    # --------------------------------------------------
     hobby_nodes = hobby_to_profiles.sort_by { |hobby, _| hobby.name }.map do |hobby, profiles|
       profile_nodes = profiles.sort_by(&:id).map do |profile|
         {
-          # jsMind ノードIDはツリー内で一意である必要がある
-          id: "p_#{profile.id}_h_#{hobby.id}",
+          id:    "p_#{profile.id}_h_#{hobby.id}", # ツリー内で一意である必要がある
           topic: profile.user.nickname.presence || "no-name",
-
-          # ノードクリック時に呼び出すメンバー詳細URL
-          data: { url: room_member_path(room_id: room.id, id: profile.id) }
+          data:  { url: room_member_path(room_id: room.id, id: profile.id) }
         }
       end
 
-      # 趣味ノード（親）
       { id: "hobby_#{hobby.id}", topic: hobby.name, children: profile_nodes }
     end
 
-    # --------------------------------------------------
-    # jsMind が期待するルート付きツリー構造
-    # --------------------------------------------------
     {
-      meta: { name: "room-map", version: "0.2" },
+      meta:   { name: "room-map", version: "0.2" },
       format: "node_tree",
-      data: {
-        id: "root",
-        isroot: true,
-        topic: room.label.presence || "この部屋の趣味",
+      data:   {
+        id:       "root",
+        isroot:   true,
+        topic:    room.label.presence || "この部屋の趣味",
         children: hobby_nodes
       }
     }

--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -5,7 +5,16 @@ module RoomsHelper
     "game"  => { label: "ゲーム", color: "rgba(124, 58, 237, 0.2)", border: "rgba(167, 139, 250, 0.4)", text: "#c4b5fd" }
   }.freeze
 
+  LOCK_STATUS_BADGES = {
+    true  => { label: "ロック中", color: "rgba(239, 68, 68, 0.15)",  border: "rgba(239, 68, 68, 0.3)",  text: "#fca5a5" },
+    false => { label: "公開中",   color: "rgba(34, 197, 94, 0.15)",  border: "rgba(34, 197, 94, 0.3)",  text: "#86efac" }
+  }.freeze
+
   def room_type_badge(room_type)
     ROOM_TYPE_BADGES[room_type]
+  end
+
+  def lock_status_badge(room)
+    LOCK_STATUS_BADGES[room.locked?]
   end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,6 +1,9 @@
 class Room < ApplicationRecord
   enum :room_type, { chat: 0, study: 1, game: 2 }
 
+  scope :locked,   -> { where(locked: true) }
+  scope :unlocked, -> { where(locked: false) }
+
   belongs_to :issuer_profile, class_name: "Profile", foreign_key: :issuer_profile_id, inverse_of: :issued_rooms
 
   has_many :room_memberships, dependent: :destroy

--- a/app/views/mypage/rooms/_room.html.erb
+++ b/app/views/mypage/rooms/_room.html.erb
@@ -9,6 +9,12 @@
       </span>
     <% end %>
 
+    <%# 公開状態バッジ %>
+    <% lock_badge = lock_status_badge(room) %>
+    <span style="display: inline-block; align-self: flex-start; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; margin-bottom: 0.5rem; background: <%= lock_badge[:color] %>; border: 1px solid <%= lock_badge[:border] %>; color: <%= lock_badge[:text] %>;">
+      <%= lock_badge[:label] %>
+    </span>
+
     <%# 部屋名 %>
     <h3 style="font-size: 1.125rem; font-weight: 600; color: #ffffff; margin-bottom: 0.75rem;">
       <%= room.label.presence || "名無しの部屋" %>
@@ -67,6 +73,18 @@
                   edit_mypage_room_path(room),
                   data: { turbo_frame: dom_id(room) },
                   style: "color: #60a5fa; text-decoration: none;" %>
+
+      <% if room.locked? %>
+        <%= link_to "解除する",
+                    unlock_mypage_room_path(room),
+                    data: { turbo_method: :patch, turbo_confirm: "この部屋のロックを解除しますか？" },
+                    style: "color: #86efac; text-decoration: none;" %>
+      <% else %>
+        <%= link_to "ロックする",
+                    lock_mypage_room_path(room),
+                    data: { turbo_method: :patch, turbo_confirm: "この部屋をロックしますか？" },
+                    style: "color: #fca5a5; text-decoration: none;" %>
+      <% end %>
 
       <%= link_to "削除",
                   mypage_room_path(room),

--- a/app/views/mypage/rooms/lock.turbo_stream.erb
+++ b/app/views/mypage/rooms/lock.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.replace @room, partial: "mypage/rooms/room",
+    locals: { room: @room, link: @room.share_link } %>
+
+<%= turbo_stream.update "flash", partial: "shared/flash" %>

--- a/app/views/mypage/rooms/unlock.turbo_stream.erb
+++ b/app/views/mypage/rooms/unlock.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.replace @room, partial: "mypage/rooms/room",
+    locals: { room: @room, link: @room.share_link } %>
+
+<%= turbo_stream.update "flash", partial: "shared/flash" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,12 @@ Rails.application.routes.draw do
   namespace :mypage do
     root to: "dashboards#show"
     resource :dashboard, only: [ :update ]
-    resources :rooms, only: %i[index create edit update destroy]
+    resources :rooms, only: %i[index create edit update destroy] do
+      member do
+        patch :lock
+        patch :unlock
+      end
+    end
     resources :room_memberships, only: [ :destroy ]
   end
 

--- a/db/migrate/20260405102454_add_locked_to_rooms.rb
+++ b/db/migrate/20260405102454_add_locked_to_rooms.rb
@@ -1,0 +1,5 @@
+class AddLockedToRooms < ActiveRecord::Migration[7.2]
+  def change
+    add_column :rooms, :locked, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_02_083650) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_05_102454) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -98,6 +98,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_02_083650) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "room_type", default: 0, null: false
+    t.boolean "locked", default: false, null: false
     t.index ["issuer_profile_id"], name: "index_rooms_on_issuer_profile_id"
   end
 

--- a/docs/designs/2026-04-05-room-lock.md
+++ b/docs/designs/2026-04-05-room-lock.md
@@ -1,0 +1,244 @@
+# ロック機能（公開状態の追加） 設計書
+
+**日付:** 2026-04-05
+**Issue:** #187
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+
+- rooms.locked boolean カラム（false=公開中 / true=ロック中）
+- 管理中の部屋カードへの公開状態バッジ＋ロック/解除ボタン（turbo_stream）
+- SharesController にロックチェック（未参加者かつ未オーナーは参加処理スキップ）
+- 後続 Issue: #188（部屋作成フォーム改善）、#189（招待リンク再発行）
+
+---
+
+## 2. 目的
+
+- 部屋オーナーが参加者流入を手動制御できるようにする
+- ロック中でも既存参加者・オーナーは引き続き利用可能
+
+---
+
+## 3. スコープ
+
+**含むもの**
+- migration: rooms.locked 追加
+- _room.html.erb: バッジ＋ロック/解除ボタン
+- mypage/rooms に lock / unlock member action
+- SharesController#show にロックチェック
+
+**含まないもの**
+- 参加済みメンバーへの通知（将来対応）
+- 管理者によるロック解除（将来対応）
+
+---
+
+## 4. 設計方針
+
+### ルーティング案の比較
+
+| 方式 | 実装コスト | 意図の明確さ | 現状との相性 |
+|---|---|---|---|
+| A: lock / unlock 2アクション | 低 | 高（操作が明示的） | ◎ 既存 member action パターンと同じ |
+| B: toggle_lock 1アクション | 低 | 中（副作用が不明確） | ○ |
+
+**採用:** 案A。lock と unlock は意図が明確で、turbo_stream のレスポンスも個別に制御しやすい。
+
+---
+
+## 5. データ設計
+
+rooms テーブルに locked カラムを追加する。
+
+### DB 制約
+
+| カラム | 制約 | 理由 |
+|---|---|---|
+| locked | boolean, default: false, null: false | 未設定による nil 混入防止 |
+
+**設計意図:** null: false で nil.locked? の意図しない挙動を防ぐ。インデックスは不要（boolean の選択性は低く、rooms 単体での検索ユースケースもない）。
+
+### ER 図
+
+```mermaid
+erDiagram
+  rooms {
+    bigint id PK ""
+    bigint issuer_profile_id FK "null: false"
+    string label ""
+    integer room_type "default: 0, null: false"
+    boolean locked "default: false, null: false ← NEW"
+    datetime created_at ""
+    datetime updated_at ""
+  }
+  share_links {
+    bigint id PK ""
+    bigint room_id FK "null: false, unique"
+    string token "null: false, unique"
+    datetime expires_at "null: false"
+  }
+  room_memberships {
+    bigint id PK ""
+    bigint room_id FK "null: false"
+    bigint profile_id FK "null: false"
+  }
+
+  rooms ||--o{ room_memberships : "has many"
+  rooms ||--o| share_links : "has one"
+```
+
+---
+
+## 6. 画面・アクセス制御の流れ
+
+### シーケンス図
+
+```mermaid
+sequenceDiagram
+  participant U as User(Owner)
+  participant RC as Mypage::RoomsController
+  participant R as Room
+  participant V as _room.html.erb
+
+  U->>RC: PATCH /mypage/rooms/:id/lock
+  RC->>R: room.update!(locked: true)
+  R-->>RC: success
+  RC-->>V: turbo_stream replace (locked状態)
+  V-->>U: バッジ「ロック中」に更新
+
+  participant G as Guest
+  participant SC as SharesController
+
+  G->>SC: GET /share/:token
+  SC->>R: share_link.room (locked: true)
+  SC->>SC: ロックチェック（未参加かつ未オーナー？）
+  SC-->>G: render :show + flash.now[:alert]「ロック中」
+           ※ find_or_create_by! はスキップ
+```
+
+---
+
+## 7. アプリケーション設計
+
+### Mypage::RoomsController
+
+```ruby
+before_action :set_room, only: %i[edit update destroy lock unlock]
+
+def lock
+  @room.update!(locked: true)
+  respond_to do |format|
+    format.turbo_stream
+    format.html { redirect_to mypage_rooms_path }
+  end
+end
+
+def unlock
+  @room.update!(locked: false)
+  respond_to do |format|
+    format.turbo_stream
+    format.html { redirect_to mypage_rooms_path }
+  end
+end
+```
+
+**turbo_stream テンプレート（lock.turbo_stream.erb / unlock.turbo_stream.erb）**
+- 既存の update.turbo_stream.erb と同様に turbo_stream.replace でカードを差し替え
+
+### SharesController#show（追加チェック）
+
+```ruby
+# @room = share_link.room の直後に挿入
+if @room.locked?
+  already_member = @viewer_profile && RoomMembership.exists?(room: @room, profile: @viewer_profile)
+  is_owner       = @viewer_profile&.id == @room.issuer_profile_id
+
+  unless already_member || is_owner
+    flash.now[:alert] = "この部屋は現在ロック中のため参加できません"
+    @memberships = @room.room_memberships
+                        .includes(profile: [:user, { profile_hobbies: { hobby: :parent_tag } }])
+                        .order(created_at: :asc)
+    @jsmind_data = build_jsmind_data(@room, @memberships)
+    render :show and return
+  end
+end
+```
+
+**設計意図:** ロックチェックは find_or_create_by! の前に置く。既存メンバー・オーナーは already_member || is_owner で通過し、未参加者のみ弾く。Service化不要（単一モデル更新、トランザクション境界なし）。
+
+---
+
+## 8. ルーティング設計
+
+```ruby
+namespace :mypage do
+  resources :rooms, only: %i[index create edit update destroy] do
+    member do
+      patch :lock
+      patch :unlock
+    end
+  end
+end
+```
+
+**設計意図:** PATCH /mypage/rooms/:id/lock は状態遷移を表す動詞 URL で Rails の慣例に沿う。
+
+---
+
+## 9. レイアウト / UI 設計
+
+_room.html.erb の部屋タイプバッジの隣に公開状態バッジを追加し、操作ボタン欄にロック/解除ボタンを追加する。
+
+| 状態 | バッジ色 | ボタン表示 |
+|---|---|---|
+| 公開中 (locked: false) | 緑系 | 「ロックする」ボタン |
+| ロック中 (locked: true) | 赤系 | 「解除する」ボタン |
+
+---
+
+## 10. クエリ・性能面
+
+- locked は rooms テーブルのカラムなので追加クエリなし
+- SharesController のロックチェックで RoomMembership.exists? を呼ぶが、既存の (room_id, profile_id) unique インデックスで高速（O(1)）
+
+---
+
+## 11. トランザクション / Service 分離
+
+- トランザクション: 不要（Room#update! 単体）
+- Service 分離: 不要（1モデル、条件分岐なし）
+
+---
+
+## 12. 実装対象一覧
+
+| # | 対象 | 内容 |
+|---|---|---|
+| 1 | Migration | rooms.locked boolean default: false, null: false 追加 |
+| 2 | Routes | lock / unlock member action 追加 |
+| 3 | Controller | Mypage::RoomsController に lock / unlock action、before_action 更新 |
+| 4 | View | _room.html.erb に公開状態バッジ＋ロック/解除ボタン追加 |
+| 5 | turbo_stream | lock.turbo_stream.erb / unlock.turbo_stream.erb 作成 |
+| 6 | Controller | SharesController#show にロックチェック追加 |
+| 7 | Spec | Room model spec、Mypage::RoomsController request spec、SharesController request spec |
+
+---
+
+## 13. 受入条件
+
+- [ ] rooms.locked カラムが追加されている
+- [ ] 管理中の部屋カードに「公開中 / ロック中」バッジが表示される
+- [ ] ロック / 解除ボタンで状態が turbo_stream で即時反映される
+- [ ] ボタンはオーナー（管理中の部屋）のみ表示
+- [ ] ロック中の共有リンクは閲覧可能。未参加・非オーナーがアクセスした場合は参加処理をスキップし、ページ上にエラーメッセージを表示する
+- [ ] 既存参加者・オーナーはロック中でも利用制限なし
+- [ ] RSpec / RuboCop 全通過
+
+---
+
+## 14. この設計の結論
+
+rooms.locked boolean 1カラムで公開状態を管理し、SharesController のロックチェックと mypage/rooms の lock/unlock アクションで最小実装に収める。Service化・トランザクション不要。将来「参加申請機能」や「オーナー通知」を追加する場合は Service 化を検討する。

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe Room, type: :model do
     end
   end
 
+  describe "locked カラム" do
+    it "デフォルト値が false である" do
+      room = create(:room)
+
+      expect(room.locked).to be false
+    end
+  end
+
   it "has associations" do
     room = described_class.reflect_on_association(:issuer_profile)
 

--- a/spec/requests/mypage/rooms_spec.rb
+++ b/spec/requests/mypage/rooms_spec.rb
@@ -28,6 +28,32 @@ RSpec.describe "Mypage::Rooms", type: :request do
         expect(response.body.index("新しい部屋")).to be < response.body.index("古い部屋")
       end
 
+      it "公開中の部屋に「公開中」バッジが表示される" do
+        # 公開中の部屋を準備
+        current_user = create(:user)
+        current_profile = create(:profile, user: current_user)
+        create(:room, issuer_profile: current_profile, locked: false)
+        sign_in current_user
+
+        get mypage_rooms_path
+
+        # 「公開中」バッジが表示されること
+        expect(response.body).to include("公開中")
+      end
+
+      it "ロック中の部屋に「ロック中」バッジが表示される" do
+        # ロック中の部屋を準備
+        current_user = create(:user)
+        current_profile = create(:profile, user: current_user)
+        create(:room, issuer_profile: current_profile, locked: true)
+        sign_in current_user
+
+        get mypage_rooms_path
+
+        # 「ロック中」バッジが表示されること
+        expect(response.body).to include("ロック中")
+      end
+
       it "他人の部屋は表示されない" do
         user = create(:user)
         create(:profile, user: user)

--- a/spec/requests/mypage/rooms_spec.rb
+++ b/spec/requests/mypage/rooms_spec.rb
@@ -183,4 +183,88 @@ RSpec.describe "Mypage::Rooms", type: :request do
       expect(response).to have_http_status(:not_found)
     end
   end
+
+  describe "PATCH /mypage/rooms/:id/lock" do
+    context "オーナーがロックする場合" do
+      it "locked が true になる" do
+        # ログインユーザーと部屋を準備
+        current_user = create(:user)
+        current_profile = create(:profile, user: current_user)
+        own_room = create(:room, issuer_profile: current_profile, locked: false)
+        sign_in current_user
+
+        # ロックを実行
+        patch lock_mypage_room_path(own_room)
+
+        # locked が true になっていること
+        expect(own_room.reload.locked).to be true
+      end
+
+      it "turbo_stream で応答する" do
+        # ログインユーザーと部屋を準備
+        current_user = create(:user)
+        current_profile = create(:profile, user: current_user)
+        own_room = create(:room, issuer_profile: current_profile)
+        sign_in current_user
+
+        # turbo_stream リクエストを送信
+        patch lock_mypage_room_path(own_room), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        # turbo_stream で応答すること
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      end
+    end
+
+    context "他人の部屋をロックしようとした場合" do
+      it "404 を返す" do
+        # ログインユーザーと他人の部屋を準備
+        current_user = create(:user)
+        create(:profile, user: current_user)
+        room_owner = create(:user)
+        room_owner_profile = create(:profile, user: room_owner)
+        room_owners_room = create(:room, issuer_profile: room_owner_profile)
+        sign_in current_user
+
+        # 他人の部屋をロックしようとする
+        patch lock_mypage_room_path(room_owners_room)
+
+        # 404 が返ること
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "PATCH /mypage/rooms/:id/unlock" do
+    context "オーナーがロック解除する場合" do
+      it "locked が false になる" do
+        # ロック中の部屋を準備
+        current_user = create(:user)
+        current_profile = create(:profile, user: current_user)
+        own_room = create(:room, issuer_profile: current_profile, locked: true)
+        sign_in current_user
+
+        # ロック解除を実行
+        patch unlock_mypage_room_path(own_room)
+
+        # locked が false になっていること
+        expect(own_room.reload.locked).to be false
+      end
+
+      it "他人の部屋はロック解除できない" do
+        # ログインユーザーと他人のロック中部屋を準備
+        current_user = create(:user)
+        create(:profile, user: current_user)
+        room_owner = create(:user)
+        room_owner_profile = create(:profile, user: room_owner)
+        room_owners_room = create(:room, issuer_profile: room_owner_profile, locked: true)
+        sign_in current_user
+
+        # 他人の部屋をロック解除しようとする
+        patch unlock_mypage_room_path(room_owners_room)
+
+        # 404 が返ること
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end

--- a/spec/requests/shares_spec.rb
+++ b/spec/requests/shares_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe "Shares", type: :request do
+  describe "GET /share/:token" do
+    context "ロック中の部屋に未参加ユーザーがアクセスした場合" do
+      it "ページは表示されるが RoomMembership は作成されない" do
+        # ロック中の部屋と共有リンクを準備
+        room_owner = create(:user)
+        room_owner_profile = create(:profile, user: room_owner)
+        locked_room = create(:room, issuer_profile: room_owner_profile, locked: true)
+        share_link = create(:share_link, room: locked_room, expires_at: 1.year.from_now)
+
+        # 未参加のゲストユーザーでアクセス
+        guest_user = create(:user)
+        create(:profile, user: guest_user)
+        sign_in guest_user
+
+        # RoomMembership が増えないこと
+        expect {
+          get share_path(share_link.token)
+        }.not_to change(RoomMembership, :count)
+
+        # ページは表示されること
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "ロック中の部屋に既存メンバーがアクセスした場合" do
+      it "通常通りページが表示される" do
+        # ロック中の部屋にメンバーを準備
+        room_owner = create(:user)
+        room_owner_profile = create(:profile, user: room_owner)
+        locked_room = create(:room, issuer_profile: room_owner_profile, locked: true)
+        share_link = create(:share_link, room: locked_room, expires_at: 1.year.from_now)
+
+        # 既存メンバーとして参加済みにする
+        member_user = create(:user)
+        member_profile = create(:profile, user: member_user)
+        create(:room_membership, room: locked_room, profile: member_profile)
+        sign_in member_user
+
+        # ページが表示されること
+        get share_path(share_link.token)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "ロック中の部屋にオーナーがアクセスした場合" do
+      it "通常通りページが表示される" do
+        # ロック中の部屋を作成したオーナーでアクセス
+        room_owner = create(:user)
+        room_owner_profile = create(:profile, user: room_owner)
+        locked_room = create(:room, issuer_profile: room_owner_profile, locked: true)
+        share_link = create(:share_link, room: locked_room, expires_at: 1.year.from_now)
+        create(:room_membership, room: locked_room, profile: room_owner_profile)
+        sign_in room_owner
+
+        # ページが表示されること
+        get share_path(share_link.token)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "ロックされていない部屋に未参加ユーザーがアクセスした場合" do
+      it "RoomMembership が作成される" do
+        # 公開中の部屋と共有リンクを準備
+        room_owner = create(:user)
+        room_owner_profile = create(:profile, user: room_owner)
+        unlocked_room = create(:room, issuer_profile: room_owner_profile, locked: false)
+        share_link = create(:share_link, room: unlocked_room, expires_at: 1.year.from_now)
+
+        # 未参加ゲストユーザーでアクセス
+        guest_user = create(:user)
+        create(:profile, user: guest_user)
+        sign_in guest_user
+
+        # RoomMembership が1件増えること
+        expect {
+          get share_path(share_link.token)
+        }.to change(RoomMembership, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `rooms.locked` boolean カラムを追加し、部屋の公開状態を管理
- マイページの部屋カードに「公開中 / ロック中」バッジとロック/解除ボタンを追加（turbo_stream で即時反映）
- SharesController にロックチェックを追加。ロック中の部屋は未参加・非オーナーの入室をスキップし、ページ上にエラーメッセージを表示

## Test plan
- [x] RSpec: 299 examples, 0 failures 通過済み
- [x] RuboCop: 145 files, no offenses 通過済み
- [x] 正常系: オーナーが「ロックする」→ バッジが「ロック中」に切り替わる
- [x] 正常系: オーナーが「解除する」→ バッジが「公開中」に切り替わる
- [x] 正常系: 既存参加者はロック中でも共有リンクから閲覧できる
- [x] 異常系: 未参加ゲストがロック中の共有リンクにアクセス → ページは表示、参加処理はスキップ、エラーメッセージ表示

## Related
- Issue: #187
- 設計書: `docs/designs/2026-04-05-room-lock.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)