### PR TITLE
feat: マインドマップを親タグ中心の表示に変更 #172

### DIFF
--- a/app/controllers/shares_controller.rb
+++ b/app/controllers/shares_controller.rb
@@ -28,7 +28,7 @@ class SharesController < ApplicationController
       unless already_member || is_owner
         flash.now[:alert] = "この部屋は現在ロック中のため参加できません"
         @memberships = memberships_for_display
-        @jsmind_data = build_jsmind_data(@room, @memberships)
+        @jsmind_data = JsmindDataBuilder.new(@room, @memberships).build
         return render :show
       end
     end
@@ -38,7 +38,7 @@ class SharesController < ApplicationController
     RoomMembership.find_or_create_by!(room: @room, profile: @viewer_profile) if @viewer_profile
 
     @memberships = memberships_for_display
-    @jsmind_data = build_jsmind_data(@room, @memberships)
+    @jsmind_data = JsmindDataBuilder.new(@room, @memberships).build
   end
 
   private
@@ -49,48 +49,5 @@ class SharesController < ApplicationController
     @room.room_memberships
          .includes(profile: [ :user, { profile_hobbies: { hobby: :parent_tag } } ])
          .order(created_at: :asc)
-  end
-
-  # jsMind 用の node_tree 形式データを生成する。
-  #
-  # ノード構造:
-  #   root
-  #   └ 趣味ノード（hobby_#{id}）
-  #       └ ユーザーノード（p_#{profile_id}_h_#{hobby_id}）
-  #
-  # ユーザーノードの data.url はクリック時に Turbo Frame で
-  # 右ペインのメンバー詳細を更新するために使用する。
-  def build_jsmind_data(room, memberships)
-    hobby_to_profiles = {}
-
-    memberships.each do |membership|
-      # 趣味名でソートして表示順を安定させる
-      membership.profile.hobbies.sort_by(&:name).each do |hobby|
-        (hobby_to_profiles[hobby] ||= []) << membership.profile
-      end
-    end
-
-    hobby_nodes = hobby_to_profiles.sort_by { |hobby, _| hobby.name }.map do |hobby, profiles|
-      profile_nodes = profiles.sort_by(&:id).map do |profile|
-        {
-          id:    "p_#{profile.id}_h_#{hobby.id}", # ツリー内で一意である必要がある
-          topic: profile.user.nickname.presence || "no-name",
-          data:  { url: room_member_path(room_id: room.id, id: profile.id) }
-        }
-      end
-
-      { id: "hobby_#{hobby.id}", topic: hobby.name, children: profile_nodes }
-    end
-
-    {
-      meta:   { name: "room-map", version: "0.2" },
-      format: "node_tree",
-      data:   {
-        id:       "root",
-        isroot:   true,
-        topic:    room.label.presence || "この部屋の趣味",
-        children: hobby_nodes
-      }
-    }
   end
 end

--- a/app/services/jsmind_data_builder.rb
+++ b/app/services/jsmind_data_builder.rb
@@ -1,0 +1,94 @@
+class JsmindDataBuilder
+  include Rails.application.routes.url_helpers
+
+  def initialize(room, memberships)
+    @room        = room
+    @memberships = memberships
+  end
+
+  def build
+    {
+      meta:   { name: "room-map", version: "0.2" },
+      format: "node_tree",
+      data:   {
+        id:       "root",
+        isroot:   true,
+        topic:    @room.label.presence || "この部屋の趣味",
+        children: build_children
+      }
+    }
+  end
+
+  private
+
+  def build_children
+    (parent_tag_nodes + [ other_node ]).compact
+  end
+
+  def parent_tag_nodes
+    matching_parent_tags.filter_map do |parent_tag|
+      profiles = profiles_for(parent_tag)
+      next if profiles.empty?
+
+      {
+        id:       "pt_#{parent_tag.id}",
+        topic:    parent_tag.name,
+        children: user_nodes_for(profiles, "pt_#{parent_tag.id}")
+      }
+    end
+  end
+
+  def other_node
+    profiles = profiles_without_matching_hobby
+    return if profiles.empty?
+
+    {
+      id:       "other",
+      topic:    "その他",
+      expanded: false,
+      children: user_nodes_for(profiles, "other")
+    }
+  end
+
+  def matching_parent_tags
+    @matching_parent_tags ||= ParentTag.where(room_type: @room.room_type).order(:position)
+  end
+
+  def matching_parent_tag_ids
+    @matching_parent_tag_ids ||= matching_parent_tags.map(&:id)
+  end
+
+  # room_memberships は DB 制約でユニーク保証済みだが、防御的に uniq を適用
+  def all_profiles
+    @all_profiles ||= @memberships.map(&:profile).uniq(&:id)
+  end
+
+  def profiles_for(parent_tag)
+    profiles_by_parent_tag_id[parent_tag.id].uniq(&:id)
+  end
+
+  def profiles_without_matching_hobby
+    matched_ids = matching_parent_tag_ids
+      .flat_map { |id| profiles_by_parent_tag_id[id] }
+      .map(&:id).to_set
+    all_profiles.reject { |p| matched_ids.include?(p.id) }
+  end
+
+  # parent_tag_id → [profile] の Hash をメモ化（O(1) ルックアップ用）
+  def profiles_by_parent_tag_id
+    @profiles_by_parent_tag_id ||=
+      all_profiles.each_with_object(Hash.new { |h, k| h[k] = [] }) do |profile, hash|
+        profile.profile_hobbies.each { |ph| hash[ph.hobby.parent_tag_id] << profile }
+      end
+  end
+
+  def user_nodes_for(profiles, parent_key)
+    profiles.sort_by(&:id).map do |profile|
+      {
+        id:    "p_#{profile.id}_#{parent_key}",
+        topic: profile.user.nickname.presence || "no-name",
+        data:  { url: room_member_path(room_id: @room.id, id: profile.id) }
+      }
+    end
+  end
+end

--- a/docs/designs/2026-04-08-mindmap-parent-tag.md
+++ b/docs/designs/2026-04-08-mindmap-parent-tag.md
@@ -1,0 +1,292 @@
+# マインドマップを親タグ中心の表示に変更 設計書
+
+**日付:** 2026-04-08
+**Issue:** #172
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+
+- `SharesController#build_jsmind_data` を `JsmindDataBuilder` サービスに切り出し
+- マインドマップノード構造を「子タグ → ユーザー」から「親タグ → ユーザー」に変更
+- 部屋タイプ不一致ユーザーを「その他」ノード（デフォルト折りたたみ）に表示
+- 対応する RSpec を追加・更新
+
+後続 Issue: #173（右ペインに子タグ一覧）は本Issue完了後に着手可。
+
+## 2. 目的
+
+- 子タグ（趣味名）が増えてもマインドマップが見やすい構造にする
+- 全メンバーをマップに表示しつつ、部屋テーマに関係ないユーザーは折りたたみで整理する
+- `build_jsmind_data` をコントローラから分離してテスタブルにする
+
+## 3. スコープ
+
+### 含むもの
+
+- `SharesController#build_jsmind_data` の削除 → `JsmindDataBuilder` サービス新設
+- マインドマップのノード構造変更（親タグ軸）
+- 「その他」ノード（デフォルト折りたたみ、0人時は非表示）
+- RSpec（サービス spec + リクエスト spec 更新）
+
+### 含まないもの
+
+- マインドマップのデザイン・テーマ変更
+- 右ペインの子タグ一覧表示（#173 で対応）
+- 「その他」ノードのラベル設定化（将来対応）
+
+## 4. 設計方針
+
+| 方式 | 実装コスト | テスタビリティ | コントローラの薄さ |
+|---|---|---|---|
+| A: コントローラ private メソッドのまま変更 | 低 | 低（リクエスト spec しか書けない） | 悪化 |
+| B: `JsmindDataBuilder` サービスに切り出し | 中 | 高（単体 spec が書ける） | 維持 |
+
+**採用理由:** `build_jsmind_data` は Room / ParentTag / Hobby / ProfileHobby / Profile / User の 6 モデルを跨ぐ。design.md の Service分離ポリシー（「2モデル以上を跨ぐ」「コントローラに置くとテストしづらい」）に完全に該当するため B を採用。
+
+**仕様確認済み事項:**
+- 同一ユーザーが複数親タグに重複表示されるのは仕様として許容（親タグごとの参加者一覧として正しい）
+
+## 5. データ設計
+
+マイグレーション: なし（既存テーブルのデータのみ利用）
+
+`parent_tags.room_type` と `rooms.room_type` が同じ enum 定義（chat/study/game）のため追加カラム不要。
+
+### ER 図
+
+```mermaid
+erDiagram
+  rooms {
+    int id PK
+    int issuer_profile_id FK
+    string label
+    int room_type "enum: chat/study/game"
+  }
+  parent_tags {
+    int id PK
+    string name
+    int room_type "enum: chat/study/game / nil=未分類"
+    int position
+  }
+  hobbies {
+    int id PK
+    string name
+    int parent_tag_id FK "optional"
+  }
+  profile_hobbies {
+    int id PK
+    int profile_id FK
+    int hobby_id FK
+  }
+  profiles {
+    int id PK
+    int user_id FK
+  }
+  users {
+    int id PK
+    string nickname
+  }
+  room_memberships {
+    int id PK
+    int room_id FK
+    int profile_id FK
+  }
+
+  rooms ||--o{ room_memberships : ""
+  profiles ||--o{ room_memberships : ""
+  profiles ||--o{ profile_hobbies : ""
+  hobbies ||--o{ profile_hobbies : ""
+  hobbies }o--|| parent_tags : ""
+  profiles ||--|| users : ""
+```
+
+## 6. 画面・アクセス制御の流れ
+
+### シーケンス図
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant C as SharesController
+  participant B as JsmindDataBuilder
+  participant DB as Database
+
+  U->>C: GET /shares/:token
+  C->>DB: ShareLink.find_by(token:) + Room
+  C->>DB: room_memberships.includes(profile: [user, {profile_hobbies: {hobby: :parent_tag}}])
+  C->>B: JsmindDataBuilder.new(room, memberships).build
+  B->>DB: ParentTag.where(room_type: room.room_type).order(:position)
+  Note over B: 以降はすべてメモリ内操作（N+1なし）
+  B-->>C: jsMind用 Hash
+  C-->>U: HTML（data-jsmindにJSONを埋め込み）
+```
+
+## 7. アプリケーション設計
+
+### `app/services/jsmind_data_builder.rb`（新規）
+
+```ruby
+class JsmindDataBuilder
+  include Rails.application.routes.url_helpers
+
+  def initialize(room, memberships)
+    @room        = room
+    @memberships = memberships
+  end
+
+  def build
+    {
+      meta:   { name: "room-map", version: "0.2" },
+      format: "node_tree",
+      data: {
+        id:       "root",
+        isroot:   true,
+        topic:    @room.label.presence || "この部屋の趣味",
+        children: build_children
+      }
+    }
+  end
+
+  private
+
+  def build_children
+    nodes = parent_tag_nodes
+    other = other_node
+    nodes << other if other
+    nodes
+  end
+
+  def parent_tag_nodes
+    matching_parent_tags.filter_map do |parent_tag|
+      profiles = profiles_for(parent_tag)
+      next if profiles.empty?
+
+      {
+        id:       "pt_#{parent_tag.id}",
+        topic:    parent_tag.name,
+        children: user_nodes_for(profiles, "pt_#{parent_tag.id}")
+      }
+    end
+  end
+
+  def other_node
+    profiles = profiles_without_matching_hobby
+    return nil if profiles.empty?
+
+    {
+      id:       "other",
+      topic:    "その他",
+      expanded: false,
+      children: user_nodes_for(profiles, "other")
+    }
+  end
+
+  def matching_parent_tags
+    @matching_parent_tags ||= ParentTag.where(room_type: @room.room_type).order(:position)
+  end
+
+  def matching_parent_tag_ids
+    @matching_parent_tag_ids ||= matching_parent_tags.map(&:id)
+  end
+
+  def all_profiles
+    @all_profiles ||= @memberships.map(&:profile).uniq(&:id)
+  end
+
+  def profiles_for(parent_tag)
+    all_profiles.select do |profile|
+      profile.profile_hobbies.any? { |ph| ph.hobby.parent_tag_id == parent_tag.id }
+    end
+  end
+
+  def profiles_without_matching_hobby
+    all_profiles.reject do |profile|
+      profile.profile_hobbies.any? { |ph| matching_parent_tag_ids.include?(ph.hobby.parent_tag_id) }
+    end
+  end
+
+  def user_nodes_for(profiles, parent_key)
+    profiles.sort_by(&:id).map do |profile|
+      {
+        id:    "p_#{profile.id}_#{parent_key}",
+        topic: profile.user.nickname.presence || "no-name",
+        data:  { url: room_member_path(room_id: @room.id, id: profile.id) }
+      }
+    end
+  end
+end
+```
+
+### `SharesController` の変更点
+
+```ruby
+# 変更前
+@jsmind_data = build_jsmind_data(@room, @memberships)
+
+# 変更後
+@jsmind_data = JsmindDataBuilder.new(@room, @memberships).build
+```
+
+`build_jsmind_data` private メソッドは削除。
+
+## 8. ルーティング設計
+
+変更なし。
+
+## 9. レイアウト / UI 設計
+
+ビューへの変更なし（`@jsmind_data.to_json` を `data-jsmind` に埋め込む部分は既存のまま）。
+
+jsMind の `node_tree` 形式は `expanded: false` をネイティブサポート済み。
+
+## 10. クエリ・性能面
+
+**主要クエリ（2本）:**
+
+```ruby
+# 1. memberships + 全関連をプリロード（既存、変更なし）
+@room.room_memberships
+     .includes(profile: [:user, { profile_hobbies: { hobby: :parent_tag } }])
+     .order(created_at: :asc)
+
+# 2. 部屋タイプに一致する親タグ一覧（新規追加、1本）
+ParentTag.where(room_type: @room.room_type).order(:position)
+```
+
+以降の `profiles_for` / `profiles_without_matching_hobby` はすべてメモリ内操作のため N+1 なし。
+
+**インデックス追加:** 不要（`parent_tags` は参加者数が少ない小テーブルのため）。
+
+## 11. トランザクション / Service 分離
+
+**トランザクション:** 不要（書き込みなし、読み取り専用）
+
+**Service 分離:** 要 → `JsmindDataBuilder`
+- 6モデルを跨ぐ、コントローラに置くとテスタブルでない → design.md の分離ポリシーに該当
+
+## 12. 実装対象一覧
+
+| # | 対象 | 内容 |
+|---|---|---|
+| 1 | Service | `app/services/jsmind_data_builder.rb` 新規作成 |
+| 2 | Controller | `SharesController` から `build_jsmind_data` 削除 → サービス呼び出しに変更 |
+| 3 | Spec（新規） | `spec/services/jsmind_data_builder_spec.rb` |
+| 4 | Spec（更新） | `spec/requests/shares/shares_show_jsmind_spec.rb` を親タグ構造に合わせて更新 |
+
+## 13. 受入条件
+
+- [ ] マインドマップが「親タグ → ユーザー」の構造で表示される
+- [ ] 部屋タイプに一致する親タグのみノードとして表示される
+- [ ] 複数の親タグに趣味を持つユーザーは複数ノードに重複表示される（仕様）
+- [ ] マッチする趣味を持たないユーザーは「その他」ノード配下に表示される
+- [ ] 「その他」ノードはデフォルトで折りたたまれている
+- [ ] 「その他」に該当ユーザーが0人のときはノードが表示されない
+- [ ] 既存のユーザーノードクリック → 右ペイン表示が維持される
+- [ ] N+1 が発生していない（親タグ取得1回・membership関連はプリロード済み・profile/hobby 単位のクエリが発生しない）
+- [ ] RSpec / RuboCop 全通過
+
+## 14. この設計の結論
+
+`JsmindDataBuilder` サービスにロジックを集約し、コントローラはデータ取得のみに専念。親タグ軸に変更することでタグが増えても視認性が保たれる構造にする。「その他」ノードは折りたたみで全メンバー可視性も確保。将来的に右ペインで子タグを表示する #173 とも相性が良い設計。

--- a/spec/requests/shares/shares_show_jsmind_spec.rb
+++ b/spec/requests/shares/shares_show_jsmind_spec.rb
@@ -1,31 +1,32 @@
 require "rails_helper"
 
 RSpec.describe "Shares#show jsMind data", type: :request do
-  # 事前準備（User, Profile, Room, ShareLink）
-  let(:issuer_user) { create(:user, nickname: "issuer_nick") }
-  let(:issuer_profile) { create(:profile, user: issuer_user) }
-  let(:room) { create(:room, issuer_profile: issuer_profile) }
-  let(:share_link) { create(:share_link, room: room, expires_at: 1.hour.from_now) }
+  # 部屋オーナー（ログインユーザー）
+  let(:current_user)    { create(:user, nickname: "issuer_nick") }
+  let(:current_profile) { create(:profile, user: current_user) }
+  let(:chat_room)       { create(:room, issuer_profile: current_profile, room_type: :chat) }
+  let(:share_link)      { create(:share_link, room: chat_room, expires_at: 1.hour.from_now) }
+  let(:chat_parent_tag) { create(:parent_tag, name: "アニメ", room_type: :chat) }
 
-  # issuer_profile を room のメンバーに追加（jsMindデータ生成に必要）
-  # Shares#show にアクセスできるようログイン状態にする
   before do
-    create(:room_membership, room: room, profile: issuer_profile)
-    sign_in issuer_user
+    # 部屋に参加済み・ログイン状態にする
+    create(:room_membership, room: chat_room, profile: current_profile)
+    sign_in current_user
   end
 
-  it "趣味名がjsMindデータとしてレスポンスに含まれる" do
-    hobby = create(:hobby, name: "登山")
-    issuer_profile.hobbies << hobby
+  it "親タグ名がjsMindデータとしてレスポンスに含まれる" do
+    # chat 部屋で chat タイプの親タグに属する趣味を持つ
+    hobby = create(:hobby, name: "ワンピース", parent_tag: chat_parent_tag)
+    current_profile.hobbies << hobby
 
     get share_path(share_link.token)
 
-    expect(response.body).to include("登山")
+    expect(response.body).to include("アニメ")
   end
 
   it "ユーザーのnicknameがjsMindデータとしてレスポンスに含まれる" do
-    hobby = create(:hobby, name: "読書")
-    issuer_profile.hobbies << hobby
+    hobby = create(:hobby, name: "読書", parent_tag: chat_parent_tag)
+    current_profile.hobbies << hobby
 
     get share_path(share_link.token)
 
@@ -33,11 +34,11 @@ RSpec.describe "Shares#show jsMind data", type: :request do
   end
 
   it "人ノードの詳細URLがレスポンスに含まれる" do
-    hobby = create(:hobby, name: "料理")
-    issuer_profile.hobbies << hobby
+    hobby = create(:hobby, name: "料理", parent_tag: chat_parent_tag)
+    current_profile.hobbies << hobby
 
     get share_path(share_link.token)
 
-    expect(response.body).to include("/rooms/#{room.id}/members/#{issuer_profile.id}")
+    expect(response.body).to include("/rooms/#{chat_room.id}/members/#{current_profile.id}")
   end
 end

--- a/spec/services/jsmind_data_builder_spec.rb
+++ b/spec/services/jsmind_data_builder_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe JsmindDataBuilder do
+  # 部屋タイプ: chat
+  let(:chat_parent_tag)  { create(:parent_tag, name: "アニメ",        room_type: :chat,  position: 1) }
+  let(:chat_parent_tag2) { create(:parent_tag, name: "ゲーム",        room_type: :chat,  position: 2) }
+  let(:study_parent_tag) { create(:parent_tag, name: "プログラミング", room_type: :study, position: 1) }
+
+  let(:hobby_anime) { create(:hobby, name: "ワンピース", parent_tag: chat_parent_tag) }
+  let(:hobby_game)  { create(:hobby, name: "マイクラ",  parent_tag: chat_parent_tag2) }
+  let(:hobby_prog)  { create(:hobby, name: "Rails",    parent_tag: study_parent_tag) }
+
+  let(:chat_room) { create(:room, room_type: :chat) }
+
+  let(:current_user)    { create(:user, nickname: "user1") }
+  let(:current_profile) { create(:profile, user: current_user) }
+
+  # memberships は before ブロックで membership を作成してから評価する
+  let(:memberships) do
+    chat_room.room_memberships
+             .includes(profile: [:user, { profile_hobbies: { hobby: :parent_tag } }])
+  end
+
+  subject(:result) { described_class.new(chat_room, memberships).build }
+
+  describe "#build" do
+    before { create(:room_membership, room: chat_room, profile: current_profile) }
+
+    it "node_tree フォーマットを返す" do
+      expect(result[:format]).to eq "node_tree"
+    end
+
+    it "ルートノードの topic に部屋名が設定される" do
+      expect(result[:data][:topic]).to eq chat_room.label
+    end
+
+    context "部屋タイプに一致する趣味を持つユーザーがいる場合" do
+      before { current_profile.hobbies << hobby_anime }
+
+      it "親タグノードが children に含まれる" do
+        expect(result[:data][:children].map { |n| n[:topic] }).to include("アニメ")
+      end
+
+      it "ユーザーが親タグノードの children に含まれる" do
+        anime_node = result[:data][:children].find { |n| n[:topic] == "アニメ" }
+        expect(anime_node[:children].map { |n| n[:topic] }).to include("user1")
+      end
+
+      it "ユーザーノードの URL に /rooms/:room_id/members/:id が設定される" do
+        anime_node = result[:data][:children].find { |n| n[:topic] == "アニメ" }
+        user_node  = anime_node[:children].find { |n| n[:topic] == "user1" }
+        expect(user_node[:data][:url]).to eq "/rooms/#{chat_room.id}/members/#{current_profile.id}"
+      end
+
+      it "「その他」ノードが表示されない" do
+        expect(result[:data][:children].map { |n| n[:topic] }).not_to include("その他")
+      end
+    end
+
+    context "複数の親タグに趣味を持つユーザーがいる場合" do
+      before do
+        # chat_parent_tag（アニメ）と chat_parent_tag2（ゲーム）両方に趣味を持つ
+        current_profile.hobbies << hobby_anime
+        current_profile.hobbies << hobby_game
+      end
+
+      it "複数の親タグノードにユーザーが重複表示される" do
+        nodes_with_user = result[:data][:children].select do |n|
+          n[:children]&.any? { |u| u[:topic] == "user1" }
+        end
+        expect(nodes_with_user.size).to eq 2
+      end
+
+      it "「その他」ノードが表示されない" do
+        expect(result[:data][:children].map { |n| n[:topic] }).not_to include("その他")
+      end
+    end
+
+    context "部屋タイプに一致しない趣味しか持たないユーザーがいる場合" do
+      before { current_profile.hobbies << hobby_prog }
+
+      it "「その他」ノードが children に含まれる" do
+        expect(result[:data][:children].map { |n| n[:topic] }).to include("その他")
+      end
+
+      it "「その他」ノードは expanded: false" do
+        other_node = result[:data][:children].find { |n| n[:topic] == "その他" }
+        expect(other_node[:expanded]).to eq false
+      end
+
+      it "ユーザーが「その他」ノードの children に含まれる" do
+        other_node = result[:data][:children].find { |n| n[:topic] == "その他" }
+        expect(other_node[:children].map { |n| n[:topic] }).to include("user1")
+      end
+    end
+
+    context "趣味未登録のユーザーがいる場合" do
+      # 趣味なし（before ブロックに追記なし）
+
+      it "「その他」ノードに表示される" do
+        other_node = result[:data][:children].find { |n| n[:topic] == "その他" }
+        expect(other_node[:children].map { |n| n[:topic] }).to include("user1")
+      end
+    end
+
+    context "対象ユーザーが0人の親タグがある場合" do
+      before do
+        # chat_parent_tag（アニメ）のみ持つ → chat_parent_tag2（ゲーム）は0人
+        current_profile.hobbies << hobby_anime
+        chat_parent_tag2 # 事前生成して DB に存在させる
+      end
+
+      it "対象ユーザーが0人の親タグノードは表示されない" do
+        expect(result[:data][:children].map { |n| n[:topic] }).not_to include("ゲーム")
+      end
+    end
+  end
+end

--- a/spec/services/jsmind_data_builder_spec.rb
+++ b/spec/services/jsmind_data_builder_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe JsmindDataBuilder do
   # memberships は before ブロックで membership を作成してから評価する
   let(:memberships) do
     chat_room.room_memberships
-             .includes(profile: [:user, { profile_hobbies: { hobby: :parent_tag } }])
+             .includes(profile: [ :user, { profile_hobbies: { hobby: :parent_tag } } ])
   end
 
   subject(:result) { described_class.new(chat_room, memberships).build }


### PR DESCRIPTION
## Summary
- `SharesController` の jsMind データ構築ロジックを `JsmindDataBuilder` サービスに切り出し
- マインドマップのノード構造を「子タグ → ユーザー」から「親タグ → ユーザー」に変更
- 部屋タイプに一致する親タグのみ表示し、不一致ユーザーは「その他」ノード（デフォルト折りたたみ）に表示
- `profiles_by_parent_tag_id` Hash による O(1) ルックアップでパフォーマンス改善

## Test plan
- [x] `spec/services/jsmind_data_builder_spec.rb` — 13 examples, 0 failures
- [x] `spec/requests/shares/shares_show_jsmind_spec.rb` — 3 examples, 0 failures
- [x] 全テスト 327 examples, 0 failures
- [x] RuboCop no offenses detected
- [x] マインドマップが親タグ → ユーザー構造で表示されることを手動確認
- [x] 部屋タイプ不一致ユーザーが「その他」ノードに表示されることを手動確認

## Related
- Issue: #172
- 後続: #173（右ペインで子タグ一覧を表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)