### PR TITLE
feat: 未分類タグ管理画面を追加（一覧・検索・分類・統合） #171

### DIFF
--- a/app/controllers/admin/unclassified_hobbies_controller.rb
+++ b/app/controllers/admin/unclassified_hobbies_controller.rb
@@ -1,0 +1,32 @@
+class Admin::UnclassifiedHobbiesController < Admin::BaseController
+  def index
+    scope = Hobby.unclassified
+                 .left_joins(:profile_hobbies)
+                 .select("hobbies.*, COUNT(DISTINCT profile_hobbies.id) AS usage_count, COUNT(DISTINCT profile_hobbies.profile_id) AS user_count")
+                 .group("hobbies.id")
+    scope = scope.where("hobbies.name LIKE ?", "%#{ActiveRecord::Base.sanitize_sql_like(params[:q])}%") if params[:q].present?
+    @hobbies = scope
+    @parent_tags = ParentTag.order(:room_type, :position)
+    @all_hobbies = Hobby.order(:name).pluck(:name, :id)
+  end
+
+  def update
+    @hobby = Hobby.unclassified.find(params[:id])
+    if @hobby.update(parent_tag_id: params[:parent_tag_id])
+      redirect_to admin_unclassified_hobbies_path, notice: "分類しました"
+    else
+      redirect_to admin_unclassified_hobbies_path, alert: "分類に失敗しました"
+    end
+  end
+
+  def merge
+    source = Hobby.unclassified.find(params[:id])
+    target = Hobby.find(params[:target_hobby_id])
+    result = Admin::HobbyMergeService.call(source:, target:)
+    if result.success?
+      redirect_to admin_unclassified_hobbies_path, notice: "統合しました"
+    else
+      redirect_to admin_unclassified_hobbies_path, alert: result.error
+    end
+  end
+end

--- a/app/models/hobby.rb
+++ b/app/models/hobby.rb
@@ -1,6 +1,8 @@
 class Hobby < ApplicationRecord
   belongs_to :parent_tag, optional: true
 
+  scope :unclassified, -> { where(parent_tag: ParentTag.where(slug: "uncategorized")) }
+
   has_many :profile_hobbies, dependent: :destroy
   has_many :profiles, through: :profile_hobbies
 

--- a/app/services/admin/hobby_merge_service.rb
+++ b/app/services/admin/hobby_merge_service.rb
@@ -1,0 +1,26 @@
+class Admin::HobbyMergeService
+  Result = Struct.new(:success?, :error, keyword_init: true)
+
+  def self.call(source:, target:)
+    new(source:, target:).call
+  end
+
+  def initialize(source:, target:)
+    @source = source
+    @target = target
+  end
+
+  def call
+    return Result.new(success?: false, error: "統合元と統合先が同じです") if @source.id == @target.id
+
+    ActiveRecord::Base.transaction do
+      duplicate_profile_ids = ProfileHobby.where(hobby_id: @target.id).pluck(:profile_id)
+      ProfileHobby.where(hobby_id: @source.id, profile_id: duplicate_profile_ids).delete_all
+      ProfileHobby.where(hobby_id: @source.id).update_all(hobby_id: @target.id)
+      @source.destroy!
+    end
+    Result.new(success?: true, error: nil)
+  rescue ActiveRecord::RecordNotDestroyed, ActiveRecord::RecordInvalid => e
+    Result.new(success?: false, error: e.message)
+  end
+end

--- a/app/views/admin/unclassified_hobbies/index.html.erb
+++ b/app/views/admin/unclassified_hobbies/index.html.erb
@@ -1,0 +1,51 @@
+<div style="max-width: 72rem; margin: 0 auto;">
+  <h1 style="font-size: 1.5rem; font-weight: bold; color: #f9fafb; margin-bottom: 1.5rem;">未分類タグ管理</h1>
+
+  <%= form_with url: admin_unclassified_hobbies_path, method: :get, local: true do |f| %>
+    <%= f.text_field :q, value: params[:q], placeholder: "タグ名で検索",
+          style: "background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.375rem 0.75rem; border-radius: 0.25rem;" %>
+    <%= f.submit "検索",
+          style: "margin-left: 0.5rem; background: #374151; color: #f9fafb; border: none; padding: 0.375rem 0.75rem; border-radius: 0.25rem; cursor: pointer;" %>
+  <% end %>
+
+  <table style="width: 100%; border-collapse: collapse; margin-top: 1.5rem; color: #d1d5db;">
+    <thead>
+      <tr style="border-bottom: 1px solid #374151; text-align: left;">
+        <th style="padding: 0.5rem 1rem;">タグ名</th>
+        <th style="padding: 0.5rem 1rem;">使用回数</th>
+        <th style="padding: 0.5rem 1rem;">ユーザー数</th>
+        <th style="padding: 0.5rem 1rem;">分類</th>
+        <th style="padding: 0.5rem 1rem;">統合</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @hobbies.each do |hobby| %>
+        <tr data-hobby-id="<%= hobby.id %>" style="border-bottom: 1px solid #1f2937;">
+          <td data-col="name" style="padding: 0.5rem 1rem;"><%= hobby.name %></td>
+          <td style="padding: 0.5rem 1rem;"><%= hobby.usage_count %></td>
+          <td style="padding: 0.5rem 1rem;"><%= hobby.user_count %></td>
+          <td style="padding: 0.5rem 1rem;">
+            <%= form_with url: admin_unclassified_hobby_path(hobby), method: :patch, local: true do |f| %>
+              <%= select_tag :parent_tag_id,
+                    options_for_select(@parent_tags.map { |pt| [pt.name, pt.id] }),
+                    prompt: "選択してください",
+                    style: "background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.25rem;" %>
+              <%= f.submit "分類",
+                    style: "margin-left: 0.25rem; background: #2563eb; color: white; border: none; padding: 0.25rem 0.75rem; border-radius: 0.25rem; cursor: pointer;" %>
+            <% end %>
+          </td>
+          <td style="padding: 0.5rem 1rem;">
+            <%= form_with url: merge_admin_unclassified_hobby_path(hobby), method: :post, local: true do |f| %>
+              <%= select_tag :target_hobby_id,
+                    options_for_select(@all_hobbies.reject { |(_, id)| id == hobby.id }),
+                    prompt: "選択してください",
+                    style: "background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.25rem;" %>
+              <%= submit_tag "統合",
+                    style: "margin-left: 0.25rem; background: #dc2626; color: white; border: none; padding: 0.25rem 0.75rem; border-radius: 0.25rem; cursor: pointer;" %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -12,6 +12,7 @@
     <header style="background: #111827; border-bottom: 1px solid #374151; padding: 0.75rem 1.5rem; display: flex; align-items: center; gap: 1.5rem;">
       <span style="font-weight: bold; color: #f9fafb;">管理画面</span>
       <%= link_to "ダッシュボード", admin_root_path, style: "color: #9ca3af; text-decoration: none; font-size: 0.875rem;" %>
+      <%= link_to "未分類タグ管理", admin_unclassified_hobbies_path, style: "color: #9ca3af; text-decoration: none; font-size: 0.875rem;" %>
       <span style="margin-left: auto;">
         <%= link_to "サイトに戻る", root_path, style: "color: #9ca3af; text-decoration: none; font-size: 0.875rem;" %>
       </span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,5 +63,10 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root "dashboards#show"
+    resources :unclassified_hobbies, only: [:index, :update] do
+      member do
+        post :merge
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root "dashboards#show"
-    resources :unclassified_hobbies, only: [:index, :update] do
+    resources :unclassified_hobbies, only: [ :index, :update ] do
       member do
         post :merge
       end

--- a/docs/designs/2026-04-10-unclassified-hobbies-admin.md
+++ b/docs/designs/2026-04-10-unclassified-hobbies-admin.md
@@ -1,0 +1,268 @@
+# 未分類タグ管理画面 設計書
+
+**日付:** 2026-04-10
+**Issue:** #171
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+- `Admin::UnclassifiedHobbiesController`（index / update / merge）
+- `Admin::HobbyMergeService`（統合ロジック）
+- 管理画面ビュー（一覧・分類フォーム・統合フォーム）
+- adminルーティング拡張
+
+マイグレーション不要（`hobbies.parent_tag_id` はすでに nullable）。
+
+## 2. 目的
+- 未分類タグ（`parent_tag_id = NULL`）を管理者が親タグへ振り分けられる
+- 表記ゆれタグを統合し、`profile_hobbies` の一貫性を保つ
+
+## 3. スコープ
+
+### 含むもの
+- 未分類タグ一覧（タグ名・使用回数・ユーザー数）
+- 検索機能
+- 分類機能（親タグへの振り分け）
+- 統合機能（profile_hobbies 付け替え＋元タグ削除）
+
+### 含まないもの
+- 親タグ自体の追加・編集・削除（将来対応）
+- バッチ分類（複数タグの一括操作）（将来対応）
+- 自動分類提案機能（将来対応）
+- 統合先ドロップダウンの検索UI（リストが長い場合の将来対応）
+
+## 4. 設計方針
+
+### 統合UI — ドロップダウンの選択肢
+
+| 方式 | 実装コスト | UX | 懸念 |
+|---|---|---|---|
+| A: 全タグから選択 | 低 | 表記ゆれ先が未分類でも選べる | リストが長い |
+| B: 分類済みタグのみ | 低 | シンプル | 未分類→未分類統合ができない |
+
+**採用: A（全タグから選択、自分自身を除外）**
+表記ゆれは未分類タグ同士の統合もありうるため。リストが長くなる問題は将来的に検索UIで対応。
+
+### 異常系方針
+- 統合元＝統合先の場合はバリデーションエラーでフォームに戻す
+- 統合先が存在しない場合は 404（ドロップダウン選択なので念のための安全網）
+
+## 5. データ設計
+
+マイグレーション不要。
+
+| テーブル | 操作 | 内容 |
+|---|---|---|
+| `hobbies` | UPDATE | `parent_tag_id` を設定（分類）または DELETE（統合後） |
+| `profile_hobbies` | UPDATE | 統合時に `hobby_id` を統合先に付け替え（重複は削除） |
+
+### DB 制約
+
+| カラム | 制約 | 理由 |
+|---|---|---|
+| `profile_hobbies(profile_id, hobby_id)` | unique | 統合後に重複が発生しうるため DELETE で対処 |
+
+### ER 図
+
+```mermaid
+erDiagram
+  parent_tags {
+    bigint id PK
+    string name "NOT NULL"
+    string slug "NOT NULL"
+    integer room_type
+    integer position "NOT NULL"
+  }
+  hobbies {
+    bigint id PK
+    string name "NOT NULL unique"
+    bigint parent_tag_id FK "nullable=未分類"
+    string normalized_name
+  }
+  profile_hobbies {
+    bigint id PK
+    bigint profile_id FK "NOT NULL"
+    bigint hobby_id FK "NOT NULL"
+    string description
+  }
+  profiles {
+    bigint id PK
+    bigint user_id FK "NOT NULL unique"
+    text bio
+  }
+
+  parent_tags ||--o{ hobbies : "has_many"
+  hobbies ||--o{ profile_hobbies : "has_many"
+  profiles ||--o{ profile_hobbies : "has_many"
+```
+
+## 6. 画面・アクセス制御の流れ
+
+### シーケンス図（分類）
+
+```mermaid
+sequenceDiagram
+  participant A as Admin
+  participant C as UnclassifiedHobbiesCtrl
+  participant M as Hobby
+
+  A->>C: PATCH /admin/unclassified_hobbies/:id
+  C->>C: require_admin!
+  C->>M: hobby.update(parent_tag_id:)
+  M-->>C: success/fail
+  C-->>A: redirect index (flash)
+```
+
+### シーケンス図（統合）
+
+```mermaid
+sequenceDiagram
+  participant A as Admin
+  participant C as UnclassifiedHobbiesCtrl
+  participant S as HobbyMergeService
+  participant PH as ProfileHobby
+  participant H as Hobby
+
+  A->>C: POST /admin/unclassified_hobbies/:id/merge
+  C->>C: require_admin!
+  C->>S: call(source:, target:)
+  S->>S: validate source != target
+  S->>PH: transaction開始
+  S->>PH: 重複する profile_hobbies を DELETE
+  S->>PH: 残りを target_id に UPDATE
+  S->>H: source hobby を DELETE
+  S-->>C: success/error
+  C-->>A: redirect index (flash)
+```
+
+## 7. アプリケーション設計
+
+### Controller
+
+```ruby
+class Admin::UnclassifiedHobbiesController < Admin::BaseController
+  def index
+    @hobbies = Hobby.where(parent_tag_id: nil)
+                    .left_joins(:profile_hobbies)
+                    .select("hobbies.*, COUNT(DISTINCT profile_hobbies.id) AS usage_count,
+                             COUNT(DISTINCT profile_hobbies.profile_id) AS user_count")
+                    .group("hobbies.id")
+                    .then { |q| params[:q].present? ? q.where("hobbies.name LIKE ?", "%#{params[:q]}%") : q }
+    @parent_tags = ParentTag.order(:room_type, :position)
+    @all_hobbies = Hobby.order(:name)
+  end
+
+  def update
+    @hobby = Hobby.where(parent_tag_id: nil).find(params[:id])
+    if @hobby.update(parent_tag_id: params[:hobby][:parent_tag_id])
+      redirect_to admin_unclassified_hobbies_path, notice: "分類しました"
+    else
+      redirect_to admin_unclassified_hobbies_path, alert: "分類に失敗しました"
+    end
+  end
+
+  def merge
+    source = Hobby.find(params[:id])
+    target = Hobby.find(params[:target_hobby_id])
+    result = Admin::HobbyMergeService.call(source:, target:)
+    if result.success?
+      redirect_to admin_unclassified_hobbies_path, notice: "統合しました"
+    else
+      redirect_to admin_unclassified_hobbies_path, alert: result.error
+    end
+  end
+end
+```
+
+### Service（`app/services/admin/hobby_merge_service.rb`）
+
+```ruby
+class Admin::HobbyMergeService
+  Result = Struct.new(:success?, :error, keyword_init: true)
+
+  def self.call(source:, target:)
+    new(source:, target:).call
+  end
+
+  def initialize(source:, target:)
+    @source = source
+    @target = target
+  end
+
+  def call
+    return Result.new(success?: false, error: "統合元と統合先が同じです") if @source.id == @target.id
+
+    ActiveRecord::Base.transaction do
+      duplicate_profile_ids = ProfileHobby.where(hobby_id: @target.id).pluck(:profile_id)
+      ProfileHobby.where(hobby_id: @source.id, profile_id: duplicate_profile_ids).delete_all
+      ProfileHobby.where(hobby_id: @source.id).update_all(hobby_id: @target.id)
+      @source.destroy!
+    end
+    Result.new(success?: true, error: nil)
+  rescue => e
+    Result.new(success?: false, error: e.message)
+  end
+end
+```
+
+## 8. ルーティング設計
+
+```ruby
+namespace :admin do
+  root "dashboards#show"
+  resources :unclassified_hobbies, only: [:index, :update] do
+    member do
+      post :merge
+    end
+  end
+end
+```
+
+**設計意図:** member route の `merge` は特定リソース（source hobby）に対する操作のため、`member` に配置。
+
+## 9. レイアウト / UI 設計
+
+既存の `admin` レイアウトを使用。各行にインラインフォームを配置：
+- **[分類]** → 親タグの select ドロップダウン + 保存ボタン
+- **[統合]** → 全タグの select ドロップダウン（自分自身を除外）+ 統合ボタン
+
+## 10. クエリ・性能面
+
+| クエリ | 対策 |
+|---|---|
+| 未分類一覧（usage_count / user_count） | `left_joins` + `group` + `select` で1クエリ |
+| 親タグ一覧 | `@parent_tags` でまとめて取得 |
+| 統合先選択肢 | `@all_hobbies` でまとめて取得 |
+
+N+1なし。追加インデックス不要（`parent_tag_id` にインデックス済み）。
+
+## 11. トランザクション / Service 分離
+
+**トランザクション:** 必要（`profile_hobbies` の付け替え＋`hobbies` の削除が不可分）
+**Service分離:** 要（`Admin::HobbyMergeService`）
+→ 2モデル跨ぎ＋トランザクション＋削除処理のため、design.mdの分離ポリシーに完全合致。
+
+## 12. 実装対象一覧
+
+| # | 対象 | 内容 |
+|---|---|---|
+| 1 | Route | `admin/unclassified_hobbies` 追加 |
+| 2 | Controller | `Admin::UnclassifiedHobbiesController`（index/update/merge） |
+| 3 | Service | `Admin::HobbyMergeService` |
+| 4 | View | `app/views/admin/unclassified_hobbies/index.html.erb` |
+| 5 | Spec | `spec/system/admin/unclassified_hobbies_spec.rb` |
+| 6 | Spec | `spec/services/admin/hobby_merge_service_spec.rb` |
+
+## 13. 受入条件
+
+- [ ] 未分類タグの一覧が表示される（タグ名・使用回数・ユーザー数）
+- [ ] タグを親タグに分類できる（`parent_tag_id` 更新）
+- [ ] タグを別のタグに統合できる（`profile_hobbies` 付け替え＋元タグ削除）
+- [ ] 検索でタグを絞り込める
+- [ ] adminユーザーのみアクセスできる
+- [ ] RSpec / RuboCop 全通過
+
+## 14. この設計の結論
+
+マイグレーション不要でService（`HobbyMergeService`）にトランザクションを集約。コントローラは薄く保ち、統合ロジックのみServiceに切り出す設計。将来的なバッチ分類・自動分類提案は本設計を拡張する形で対応可能。

--- a/spec/services/admin/hobby_merge_service_spec.rb
+++ b/spec/services/admin/hobby_merge_service_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe Admin::HobbyMergeService do
+  describe ".call" do
+    let!(:source) { create(:hobby, name: "rails") }
+    let!(:target) { create(:hobby, name: "Rails") }
+
+    context "正常系: profile_hobbiesがない場合" do
+      it "sourceが削除される" do
+        described_class.call(source:, target:)
+        expect(Hobby.find_by(id: source.id)).to be_nil
+      end
+
+      it "success?がtrueを返す" do
+        result = described_class.call(source:, target:)
+        expect(result.success?).to be true
+      end
+    end
+
+    context "正常系: profile_hobbiesがある場合" do
+      let!(:admin_profile) { create(:profile) }
+
+      before { create(:profile_hobby, profile: admin_profile, hobby: source) }
+
+      it "sourceのprofile_hobbiesがtargetに付け替えられる" do
+        described_class.call(source:, target:)
+        expect(ProfileHobby.where(hobby_id: target.id, profile_id: admin_profile.id)).to exist
+      end
+
+      it "sourceが削除される" do
+        described_class.call(source:, target:)
+        expect(Hobby.find_by(id: source.id)).to be_nil
+      end
+    end
+
+    context "正常系: 重複するprofile_hobbiesがある場合" do
+      let!(:admin_profile) { create(:profile) }
+
+      before do
+        # 同一プロフィールがsourceとtarget両方を持つ場合
+        create(:profile_hobby, profile: admin_profile, hobby: source)
+        create(:profile_hobby, profile: admin_profile, hobby: target)
+      end
+
+      it "重複するprofile_hobbiesが1件になる" do
+        described_class.call(source:, target:)
+        expect(ProfileHobby.where(profile_id: admin_profile.id, hobby_id: target.id).count).to eq 1
+      end
+
+      it "sourceが削除される" do
+        described_class.call(source:, target:)
+        expect(Hobby.find_by(id: source.id)).to be_nil
+      end
+    end
+
+    context "異常系: 統合元と統合先が同じ場合" do
+      it "success?がfalseを返す" do
+        result = described_class.call(source:, target: source)
+        expect(result.success?).to be false
+      end
+
+      it "errorメッセージを返す" do
+        result = described_class.call(source:, target: source)
+        expect(result.error).to eq "統合元と統合先が同じです"
+      end
+
+      it "sourceは削除されない" do
+        described_class.call(source:, target: source)
+        expect(Hobby.find_by(id: source.id)).to be_present
+      end
+    end
+  end
+end

--- a/spec/system/admin/unclassified_hobbies_spec.rb
+++ b/spec/system/admin/unclassified_hobbies_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Admin 未分類タグ管理", type: :system do
   let!(:admin_user) { create(:user, :admin) }
   let!(:uncategorized_parent_tag) { ParentTag.find_or_create_by!(slug: "uncategorized") { |pt| pt.name = "未分類" } }
-  let!(:programming_parent_tag)   { create(:parent_tag, name: "プログラミング", room_type: :study, position: 1) }
+  let!(:programming_parent_tag)   { ParentTag.find_or_create_by!(slug: "programming") { |pt| pt.name = "プログラミング"; pt.room_type = :study; pt.position = 1 } }
 
   before { login_as(admin_user, scope: :user) }
 

--- a/spec/system/admin/unclassified_hobbies_spec.rb
+++ b/spec/system/admin/unclassified_hobbies_spec.rb
@@ -1,0 +1,138 @@
+require "rails_helper"
+
+RSpec.describe "Admin 未分類タグ管理", type: :system do
+  let!(:admin_user) { create(:user, :admin) }
+  let!(:uncategorized_parent_tag) { create(:parent_tag, name: "未分類", slug: "uncategorized") }
+  let!(:programming_parent_tag)   { create(:parent_tag, name: "プログラミング", room_type: :study, position: 1) }
+
+  before { login_as(admin_user, scope: :user) }
+
+  describe "一覧表示" do
+    let!(:unclassified_hobby) { create(:hobby, name: "rails", parent_tag: uncategorized_parent_tag) }
+    let!(:classified_hobby)   { create(:hobby, name: "Ruby", parent_tag: programming_parent_tag) }
+
+    before { visit admin_unclassified_hobbies_path }
+
+    it "未分類タグが表示される" do
+      expect(page).to have_content "rails"
+    end
+
+    it "分類済みタグは表示されない" do
+      # 名前列にのみ絞って確認（mergeドロップダウンは全タグを含む）
+      expect(page).not_to have_css("td[data-col='name']", text: "Ruby")
+    end
+
+    it "タグ名・使用回数・ユーザー数の列ヘッダーが表示される" do
+      expect(page).to have_content "タグ名"
+      expect(page).to have_content "使用回数"
+      expect(page).to have_content "ユーザー数"
+    end
+  end
+
+  describe "使用回数・ユーザー数の集計" do
+    let!(:target_hobby) { create(:hobby, name: "python", parent_tag: uncategorized_parent_tag) }
+    let!(:first_profile)  { create(:profile) }
+    let!(:second_profile) { create(:profile) }
+
+    before do
+      # 2ユーザーがpythonタグを使用している
+      create(:profile_hobby, profile: first_profile,  hobby: target_hobby)
+      create(:profile_hobby, profile: second_profile, hobby: target_hobby)
+      visit admin_unclassified_hobbies_path
+    end
+
+    it "使用回数が2と表示される" do
+      within "[data-hobby-id='#{target_hobby.id}']" do
+        expect(page).to have_content "2"
+      end
+    end
+  end
+
+  describe "検索" do
+    let!(:rails_hobby)  { create(:hobby, name: "rails",  parent_tag: uncategorized_parent_tag) }
+    let!(:python_hobby) { create(:hobby, name: "python", parent_tag: uncategorized_parent_tag) }
+
+    before { visit admin_unclassified_hobbies_path }
+
+    it "検索ワードに一致するタグだけが表示される" do
+      # rails で検索
+      fill_in "q", with: "rails"
+      click_button "検索"
+      # 名前列にのみ絞って確認（mergeドロップダウンは全タグを含む）
+      expect(page).to     have_css("td[data-col='name']", text: "rails")
+      expect(page).not_to have_css("td[data-col='name']", text: "python")
+    end
+  end
+
+  describe "分類" do
+    let!(:unclassified_rails) { create(:hobby, name: "rails", parent_tag: uncategorized_parent_tag) }
+
+    before { visit admin_unclassified_hobbies_path }
+
+    it "親タグを選択して保存するとフラッシュが表示される" do
+      # parent_tag_id selectで親タグを選択して分類ボタンを押す
+      select "プログラミング", from: "parent_tag_id"
+      click_button "分類"
+      expect(page).to have_content "分類しました"
+    end
+
+    it "分類後にparent_tag_idが更新される" do
+      select "プログラミング", from: "parent_tag_id"
+      click_button "分類"
+      expect(unclassified_rails.reload.parent_tag_id).to eq programming_parent_tag.id
+    end
+
+    it "分類後に一覧から消える" do
+      select "プログラミング", from: "parent_tag_id"
+      click_button "分類"
+      expect(page).not_to have_css("td[data-col='name']", text: "rails")
+    end
+  end
+
+  describe "統合" do
+    let!(:source_rails_hobby)  { create(:hobby, name: "rails",  parent_tag: uncategorized_parent_tag) }
+    let!(:target_Rails_hobby)  { create(:hobby, name: "Rails") }
+    let!(:source_hobby_owner_profile) { create(:profile) }
+
+    before do
+      # sourceタグを持つプロフィールを作成
+      create(:profile_hobby, profile: source_hobby_owner_profile, hobby: source_rails_hobby)
+      visit admin_unclassified_hobbies_path
+    end
+
+    it "統合するとフラッシュが表示される" do
+      within "[data-hobby-id='#{source_rails_hobby.id}']" do
+        select "Rails", from: "target_hobby_id"
+        click_button "統合"
+      end
+      expect(page).to have_content "統合しました"
+    end
+
+    it "統合後にprofile_hobbiesがtargetに付け替えられる" do
+      within "[data-hobby-id='#{source_rails_hobby.id}']" do
+        select "Rails", from: "target_hobby_id"
+        click_button "統合"
+      end
+      expect(ProfileHobby.where(hobby_id: target_Rails_hobby.id, profile_id: source_hobby_owner_profile.id)).to exist
+    end
+
+    it "統合後にsource hobbyが削除される" do
+      within "[data-hobby-id='#{source_rails_hobby.id}']" do
+        select "Rails", from: "target_hobby_id"
+        click_button "統合"
+      end
+      expect(Hobby.find_by(id: source_rails_hobby.id)).to be_nil
+    end
+  end
+
+  describe "アクセス制御" do
+    let!(:normal_user) { create(:user) }
+
+    it "一般ユーザーはrootにリダイレクトされる" do
+      # 一般ユーザーでログイン
+      login_as(normal_user, scope: :user)
+      visit admin_unclassified_hobbies_path
+      expect(page).to have_current_path root_path
+    end
+  end
+end

--- a/spec/system/admin/unclassified_hobbies_spec.rb
+++ b/spec/system/admin/unclassified_hobbies_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Admin 未分類タグ管理", type: :system do
   let!(:admin_user) { create(:user, :admin) }
-  let!(:uncategorized_parent_tag) { create(:parent_tag, name: "未分類", slug: "uncategorized") }
+  let!(:uncategorized_parent_tag) { ParentTag.find_or_create_by!(slug: "uncategorized") { |pt| pt.name = "未分類" } }
   let!(:programming_parent_tag)   { create(:parent_tag, name: "プログラミング", room_type: :study, position: 1) }
 
   before { login_as(admin_user, scope: :user) }


### PR DESCRIPTION
## Summary
- 未分類タグ（`slug: "uncategorized"` の親タグに属する hobby）の一覧・検索・分類・統合機能を管理画面に追加
- `Admin::HobbyMergeService` を新規作成し、タグ統合時の `profile_hobbies` 付け替えロジックを分離
- `Hobby.unclassified` スコープを追加（`parent_tag.slug = "uncategorized"` で絞り込み）

## Test plan
- [x] 未分類タグ一覧が表示される（タグ名・使用回数・ユーザー数）
- [x] 検索ワードでタグを絞り込める
- [x] 親タグを選択して分類できる（`parent_tag_id` が更新される）
- [x] 分類後に一覧から消える
- [x] 統合するとフラッシュが表示され、`profile_hobbies` が付け替えられ、元タグが削除される
- [x] 統合先・統合元が同じ場合はエラーになる
- [x] 一般ユーザーはアクセスできない（root にリダイレクト）

## Related
- Issue: #171