### PR TITLE
feat: ログインフォームにremember me（オートログイン）を追加 #70

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -16,6 +16,11 @@
             placeholder: "pass1234" %>
     </div>
 
+    <div style="margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem;">
+      <%= f.check_box :remember_me, style: "width: 1rem; height: 1rem; accent-color: #3b82f6; cursor: pointer;" %>
+      <%= f.label :remember_me, "ログイン状態を保持する", style: "font-size: 0.875rem; color: #d1d5db; cursor: pointer; margin: 0;" %>
+    </div>
+
     <div style="margin-bottom: 1.5rem; text-align: right;">
       <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name),
             style: "font-size: 0.75rem; color: #60a5fa; text-decoration: none;" %>

--- a/spec/system/auth/login_spec.rb
+++ b/spec/system/auth/login_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe "ログイン画面", type: :system do
   it "「ユーザー登録はこちら」リンクが表示される" do
     expect(page).to have_link("ユーザー登録はこちら", href: new_user_registration_path)
   end
+
+  it "「ログイン状態を保持する」チェックボックスが表示される" do
+    expect(page).to have_field("ログイン状態を保持する", type: :checkbox)
+  end
 end

--- a/spec/system/auth/login_spec.rb
+++ b/spec/system/auth/login_spec.rb
@@ -14,4 +14,30 @@ RSpec.describe "ログイン画面", type: :system do
   it "「ログイン状態を保持する」チェックボックスが表示される" do
     expect(page).to have_field("ログイン状態を保持する", type: :checkbox)
   end
+
+  describe "remember me" do
+    # ビューのラベルにfor属性がないため、fill_in はフィールドIDで指定する
+    let(:password) { "password123" }
+    let(:login_user) { create(:user, password: password) }
+
+    before do
+      fill_in "user_email", with: login_user.email
+      fill_in "user_password", with: password
+    end
+
+    it "チェックボックスをオンにしてログインすると remember_created_at が設定される" do
+      check "ログイン状態を保持する"
+      click_button "ログイン"
+
+      # Devise がサーバー側で remember_created_at を更新することを確認
+      expect(login_user.reload.remember_created_at).to be_present
+    end
+
+    it "チェックボックスをオフにしてログインすると remember_created_at が設定されない" do
+      # チェックボックスはデフォルトでオフ（デフォルト動作の確認）
+      click_button "ログイン"
+
+      expect(login_user.reload.remember_created_at).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- ログインフォームに「ログイン状態を保持する」チェックボックスを追加
- Devise の `rememberable` モジュールを活用（マイグレーション不要）
- チェックありでログインすると2週間ログイン状態が維持される

## Test plan
- [x] ログインフォームに「ログイン状態を保持する」チェックボックスが表示される
- [x] チェックありでログインすると `remember_created_at` が設定される
- [x] チェックなしでログインすると `remember_created_at` が設定されない
- [x] RSpec 11 examples, 0 failures
- [x] RuboCop no offenses

## Related
- Issue: #70
- OAuth対応（Google/Discord）は #199 で別途実施