### PR TITLE
feat: action_policy 導入 + SharesController アクセス権判定を Policy に分離 #201

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,6 @@ gem "cloudinary"
 
 # Active Storage バリデーション（スプーフィング対策込み）
 gem "active_storage_validations"
+
+# 認可
+gem "action_policy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    action_policy (0.7.6)
+      ruby-next-core (>= 1.0)
     actioncable (7.2.3)
       actionpack (= 7.2.3)
       activesupport (= 7.2.3)
@@ -396,6 +398,7 @@ GEM
     rubocop-rspec (3.9.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
+    ruby-next-core (1.2.0)
     ruby-progressbar (1.13.0)
     ruby-vips (2.3.0)
       ffi (~> 1.12)
@@ -477,6 +480,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  action_policy
   active_storage_validations
   bootsnap
   brakeman (~> 8.0)
@@ -515,6 +519,7 @@ DEPENDENCIES
   webmock
 
 CHECKSUMS
+  action_policy (0.7.6) sha256=a80156671e6b7784a2f1fa3a5f347da27c7e13abe7b1c9aab81772839794002d
   actioncable (7.2.3) sha256=e15d17b245f1dfe7cafdda4a0c6f7ba8ebaab1af33884415e09cfef4e93ad4f9
   actionmailbox (7.2.3) sha256=16bbf0a7c330f2d08d52d5e3c1b03813a8ef60bfb0a48e89c0bf92b069cb4d5e
   actionmailer (7.2.3) sha256=68d646b852a6d2b25d8834fc796c3dc10f76a4c7fd77b3251c3f4dd832ec8ab8
@@ -660,6 +665,7 @@ CHECKSUMS
   rubocop-rails (2.34.3) sha256=10d37989024865ecda8199f311f3faca990143fbac967de943f88aca11eb9ad2
   rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
   rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
+  ruby-next-core (1.2.0) sha256=f6a7d00bb5186cecbb02f7f1845a0f3a2c9788d35b6ccff5c9be3f0d46799b86
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby-vips (2.3.0) sha256=e685ec02c13969912debbd98019e50492e12989282da5f37d05f5471442f5374
   ruby_http_client (3.6.0) sha256=9308505d3a0421810d2dc012d79d986f7d360d5b02178641190849a22fd279f2

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,7 @@
 class ApplicationController < ActionController::Base
+  include ActionPolicy::Controller
+  authorize :user, through: :current_user
+
   allow_browser versions: :modern
   before_action :configure_permitted_parameters, if: :devise_controller?
 

--- a/app/controllers/shares_controller.rb
+++ b/app/controllers/shares_controller.rb
@@ -1,53 +1,35 @@
-# 共有リンク（token）から部屋ページを表示するコントローラ
-# 主な責務：
-#   1. トークンの有効性検証（存在・有効期限）
-#   2. ロック状態に応じた参加制御
-#   3. 入室処理（RoomMembership の作成）
-#   4. マインドマップ表示用データの準備
 class SharesController < ApplicationController
   before_action :authenticate_user!
+  rescue_from ActionPolicy::Unauthorized, with: :handle_unauthorized
 
   def show
     share_link      = ShareLink.includes(:room).find_by!(token: params[:token])
     @room           = share_link.room
     @viewer_profile = current_user.profile
 
-    # 期限切れの場合は未参加者のみ 410 Gone を返す。
-    # 既存メンバーはリンクが切れていても閲覧を継続できる。
-    if share_link.expired?
-      return head :gone unless @viewer_profile && RoomMembership.exists?(room: @room, profile: @viewer_profile)
+    authorize! share_link, to: :show?
+
+    unless allowed_to?(:join?, share_link)
+      flash.now[:alert] = "この部屋は現在ロック中のため参加できません"
+      @memberships = memberships_for_display
+      @jsmind_data = JsmindDataBuilder.new(@room, @memberships).build
+      return render :show
     end
 
-    # ロック中の部屋は未参加・非オーナーの入室を拒否する。
-    # ページ自体は表示し、flash で理由を伝える（完全な 403 ではなく閲覧は許容）。
-    # 既存メンバー・オーナーはロック状態に関わらず通過する。
-    if @room.locked?
-      already_member = @viewer_profile && RoomMembership.exists?(room: @room, profile: @viewer_profile)
-      is_owner       = @viewer_profile&.id == @room.issuer_profile_id
-
-      unless already_member || is_owner
-        flash.now[:alert] = "この部屋は現在ロック中のため参加できません"
-        @memberships = memberships_for_display
-        @jsmind_data = JsmindDataBuilder.new(@room, @memberships).build
-        return render :show
-      end
-    end
-
-    # 初回アクセス時に入室処理を行う。
-    # find_or_create_by! により二重参加は発生しない。
     RoomMembership.find_or_create_by!(room: @room, profile: @viewer_profile) if @viewer_profile
-
     @memberships = memberships_for_display
     @jsmind_data = JsmindDataBuilder.new(@room, @memberships).build
   end
 
   private
 
-  # マインドマップ表示に必要な membership 一覧を取得する。
-  # includes で N+1 を防止する。
   def memberships_for_display
     @room.room_memberships
          .includes(profile: [ :user, { profile_hobbies: { hobby: :parent_tag } } ])
          .order(created_at: :asc)
+  end
+
+  def handle_unauthorized
+    head :gone
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,2 @@
+class ApplicationPolicy < ActionPolicy::Base
+end

--- a/app/policies/share_link_policy.rb
+++ b/app/policies/share_link_policy.rb
@@ -1,0 +1,31 @@
+class ShareLinkPolicy < ApplicationPolicy
+  # user   = current_user（action_policy が自動注入）
+  # record = share_link
+
+  # 期限切れでも既存メンバーなら閲覧継続可
+  def show?
+    !record.expired? || member?
+  end
+
+  # ロック中は既存メンバー or オーナーのみ参加可
+  def join?
+    !record.room.locked? || member? || owner?
+  end
+
+  private
+
+  def member?
+    return @member if instance_variable_defined?(:@member)
+
+    @member = viewer_profile.present? &&
+      RoomMembership.exists?(room: record.room, profile: viewer_profile)
+  end
+
+  def owner?
+    viewer_profile&.id == record.room.issuer_profile_id
+  end
+
+  def viewer_profile
+    user.profile
+  end
+end

--- a/docs/designs/2026-04-11-action-policy-shares-controller.md
+++ b/docs/designs/2026-04-11-action-policy-shares-controller.md
@@ -1,0 +1,230 @@
+# action_policy 導入 + SharesController アクセス権判定分離 設計書
+
+**日付:** 2026-04-11
+**Issue:** 未採番
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+
+- `Gemfile` に `gem "action_policy"` を追加
+- `app/policies/application_policy.rb`（新規）: ベースポリシー
+- `app/policies/share_link_policy.rb`（新規）: ShareLink のアクセス権判定
+- `app/controllers/application_controller.rb`（変更）: `include ActionPolicy::Controller`
+- `app/controllers/shares_controller.rb`（変更）: `authorize!` / `allowed_to?` に委譲
+- `spec/policies/share_link_policy_spec.rb`（新規）: Policy ユニットテスト
+
+---
+
+## 2. 目的
+
+1. アクセス権判定を Policy に切り出し、Controller を HTTP の入出力に専念させる
+2. action_policy の `authorize!` / `allowed_to?` によりテスト可能な単一責務クラスにする
+3. 将来他コントローラへの認可追加も同じパターンで拡張できる基盤を作る
+
+---
+
+## 3. スコープ
+
+### 含むもの
+- action_policy gem 導入とベース設定
+- `ShareLinkPolicy#show?`（期限切れ判定）・`#join?`（ロック判定）の実装
+- Controller の `rescue_from ActionPolicy::Unauthorized → 410 Gone`
+
+### 含まないもの
+- 他コントローラへの `authorize!` 追加（別 Issue で段階的に導入）
+- Pundit の利用（今回は採用しない）
+
+---
+
+## 4. 設計方針
+
+| 方式 | 実装コスト | 将来の拡張 | 現状との相性 |
+|------|----------|-----------|------------|
+| **action_policy（採用）** | 中（gem + ApplicationPolicy） | ◎ 全コントローラに展開可 | ◎ Rails 標準の `current_user` と親和 |
+| Plain Ruby Policy | 低 | △ gem なし・独自設計 | ◎ |
+| Pundit | 中 | ○ | ○ |
+
+**採用理由:** action_policy は `authorize!` / `allowed_to?` の使い分けでハードブロック・ソフトブロック両方を自然に表現でき、今回のケース（410 返す場合 vs フラッシュ表示にとどめる場合）に最も適合する。
+
+---
+
+## 5. データ設計
+
+変更: **なし**（マイグレーション不要）
+
+---
+
+## 6. 画面・アクセス制御の流れ
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as SharesController
+    participant P as ShareLinkPolicy
+    participant RM as RoomMembership
+
+    U->>C: GET /share/:token
+    C->>C: ShareLink.find_by!(token:)
+    C->>P: authorize!(share_link, to: :show?)
+    P->>RM: exists? ※memoize
+    alt show? == false (期限切れ+非メンバー)
+        P-->>C: raise Unauthorized
+        C-->>U: 410 Gone
+    end
+    C->>P: allowed_to?(:join?, share_link)
+    alt join? == false (ロック中+非メンバー非オーナー)
+        C-->>U: render :show (flash alert)
+    end
+    C->>RM: find_or_create_by!
+    C-->>U: render :show
+```
+
+---
+
+## 7. アプリケーション設計
+
+```ruby
+# app/policies/application_policy.rb
+class ApplicationPolicy < ActionPolicy::Base
+end
+```
+
+```ruby
+# app/policies/share_link_policy.rb
+class ShareLinkPolicy < ApplicationPolicy
+  # user   = current_user（action_policy が自動注入）
+  # record = share_link
+
+  # 期限切れ でも 既存メンバーなら閲覧継続可
+  def show?
+    !record.expired? || member?
+  end
+
+  # ロック中は 既存メンバー or オーナーのみ参加可
+  def join?
+    !record.room.locked? || member? || owner?
+  end
+
+  private
+
+  def member?
+    @member ||= viewer_profile.present? &&
+      RoomMembership.exists?(room: record.room, profile: viewer_profile)
+  end
+
+  def owner?
+    viewer_profile&.id == record.room.issuer_profile_id
+  end
+
+  def viewer_profile
+    user.profile
+  end
+end
+```
+
+```ruby
+# app/controllers/application_controller.rb（変更）
+class ApplicationController < ActionController::Base
+  include ActionPolicy::Controller
+  authorize :user, through: :current_user
+  # ... 既存の before_action など
+end
+```
+
+```ruby
+# app/controllers/shares_controller.rb（変更後）
+class SharesController < ApplicationController
+  before_action :authenticate_user!
+  rescue_from ActionPolicy::Unauthorized, with: :handle_unauthorized
+
+  def show
+    share_link      = ShareLink.includes(:room).find_by!(token: params[:token])
+    @room           = share_link.room
+    @viewer_profile = current_user.profile
+
+    authorize! share_link, to: :show?   # 期限切れ+非メンバー → 410
+
+    unless allowed_to?(:join?, share_link)
+      flash.now[:alert] = "この部屋は現在ロック中のため参加できません"
+      @memberships = memberships_for_display
+      @jsmind_data = JsmindDataBuilder.new(@room, @memberships).build
+      return render :show
+    end
+
+    RoomMembership.find_or_create_by!(room: @room, profile: @viewer_profile) if @viewer_profile
+    @memberships = memberships_for_display
+    @jsmind_data = JsmindDataBuilder.new(@room, @memberships).build
+  end
+
+  private
+
+  def memberships_for_display
+    @room.room_memberships
+         .includes(profile: [ :user, { profile_hobbies: { hobby: :parent_tag } } ])
+         .order(created_at: :asc)
+  end
+
+  def handle_unauthorized
+    head :gone
+  end
+end
+```
+
+**設計意図:**
+- `authorize!` は「見られてはいけない」ケース（期限切れ+非メンバー）に使用 → 例外で一元ハンドリング
+- `allowed_to?` は「ソフトブロック」（ロック中）に使用 → ページは表示しつつ flash で案内
+- `rescue_from` は `SharesController` に閉じる → 他コントローラに影響しない
+- `member?` は `@member` でメモ化 → `show?` と `join?` の両方から呼ばれても DB クエリは 1 回
+
+---
+
+## 8. ルーティング設計
+
+変更: **なし**
+
+---
+
+## 10. クエリ・性能面
+
+- `RoomMembership.exists?` は Policy 内でメモ化済み → 最大 1 回のみ実行
+- 既存の `includes` は変更なし
+
+---
+
+## 11. トランザクション / Service 分離
+
+**トランザクション:** 不要（書き込みは `find_or_create_by!` 1 件のみ）
+**Service 分離:** 不要（Policy に判定ロジックを分離。入室処理は単純なため）
+
+---
+
+## 12. 実装対象一覧
+
+| # | 対象 | 内容 |
+|---|------|------|
+| 1 | `Gemfile` | `gem "action_policy"` 追加 |
+| 2 | `app/policies/application_policy.rb` | 新規（ベースポリシー） |
+| 3 | `app/policies/share_link_policy.rb` | 新規（show? / join?） |
+| 4 | `app/controllers/application_controller.rb` | `include ActionPolicy::Controller` + `authorize :user` 追加 |
+| 5 | `app/controllers/shares_controller.rb` | `authorize!` / `allowed_to?` に変更 |
+| 6 | `spec/policies/share_link_policy_spec.rb` | 新規（5 ケース） |
+
+---
+
+## 13. 受入条件
+
+- [ ] `ShareLinkPolicy#show?` が「期限切れ + 非メンバー」で `false` を返す
+- [ ] `ShareLinkPolicy#show?` が「期限切れ + メンバー」で `true` を返す
+- [ ] `ShareLinkPolicy#join?` が「ロック中 + 非メンバー・非オーナー」で `false` を返す
+- [ ] `ShareLinkPolicy#join?` が「ロック中 + メンバー」で `true` を返す
+- [ ] `ShareLinkPolicy#join?` が「ロック中 + オーナー」で `true` を返す
+- [ ] 期限切れ + 非メンバーのリクエストが 410 を返す
+- [ ] 既存の `spec/requests/shares_spec.rb` が全て通過する
+
+---
+
+## 14. この設計の結論
+
+action_policy を導入し `ShareLinkPolicy` に `show?` / `join?` を実装。Controller はハードブロック（`authorize!`）とソフトブロック（`allowed_to?`）を使い分けるだけになり、判定ロジックがゼロになる。将来の他コントローラへの拡張も同パターンで対応可能。

--- a/spec/policies/share_link_policy_spec.rb
+++ b/spec/policies/share_link_policy_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe ShareLinkPolicy do
+  # 部屋オーナー
+  let(:room_owner_user)    { create(:user) }
+  let(:room_owner_profile) { create(:profile, user: room_owner_user) }
+  let(:room)               { create(:room, issuer_profile: room_owner_profile) }
+
+  # 閲覧者（オーナー以外）
+  let(:viewer_user)    { create(:user) }
+  let(:viewer_profile) { create(:profile, user: viewer_user) }
+
+  # 有効なリンク（期限内）と期限切れリンク
+  let(:active_link)  { create(:share_link, room: room, expires_at: 1.year.from_now) }
+  let(:expired_link) { create(:share_link, room: room, expires_at: 1.hour.ago) }
+
+  def policy(share_link, user)
+    described_class.new(share_link, user: user)
+  end
+
+  describe "#show?" do
+    context "有効なリンク（期限内）の場合" do
+      it "非メンバーでも true を返す" do
+        # 閲覧者は未参加
+        expect(policy(active_link, viewer_user).show?).to be true
+      end
+    end
+
+    context "期限切れリンクの場合" do
+      it "非メンバーは false を返す" do
+        # 閲覧者は未参加かつリンクは期限切れ → アクセス不可
+        expect(policy(expired_link, viewer_user).show?).to be false
+      end
+
+      it "既存メンバーは true を返す" do
+        # 閲覧者がすでに参加済み → 期限切れでも閲覧継続可
+        create(:room_membership, room: room, profile: viewer_profile)
+        expect(policy(expired_link, viewer_user).show?).to be true
+      end
+    end
+  end
+
+  describe "#join?" do
+    context "アンロック中の部屋の場合" do
+      before { room.update!(locked: false) }
+
+      it "非メンバーでも true を返す" do
+        # 未参加でもアンロック中なら参加可
+        expect(policy(active_link, viewer_user).join?).to be true
+      end
+    end
+
+    context "ロック中の部屋の場合" do
+      before { room.update!(locked: true) }
+
+      it "非メンバー・非オーナーは false を返す" do
+        # 未参加かつオーナーでない → 参加拒否
+        expect(policy(active_link, viewer_user).join?).to be false
+      end
+
+      it "既存メンバーは true を返す" do
+        # すでに参加済みならロック中でも通過
+        create(:room_membership, room: room, profile: viewer_profile)
+        expect(policy(active_link, viewer_user).join?).to be true
+      end
+
+      it "オーナーは true を返す" do
+        # 部屋の作成者はロック中でも通過
+        expect(policy(active_link, room_owner_user).join?).to be true
+      end
+    end
+  end
+end

--- a/spec/requests/shares_spec.rb
+++ b/spec/requests/shares_spec.rb
@@ -63,6 +63,26 @@ RSpec.describe "Shares", type: :request do
       end
     end
 
+    context "期限切れリンクに非メンバーがアクセスした場合" do
+      it "410 Gone を返す" do
+        # 期限切れの共有リンクを準備
+        room_owner = create(:user)
+        room_owner_profile = create(:profile, user: room_owner)
+        room = create(:room, issuer_profile: room_owner_profile)
+        expired_link = create(:share_link, room: room, expires_at: 1.hour.ago)
+
+        # 未参加のゲストユーザーでアクセス
+        guest_user = create(:user)
+        create(:profile, user: guest_user)
+        sign_in guest_user
+
+        get share_path(expired_link.token)
+
+        # 期限切れ+非メンバー → 410 Gone
+        expect(response).to have_http_status(:gone)
+      end
+    end
+
     context "ロックされていない部屋に未参加ユーザーがアクセスした場合" do
       it "RoomMembership が作成される" do
         # 公開中の部屋と共有リンクを準備


### PR DESCRIPTION
## Summary
- `action_policy` gem を導入し、`ApplicationPolicy` ベースクラスを追加
- `ShareLinkPolicy` を新設し、期限切れ判定（`show?`）とロック判定（`join?`）をコントローラから分離
- `SharesController` を `authorize!` / `allowed_to?` に変更（53行 → 34行）
- `member?` を `instance_variable_defined?` でメモ化し、同一リクエスト内の DB クエリを最大 1 回に抑制

## Test plan
- [x] `spec/policies/share_link_policy_spec.rb` — 7 ケース（show? / join? の全ブランチ）
- [x] `spec/requests/shares_spec.rb` — 5 ケース（410 Gone ケースを新規追加）
- [x] 全テスト 360 examples, 0 failures
- [x] RuboCop no offenses detected

## Related
- Issue: #201
- 設計書: `docs/designs/2026-04-11-action-policy-shares-controller.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)