### PR TITLE
fix: ProfilesController#show の hobbies N+1 を解消 #203

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -10,12 +10,17 @@ class ProfilesController < ApplicationController
   end
 
   def show
-    @profile = Profile.includes(profile_hobbies: { hobby: :parent_tag }, user: { avatar_attachment: :blob }).find_by(id: params[:id])
+    @profile = Profile.includes(
+      :hobbies,
+      profile_hobbies: { hobby: :parent_tag },
+      user: { avatar_attachment: :blob }
+    ).find_by(id: params[:id])
     return redirect_to profiles_path, alert: "プロフィールが見つかりません" unless @profile
 
     @profile_hobby_map = @profile.profile_hobbies.index_by(&:hobby_id)
 
-    my_profile = current_user.profile
+    # current_user.profile は includes を付けられないため、直接クエリで hobbies を eager load する
+    my_profile = Profile.includes(:hobbies).find_by(user_id: current_user.id)
     @shared_hobbies = my_profile ? my_profile.shared_hobbies_with(@profile) : []
   end
 end

--- a/spec/requests/profiles/profiles_show_shared_hobbies_spec.rb
+++ b/spec/requests/profiles/profiles_show_shared_hobbies_spec.rb
@@ -64,4 +64,37 @@ RSpec.describe "Profiles#show shared hobbies", type: :request do
     expect(response.body).to include("共通の趣味")
     expect(response.body).to include("共通の趣味はまだありません")
   end
+
+  it "show アクションで hobbies の余分なクエリが発行されない" do
+    # ログインユーザーと相手ユーザーを用意
+    current_user = create(:user)
+    current_profile = create(:profile, user: current_user)
+    other_user = create(:user)
+    other_profile = create(:profile, user: other_user)
+
+    # 共通の趣味を持たせる（hobbies のロードが必ず発生する状態にする）
+    shared_hobby = create(:hobby, name: "rails")
+    create(:profile_hobby, profile: current_profile, hobby: shared_hobby)
+    create(:profile_hobby, profile: other_profile, hobby: shared_hobby)
+
+    sign_in current_user
+
+    # hobbies テーブルへのSQLをキャプチャ
+    hobbies_queries = []
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      hobbies_queries << payload[:sql] if payload[:sql].match?(/FROM "hobbies"/)
+    end
+
+    begin
+      get profile_path(other_profile)
+    ensure
+      # 例外発生時にも必ず購読解除する
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    expect(response).to have_http_status(:ok)
+    # eager load なし: my_profile.hobbies と other_profile.hobbies で個別にSQLが発行され計3回以上
+    # eager load あり: @profile と my_profile それぞれの includes で最大2回（IN句でまとめてロード）
+    expect(hobbies_queries.count).to be <= 2
+  end
 end


### PR DESCRIPTION
## Summary
- `ProfilesController#show` で `shared_hobbies_with` 呼び出し時に発生していた N+1 クエリを解消
- `@profile` の `includes` に `:hobbies` を追加
- `my_profile` のロードを `Profile.includes(:hobbies).find_by(user_id: current_user.id)` に変更（`current_user.profile` は `includes` を付けられないため）
- N+1 再現テストを `profiles_show_shared_hobbies_spec.rb` に追加

## Test plan
- [x] `show` アクションで hobbies の余分なクエリが発行されない（`<= 2` 回）
- [x] 共通趣味の表示が引き続き正常に動作する
- [x] 既存の shared_hobbies 関連 spec 全通過（5 examples）

## Related
- Issue: #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)