### PR TITLE
feat: mypage/rooms のUI改善（バッジ横並び・操作分離・フォーム折りたたみ） #209

### DIFF
--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu"]
+
+  connect() {
+    this.boundClose = this.closeOnOutsideClick.bind(this)
+    document.addEventListener("click", this.boundClose)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.boundClose)
+  }
+
+  toggle(event) {
+    event.stopPropagation()
+    this.menuTarget.classList.toggle("hidden")
+  }
+
+  closeOnOutsideClick(event) {
+    if (!this.element.contains(event.target)) {
+      this.menuTarget.classList.add("hidden")
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,11 +4,26 @@
 
 import { application } from "./application"
 
+import AvatarPreviewController from "./avatar_preview_controller"
+application.register("avatar-preview", AvatarPreviewController)
+
+import ClipboardController from "./clipboard_controller"
+application.register("clipboard", ClipboardController)
+
+import DropdownController from "./dropdown_controller"
+application.register("dropdown", DropdownController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import InlineEditController from "./inline_edit_controller"
+application.register("inline-edit", InlineEditController)
+
 import ProfileSearchController from "./profile_search_controller"
 application.register("profile-search", ProfileSearchController)
+
+import TabsController from "./tabs_controller"
+application.register("tabs", TabsController)
 
 import TagAutocompleteController from "./tag_autocomplete_controller"
 application.register("tag-autocomplete", TagAutocompleteController)
@@ -19,15 +34,5 @@ application.register("tag-description", TagDescriptionController)
 import TagToggleController from "./tag_toggle_controller"
 application.register("tag-toggle", TagToggleController)
 
-import InlineEditController from "./inline_edit_controller"
-application.register("inline-edit", InlineEditController)
-
-import ClipboardController from "./clipboard_controller"
-application.register("clipboard", ClipboardController)
-
-import AvatarPreviewController from "./avatar_preview_controller"
-application.register("avatar-preview", AvatarPreviewController)
-
-import TabsController from "./tabs_controller"
-application.register("tabs", TabsController)
-
+import ToggleController from "./toggle_controller"
+application.register("toggle", ToggleController)

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["content", "openText", "closeText"]
+
+  connect() {
+    this.contentTarget.classList.add("hidden")
+  }
+
+  toggle() {
+    this.contentTarget.classList.toggle("hidden")
+    this.openTextTarget.classList.toggle("hidden")
+    this.closeTextTarget.classList.toggle("hidden")
+  }
+}

--- a/app/views/mypage/rooms/_room.html.erb
+++ b/app/views/mypage/rooms/_room.html.erb
@@ -1,100 +1,130 @@
 <% badge = room_type_badge(room.room_type) %>
+<% lock_badge = lock_status_badge(room) %>
 
 <%= turbo_frame_tag dom_id(room) do %>
-  <div style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); display: flex; flex-direction: column;">
-    <%# 部屋タイプバッジ %>
-    <% if badge %>
-      <span style="display: inline-block; align-self: flex-start; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; margin-bottom: 0.5rem; background: <%= badge[:color] %>; border: 1px solid <%= badge[:border] %>; color: <%= badge[:text] %>;">
-        <%= badge[:label] %>
-      </span>
-    <% end %>
+  <div style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); display: flex; flex-direction: column; gap: 1rem; min-height: 100%;">
 
-    <%# 公開状態バッジ %>
-    <% lock_badge = lock_status_badge(room) %>
-    <span style="display: inline-block; align-self: flex-start; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; margin-bottom: 0.5rem; background: <%= lock_badge[:color] %>; border: 1px solid <%= lock_badge[:border] %>; color: <%= lock_badge[:text] %>;">
-      <%= lock_badge[:label] %>
-    </span>
+    <%# ヘッダー：部屋名 + バッジ + ︙メニュー %>
+    <div style="display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem;">
+      <div style="min-width: 0; flex: 1;">
+        <h3 style="font-size: 1.125rem; font-weight: 600; color: #ffffff; margin: 0 0 0.5rem 0;">
+          <%= room.label.presence || "名無しの部屋" %>
+        </h3>
 
-    <%# 部屋名 %>
-    <h3 style="font-size: 1.125rem; font-weight: 600; color: #ffffff; margin-bottom: 0.75rem;">
-      <%= room.label.presence || "名無しの部屋" %>
-    </h3>
+        <%# バッジ横並び %>
+        <div style="display: flex; flex-wrap: wrap; gap: 0.5rem;">
+          <% if badge %>
+            <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: <%= badge[:color] %>; border: 1px solid <%= badge[:border] %>; color: <%= badge[:text] %>;">
+              <%= badge[:label] %>
+            </span>
+          <% end %>
 
-    <% if link.present? %>
-      <%# 共有URL %>
-      <div style="word-break: break-all; margin-bottom: 0.5rem;" data-controller="clipboard" data-clipboard-text-value="<%= share_url(link.token) %>">
-        <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.25rem;">
-          <span style="color: #6b7280; font-weight: 500; font-size: 0.875rem;">共有URL</span>
-          <button type="button"
-                  data-clipboard-target="button"
-                  data-action="click->clipboard#copy"
-                  style="display: inline-flex; align-items: center; padding: 0.125rem 0.5rem; font-size: 0.75rem; font-weight: 500; color: #60a5fa; background: rgba(96, 165, 250, 0.1); border: 1px solid rgba(96, 165, 250, 0.3); border-radius: 0.25rem; cursor: pointer;">
-            Copy
-          </button>
+          <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: <%= lock_badge[:color] %>; border: 1px solid <%= lock_badge[:border] %>; color: <%= lock_badge[:text] %>;">
+            <%= lock_badge[:label] %>
+          </span>
+
+          <% if link.present? %>
+            <% if link.expired? %>
+              <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: rgba(239, 68, 68, 0.15); border: 1px solid rgba(239, 68, 68, 0.3); color: #fca5a5;">
+                期限切れ
+              </span>
+            <% else %>
+              <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: rgba(34, 197, 94, 0.15); border: 1px solid rgba(34, 197, 94, 0.3); color: #86efac;">
+                有効
+              </span>
+            <% end %>
+          <% end %>
         </div>
-        <%= link_to share_url(link.token),
-                    share_path(link.token),
-                    target: "_blank",
-                    style: "color: #60a5fa; text-decoration: none; font-size: 0.875rem;" %>
       </div>
 
-      <%# 有効期限 %>
-      <p style="font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.5rem;">
-        <span style="color: #6b7280; font-weight: 500;">有効期限</span>
-        <%= link.expires_at.in_time_zone.strftime("%Y/%m/%d %H:%M") if link.expires_at.present? %>
+      <%# ︙メニュー %>
+      <div data-controller="dropdown" style="position: relative; flex-shrink: 0;">
+        <button
+          type="button"
+          data-action="click->dropdown#toggle"
+          style="display: inline-flex; align-items: center; justify-content: center; width: 2.25rem; height: 2.25rem; border-radius: 0.5rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(55, 65, 81, 0.5); color: #d1d5db; cursor: pointer;"
+          aria-label="その他の操作"
+        >
+          &#8942;
+        </button>
 
-        <% if link.expired? %>
-          <span style="margin-left: 0.5rem; display: inline-block; background: rgba(239, 68, 68, 0.15); color: #fca5a5; font-size: 0.75rem; padding: 0.125rem 0.5rem; border-radius: 9999px;">
-            期限切れ
-          </span>
-        <% else %>
-          <span style="margin-left: 0.5rem; display: inline-block; background: rgba(34, 197, 94, 0.15); color: #86efac; font-size: 0.75rem; padding: 0.125rem 0.5rem; border-radius: 9999px;">
-            有効
-          </span>
-        <% end %>
-      </p>
-    <% end %>
+        <div
+          data-dropdown-target="menu"
+          class="hidden"
+          style="position: absolute; top: calc(100% + 0.5rem); right: 0; z-index: 10; min-width: 11rem; padding: 0.5rem; border-radius: 0.75rem; background: #111827; border: 1px solid rgba(55, 65, 81, 0.6); box-shadow: 0 10px 24px rgba(0,0,0,0.35);"
+        >
+          <% if link.present? %>
+            <%= link_to "再発行",
+                        regenerate_share_link_mypage_room_path(room),
+                        data: { turbo_method: :patch, turbo_confirm: "招待リンクを再発行しますか？古いURLは無効になります。" },
+                        style: "display: block; width: fit-content; padding: 0.5rem 0.75rem; border-radius: 0.5rem; color: #fbbf24; text-decoration: none; font-size: 0.875rem;" %>
+          <% end %>
 
-    <%# 参加人数 %>
-    <p style="font-size: 0.875rem; color: #6b7280; margin-bottom: 1rem;">
-      参加人数: <%= room.room_memberships.size %> 人
-    </p>
+          <% if room.locked? %>
+            <%= link_to "解除する",
+                        unlock_mypage_room_path(room),
+                        data: { turbo_method: :patch, turbo_confirm: "この部屋のロックを解除しますか？" },
+                        style: "display: block; width: fit-content; padding: 0.5rem 0.75rem; border-radius: 0.5rem; color: #86efac; text-decoration: none; font-size: 0.875rem;" %>
+          <% else %>
+            <%= link_to "ロックする",
+                        lock_mypage_room_path(room),
+                        data: { turbo_method: :patch, turbo_confirm: "この部屋をロックしますか？" },
+                        style: "display: block; width: fit-content; padding: 0.5rem 0.75rem; border-radius: 0.5rem; color: #fca5a5; text-decoration: none; font-size: 0.875rem;" %>
+          <% end %>
 
-    <%# 操作 %>
-    <div style="display: flex; justify-content: flex-end; gap: 1rem; font-size: 0.875rem; width: 100%;">
+          <%= link_to "削除",
+                      mypage_room_path(room),
+                      data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+                      style: "display: block; width: fit-content; padding: 0.5rem 0.75rem; border-radius: 0.5rem; color: #ef4444; text-decoration: none; font-size: 0.875rem;" %>
+        </div>
+      </div>
+    </div>
+
+    <%# メタ情報：人数・有効期限 %>
+    <div style="display: flex; flex-wrap: wrap; gap: 1rem; font-size: 0.875rem; color: #9ca3af;">
+      <p style="margin: 0;">参加人数: <%= room.room_memberships.size %> 人</p>
+
+      <% if link.present? && link.expires_at.present? %>
+        <p style="margin: 0;">
+          有効期限: <%= link.expires_at.in_time_zone.strftime("%Y/%m/%d %H:%M") %>
+        </p>
+      <% end %>
+    </div>
+
+    <%# 主操作：部屋を見る / 編集 %>
+    <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem; margin-top: auto;">
       <% if link.present? %>
         <%= link_to "部屋を見る",
                     share_path(link.token),
                     target: "_blank",
-                    style: "color: #a78bfa; text-decoration: none;" %>
-
-        <%= link_to "再発行",
-                    regenerate_share_link_mypage_room_path(room),
-                    data: { turbo_method: :patch, turbo_confirm: "招待リンクを再発行しますか？古いURLは無効になります。" },
-                    style: "color: #fbbf24; text-decoration: none;" %>
+                    style: "display: inline-flex; align-items: center; justify-content: center; padding: 0.5rem 1rem; border-radius: 0.5rem; background: linear-gradient(135deg, #8b5cf6, #7c3aed); color: #ffffff; text-decoration: none; font-size: 0.875rem; font-weight: 600;" %>
       <% end %>
 
       <%= link_to "編集",
                   edit_mypage_room_path(room),
                   data: { turbo_frame: dom_id(room) },
-                  style: "color: #60a5fa; text-decoration: none;" %>
-
-      <% if room.locked? %>
-        <%= link_to "解除する",
-                    unlock_mypage_room_path(room),
-                    data: { turbo_method: :patch, turbo_confirm: "この部屋のロックを解除しますか？" },
-                    style: "color: #86efac; text-decoration: none;" %>
-      <% else %>
-        <%= link_to "ロックする",
-                    lock_mypage_room_path(room),
-                    data: { turbo_method: :patch, turbo_confirm: "この部屋をロックしますか？" },
-                    style: "color: #fca5a5; text-decoration: none;" %>
-      <% end %>
-
-      <%= link_to "削除",
-                  mypage_room_path(room),
-                  data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
-                  style: "color: #ef4444; text-decoration: none;" %>
+                  style: "display: inline-flex; align-items: center; justify-content: center; padding: 0.5rem 1rem; border-radius: 0.5rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(55, 65, 81, 0.5); color: #d1d5db; text-decoration: none; font-size: 0.875rem; font-weight: 500;" %>
     </div>
+
+    <%# 共有リンク：下段・省略表示 %>
+    <% if link.present? %>
+      <div data-controller="clipboard" data-clipboard-text-value="<%= share_url(link.token) %>" style="padding-top: 0.75rem; border-top: 1px solid rgba(55, 65, 81, 0.35);">
+        <div style="display: flex; justify-content: space-between; align-items: center; gap: 0.75rem;">
+          <div style="min-width: 0;">
+            <p style="margin: 0 0 0.25rem 0; font-size: 0.75rem; color: #6b7280;">共有リンク</p>
+            <p style="margin: 0; font-size: 0.8125rem; color: #9ca3af; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 18rem;">
+              <%= share_url(link.token) %>
+            </p>
+          </div>
+
+          <button type="button"
+                  data-clipboard-target="button"
+                  data-action="click->clipboard#copy"
+                  style="display: inline-flex; align-items: center; padding: 0.375rem 0.75rem; font-size: 0.75rem; font-weight: 500; color: #60a5fa; background: rgba(96, 165, 250, 0.1); border: 1px solid rgba(96, 165, 250, 0.3); border-radius: 0.375rem; cursor: pointer; flex-shrink: 0;">
+            Copy
+          </button>
+        </div>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/mypage/rooms/index.html.erb
+++ b/app/views/mypage/rooms/index.html.erb
@@ -3,43 +3,54 @@
 <div style="max-width: 72rem; margin: 0 auto; padding: 2.5rem 1.5rem;">
   <h1 style="font-size: 1.875rem; font-weight: 700; color: #ffffff; margin-bottom: 2rem;">部屋管理</h1>
 
-  <%# 作成フォーム %>
-  <div style="max-width: 28rem; padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); margin-bottom: 2.5rem;">
-    <h2 style="font-size: 1.25rem; font-weight: 600; color: #ffffff; margin-bottom: 1rem;">+ 部屋を新規作成</h2>
+  <%# 作成フォーム（折りたたみ） %>
+  <div data-controller="toggle" style="margin-bottom: 2.5rem;">
+    <button
+      type="button"
+      data-action="click->toggle#toggle"
+      style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.75rem 1rem; border-radius: 0.75rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.9375rem; font-weight: 600; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);"
+    >
+      <span data-toggle-target="openText">+ 部屋を新規作成</span>
+      <span data-toggle-target="closeText" class="hidden">− フォームを閉じる</span>
+    </button>
 
-    <%= form_with model: Room.new, url: mypage_rooms_path do |f| %>
-      <div style="margin-bottom: 1rem;">
-        <%= f.label :label, "部屋名（任意）", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
-        <%= f.text_field :label,
-              style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
-      </div>
+    <div data-toggle-target="content" style="max-width: 28rem; padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); margin-top: 1rem;">
+      <h2 style="font-size: 1.125rem; font-weight: 600; color: #ffffff; margin-bottom: 1rem;">新しい部屋を作成</h2>
 
-      <div style="margin-bottom: 1rem;">
-        <%= f.label :room_type, "タイプ", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
-        <%= f.select :room_type,
-              [["雑談", "chat"], ["勉強", "study"], ["ゲーム", "game"]],
-              { selected: "chat" },
-              style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
-      </div>
+      <%= form_with model: Room.new, url: mypage_rooms_path do |f| %>
+        <div style="margin-bottom: 1rem;">
+          <%= f.label :label, "部屋名（任意）", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
+          <%= f.text_field :label,
+                style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+        </div>
 
-      <div style="margin-bottom: 1rem;">
-        <%= f.label :locked, "公開設定", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
-        <%= f.select :locked,
-              [["公開", false], ["ロック", true]],
-              { selected: false },
-              style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
-      </div>
+        <div style="margin-bottom: 1rem;">
+          <%= f.label :room_type, "タイプ", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
+          <%= f.select :room_type,
+                [["雑談", "chat"], ["勉強", "study"], ["ゲーム", "game"]],
+                { selected: "chat" },
+                style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+        </div>
 
-      <div style="margin-bottom: 1rem;">
-        <%= label_tag :expires_in, "招待リンクの有効期限", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
-        <%= select_tag :expires_in,
-              options_for_select([["1時間", "1h"], ["24時間", "24h"], ["3日", "3d"], ["7日", "7d"], ["期限なし", "none"]], "24h"),
-              style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
-      </div>
+        <div style="margin-bottom: 1rem;">
+          <%= f.label :locked, "公開設定", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
+          <%= f.select :locked,
+                [["公開", false], ["ロック", true]],
+                { selected: false },
+                style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+        </div>
 
-      <%= f.submit "部屋を作成",
-            style: "padding: 0.5rem 1rem; border-radius: 0.5rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);" %>
-    <% end %>
+        <div style="margin-bottom: 1rem;">
+          <%= label_tag :expires_in, "招待リンクの有効期限", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
+          <%= select_tag :expires_in,
+                options_for_select([["1時間", "1h"], ["24時間", "24h"], ["3日", "3d"], ["7日", "7d"], ["期限なし", "none"]], "24h"),
+                style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+        </div>
+
+        <%= f.submit "部屋を作成",
+              style: "padding: 0.5rem 1rem; border-radius: 0.5rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);" %>
+      <% end %>
+    </div>
   </div>
 
   <%# 作成済みの部屋 %>

--- a/docs/designs/2026-04-12-rooms-ui-improvement.md
+++ b/docs/designs/2026-04-12-rooms-ui-improvement.md
@@ -1,0 +1,217 @@
+# mypage/rooms UI改善 設計書
+
+**日付:** 2026-04-12
+**Issue:** 未採番（/issue で作成予定）
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+
+- `_room.html.erb` のカード構造を改修（バッジ横並び・操作分離・URL下段移動）
+- `index.html.erb` の作成フォームを折りたたみ化
+- `toggle_controller.js` を新規追加（フォーム開閉）
+- `dropdown_controller.js` を新規追加（︙メニュー）
+
+## 2. 目的
+
+1. 操作の視覚的優先度を整理し、誤タップ・誤クリックを減らす
+2. 初期表示をすっきりさせ、部屋一覧の視認性を上げる
+3. 共有URLの目立ちすぎを解消し、Copyボタン中心のUIにする
+
+## 3. スコープ
+
+### 含むもの
+- `_room.html.erb` の全面改修
+- `index.html.erb` のフォーム折りたたみ化
+- Stimulus `toggle` / `dropdown` コントローラ追加
+
+### 含まないもの
+- ロジック・DB・ルーティング変更
+- `joined_room` パーシャルへの変更
+- モバイル向け特別対応（flex-wrap で自然に折り返す）
+
+## 4. 設計方針
+
+### JS Controller の実装方式
+
+| 方式 | 実装コスト | JS依存 | 現状との相性 |
+|---|---|---|---|
+| A. Stimulus custom controller | 低（各20行程度） | あり（Stimulus） | 既存コントローラと統一 |
+| B. `<details>/<summary>` HTML | 最低（JS不要） | なし | スタイル自由度が低い |
+| C. Alpine.js 等の追加 | 高（gem追加） | 新規依存 | 既存と乖離 |
+
+**採用理由:** 案Aを採用。既存の `clipboard` / `tabs` 等と同じパターンで追加でき、スタイル自由度も高い。`<details>` は開閉アニメーションやテキスト切り替えが難しい。
+
+## 5. データ設計
+
+**なし。** マイグレーション不要。
+
+### DB 制約
+
+変更なし。
+
+### ER 図
+
+```mermaid
+erDiagram
+  rooms {
+    int id PK
+    int owner_id FK "users.id"
+    string label
+    string room_type
+    boolean locked
+  }
+  share_links {
+    int id PK
+    int room_id FK "rooms.id UNIQUE"
+    string token "UNIQUE"
+    datetime expires_at
+  }
+  room_memberships {
+    int id PK
+    int room_id FK
+    int profile_id FK
+  }
+  rooms ||--o| share_links : "1:1"
+  rooms ||--o{ room_memberships : "1:N"
+```
+
+## 6. 画面・アクセス制御の流れ
+
+### シーケンス図
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant T as toggle_controller
+  participant D as dropdown_controller
+  participant S as Server
+
+  U->>T: ボタンクリック（+ 部屋を新規作成）
+  T->>T: contentTarget.classList.toggle("hidden")
+  Note over T: テキストも openText/closeText で切り替え
+
+  U->>D: ︙ボタンクリック
+  D->>D: menuTarget.classList.toggle("hidden")
+
+  U->>S: 再発行 / ロック / 削除（Turbo Method）
+  S-->>U: Turbo Stream でカード差し替え
+  Note over D: Turbo Stream 後もコントローラは再接続される
+```
+
+## 7. アプリケーション設計
+
+### `toggle_controller.js`
+
+```javascript
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["content", "openText", "closeText"]
+
+  connect() {
+    this.contentTarget.classList.add("hidden")
+    this.openTextTarget.classList.remove("hidden")
+    this.closeTextTarget.classList.add("hidden")
+  }
+
+  toggle() {
+    const isHidden = this.contentTarget.classList.toggle("hidden")
+    this.openTextTarget.classList.toggle("hidden", !isHidden)
+    this.closeTextTarget.classList.toggle("hidden", isHidden)
+  }
+}
+```
+
+### `dropdown_controller.js`
+
+```javascript
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu"]
+
+  connect() {
+    this.boundClose = this.closeOnOutsideClick.bind(this)
+    document.addEventListener("click", this.boundClose)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.boundClose)
+  }
+
+  toggle(event) {
+    event.stopPropagation()
+    this.menuTarget.classList.toggle("hidden")
+  }
+
+  closeOnOutsideClick(event) {
+    if (!this.element.contains(event.target)) {
+      this.menuTarget.classList.add("hidden")
+    }
+  }
+}
+```
+
+**設計意図:**
+- `connect` / `disconnect` でイベントリスナーを管理し、Turbo Stream によるカード差し替え後もメモリリークしない
+- `stopPropagation` で ︙ クリック時に `closeOnOutsideClick` が即座に発火するのを防ぐ
+
+## 8. ルーティング設計
+
+**変更なし。**
+
+## 9. レイアウト / UI 設計
+
+### カード構造の変更方針
+
+```
+【現状】                   【変更後】
+バッジ（縦並び）           部屋名
+部屋名                     バッジ横並び（タイプ・公開状態・期限）  ︙
+共有URL（全文リンク）       ─────────────────────────
+有効期限                   参加人数 / 有効期限
+参加人数                   ─────────────────────────
+操作（全部同列）           [部屋を見る] [編集]
+                           ─────────────────────────
+                           共有リンク（省略）    [Copy]
+```
+
+### ︙メニューの中身
+- 再発行（黄）
+- ロックする / 解除する（赤 / 緑）
+- 削除（赤）
+
+## 10. クエリ・性能面
+
+**変更なし。** 既存の `room.room_memberships.size` はそのまま維持。N+1確認は Phase 3 REFACTOR 時にサブエージェントで実施。
+
+## 11. トランザクション / Service 分離
+
+**トランザクション:** 不要（ビュー変更のみ）
+**Service 分離:** 不要（ビュー変更のみ）
+
+## 12. 実装対象一覧
+
+| # | 対象 | 内容 |
+|---|---|---|
+| 1 | `_room.html.erb` | カード構造改修（バッジ横並び・操作分離・URL下段） |
+| 2 | `index.html.erb` | フォーム折りたたみ化（toggle controller 使用） |
+| 3 | `toggle_controller.js` | `rails generate stimulus toggle` で生成・実装 |
+| 4 | `dropdown_controller.js` | `rails generate stimulus dropdown` で生成・実装 |
+| 5 | `index.js` | `rails generate stimulus` により自動更新（手動編集不要） |
+
+## 13. 受入条件
+
+- [ ] バッジ（タイプ・公開状態・期限有効/切れ）が横並びで表示される
+- [ ] 操作が「部屋を見る（主ボタン）」「編集（副ボタン）」「︙メニュー」に分離されている
+- [ ] ︙メニューに再発行・ロック/解除・削除が入っている
+- [ ] ︙メニューが外クリックで閉じる
+- [ ] 共有URLが下段に移動し省略表示・Copyボタン中心になっている
+- [ ] 作成フォームが初期非表示で、ボタンクリックで開閉できる
+- [ ] 既存Turbo Stream（create / lock / unlock / regenerate / update / destroy）が引き続き動作する
+
+## 14. この設計の結論
+
+ビュー・JS のみの変更。DBもルーティングも触らず、既存Turbo Stream構成を維持したまま実現できる。Stimulus の `toggle` / `dropdown` 追加は既存パターンと統一しており、今後他画面に流用しやすい。


### PR DESCRIPTION
## Summary

- バッジ（タイプ・公開状態・期限有効/切れ）を横並びに変更
- 操作を「部屋を見る（主ボタン）」「︙メニュー（再発行・ロック/解除・削除）」に分離し、「編集」ボタンは副ボタンとして残留
- 共有URLを下段に移動し省略表示・Copyボタン中心のUIに変更
- 作成フォームを折りたたみ化（初期非表示・ボタンクリックで開閉）
- Stimulus `toggle_controller` / `dropdown_controller` を新規追加

## Test plan

- [x] バッジが横並びで表示される
- [x] ︙ボタンクリックでメニューが開き、外クリックで閉じる
- [x] ︙メニューの再発行・ロック/解除・削除が動作する
- [x] 「+ 部屋を新規作成」ボタンでフォームが開閉する
- [x] 共有URLが下段に省略表示される
- [x] 既存Turbo Stream（作成・ロック・解除・削除・再発行）が引き続き動作する
- [x] RSpec 375 examples, 0 failures
- [x] RuboCop no offenses

## Related

- Issue: #209

🤖 Generated with [Claude Code](https://claude.ai/claude-code)