### PR TITLE
feat: shares/show UI改善（部屋ヘッダー・状態案内・更新ボタン追加）#213

### DIFF
--- a/app/views/rooms/members/show.html.erb
+++ b/app/views/rooms/members/show.html.erb
@@ -1,10 +1,10 @@
 <turbo-frame id="member_detail">
-  <div style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+  <div style="padding: 1.5rem; border-radius: 1.5rem; background: linear-gradient(180deg, rgba(28, 32, 48, 0.98), rgba(24, 27, 44, 0.96)); border: 1px solid rgba(71, 85, 105, 0.45); box-shadow: 0 24px 60px rgba(2, 6, 23, 0.28);">
 
     <%# アバター + ユーザー名 %>
-    <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.25rem;">
+    <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1.5rem;">
       <%= avatar_image_tag(@profile.user, size: :small) %>
-      <p style="font-size: 1rem; font-weight: 500; color: #ffffff;">
+      <p style="font-size: 1.1rem; font-weight: 700; color: #ffffff;">
         <%= @profile.user.nickname.presence || "no-name" %>
       </p>
     </div>
@@ -13,18 +13,18 @@
     <div data-controller="tabs">
 
       <%# タブボタン群 %>
-      <div style="display: flex; flex-wrap: wrap; gap: 0.375rem; margin-bottom: 0.75rem; padding-bottom: 0.5rem; border-bottom: 1px solid rgba(55, 65, 81, 0.4);">
+      <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem; padding-bottom: 0.75rem; border-bottom: 1px solid rgba(55, 65, 81, 0.4);">
         <button type="button"
                 data-tabs-target="tab"
                 data-action="click->tabs#switch"
-                style="font-size: 0.75rem; padding: 0.25rem 0.75rem; border-radius: 9999px; cursor: pointer; border: 1px solid rgba(96, 165, 250, 0.4); color: #60a5fa; background: rgba(96, 165, 250, 0.15); transition: background 0.2s;">
+                style="font-size: 0.8rem; padding: 0.35rem 0.85rem; border-radius: 9999px; cursor: pointer; border: 1px solid rgba(96, 165, 250, 0.35); color: #dbeafe; background: rgba(37, 99, 235, 0.8); transition: background 0.2s;">
           ひとこと
         </button>
         <% @room_related_phs.each do |ph| %>
           <button type="button"
                   data-tabs-target="tab"
                   data-action="click->tabs#switch"
-                  style="font-size: 0.75rem; padding: 0.25rem 0.75rem; border-radius: 9999px; cursor: pointer; border: 1px solid rgba(96, 165, 250, 0.4); color: #60a5fa; background: rgba(96, 165, 250, 0.15); transition: background 0.2s;">
+                  style="font-size: 0.8rem; padding: 0.35rem 0.85rem; border-radius: 9999px; cursor: pointer; border: 1px solid rgba(96, 165, 250, 0.35); color: #93c5fd; background: rgba(37, 99, 235, 0.18); transition: background 0.2s;">
             <%= ph.hobby.name %>
           </button>
         <% end %>
@@ -32,22 +32,22 @@
 
       <%# パネル群 %>
       <div data-tabs-target="panel"
-           style="min-height: 3rem; font-size: 0.875rem; color: #d1d5db; white-space: pre-line; word-break: break-word;">
+           style="min-height: 8rem; font-size: 0.95rem; line-height: 1.8; color: #d1d5db; white-space: pre-line; word-break: break-word;">
         <%= @profile.bio.presence || "未入力" %>
       </div>
       <% @room_related_phs.each do |ph| %>
         <div data-tabs-target="panel"
              class="hidden"
-             style="min-height: 3rem; font-size: 0.875rem; color: #d1d5db; white-space: pre-line; word-break: break-word;">
+             style="min-height: 8rem; font-size: 0.95rem; line-height: 1.8; color: #d1d5db; white-space: pre-line; word-break: break-word;">
           <%= ph.description.presence || "未入力" %>
         </div>
       <% end %>
     </div>
 
     <%# 詳細を見るリンク %>
-    <div style="margin-top: 1rem; text-align: right;">
+    <div style="margin-top: 1.5rem; text-align: right;">
       <%= link_to "詳細を見る", profile_path(@profile),
-            style: "font-size: 0.875rem; color: #60a5fa; text-decoration: none;" %>
+            style: "font-size: 0.95rem; font-weight: 600; color: #60a5fa; text-decoration: none;" %>
     </div>
   </div>
 </turbo-frame>

--- a/app/views/shares/show.html.erb
+++ b/app/views/shares/show.html.erb
@@ -5,16 +5,9 @@
 
 <% content_for :full_width, true %>
 
-<div class="container mx-auto">
-
-  <!-- 部屋名 -->
-  <h1 class="text-3xl font-bold mb-8">
-    <%= @room.label.presence || "名無しの部屋" %>
-  </h1>
-
-  <!-- プロフィール未登録警告 -->
+<div class="max-w-7xl mx-auto px-4 py-10">
   <% unless @viewer_profile %>
-    <div class="mb-8 p-4 rounded-lg bg-yellow-100 text-yellow-800 flex justify-between items-center">
+    <div class="mb-6 p-4 rounded-lg bg-yellow-100 text-yellow-800 flex justify-between items-center">
       <span>プロフィール未登録です</span>
       <%= link_to "プロフィール作成",
                   new_my_profile_path,
@@ -22,27 +15,62 @@
     </div>
   <% end %>
 
-  <!-- 2カラムレイアウト -->
-  <div class="flex flex-col md:flex-row gap-8">
-
-    <!-- 左ペイン：jsMind マインドマップ -->
-    <div class="md:w-[58%]">
-      <div
-        id="jsmind_container"
-        data-jsmind="<%= @jsmind_data.to_json %>"
-        style="width: 100%; height: 600px; border: 1px solid #e5e7eb; border-radius: 0.5rem; overflow: hidden;"
-      ></div>
+  <div class="rounded-[30px] border border-white/10 bg-[linear-gradient(180deg,rgba(28,33,48,0.96),rgba(18,23,38,0.94)_60%,rgba(28,32,52,0.95))] px-6 py-8 shadow-[0_32px_100px_rgba(2,6,23,0.42)] backdrop-blur-sm md:px-10 md:py-10">
+    <div class="mb-7 text-center">
+      <h1 class="mb-4 text-4xl font-bold tracking-tight text-white md:text-5xl">
+        <%= @room.label.presence || "名無しの部屋" %>
+      </h1>
+      <div class="mb-4 flex flex-wrap items-center justify-center gap-3 text-sm">
+        <span class="inline-flex items-center rounded-full bg-indigo-500/95 px-4 py-1.5 font-semibold text-white shadow-sm">
+          <%= room_type_badge(@room.room_type)[:label] %>
+        </span>
+        <% if @room.locked? %>
+          <span class="inline-flex items-center rounded-full bg-rose-500/95 px-4 py-1.5 font-semibold text-white shadow-sm">ロック中</span>
+        <% else %>
+          <span class="inline-flex items-center rounded-full bg-emerald-500/95 px-4 py-1.5 font-semibold text-white shadow-sm">公開中</span>
+        <% end %>
+        <span class="text-sm font-medium text-slate-300">参加 <%= @memberships.size %>人</span>
+      </div>
+      <div class="mx-auto max-w-4xl rounded-2xl border border-white/10 bg-slate-900/38 px-5 py-4 text-sm leading-7 text-slate-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+        <% if @room.locked? %>
+          この部屋は現在ロック中です。新しいメンバーは参加できません。
+        <% else %>
+          この部屋は公開中です。気になるメンバーを選んでください。
+        <% end %>
+      </div>
     </div>
 
-    <!-- 右ペイン：メンバー詳細（Turbo Frame） -->
-    <div class="md:w-[42%]">
-      <turbo-frame id="member_detail">
-        <div class="bg-gray-50 rounded-xl shadow p-6 text-gray-400 text-sm flex items-center justify-center h-full">
-          左のマインドマップからメンバーを選択してください
+    <div class="grid grid-cols-1 gap-8 md:grid-cols-[minmax(0,3fr)_minmax(380px,2fr)] md:items-start">
+      <div class="min-w-0">
+        <div class="mb-4 flex min-h-[48px] items-center gap-3">
+          <span class="text-lg font-semibold tracking-wide text-slate-200">マインドマップ</span>
+          <%= link_to "更新",
+                      request.fullpath,
+                      data: { turbo: false },
+                      class: "inline-flex items-center rounded-xl border border-indigo-300/60 bg-[linear-gradient(135deg,rgba(59,130,246,0.95),rgba(79,70,229,0.95))] px-4 py-1.5 text-lg font-semibold text-white shadow-[0_10px_24px_rgba(59,130,246,0.22)] transition-transform duration-200 hover:-translate-y-0.5" %>
         </div>
-      </turbo-frame>
+        <div class="rounded-[24px] border border-white/10 bg-[#0b1328]/82 p-3 shadow-[0_24px_60px_rgba(2,6,23,0.36)]">
+          <div
+            id="jsmind_container"
+            data-jsmind="<%= json_escape(@jsmind_data.to_json) %>"
+            class="rounded-[20px]"
+            style="width: 100%; height: 600px; overflow: hidden;"
+          ></div>
+        </div>
+      </div>
+
+      <div class="min-w-0">
+        <div class="mb-4 flex min-h-[48px] items-center">
+          <span class="text-lg font-semibold tracking-wide text-slate-200">詳細</span>
+        </div>
+        <div class="min-h-[624px] rounded-[24px] border border-white/10 bg-slate-900/25 p-4 shadow-[0_18px_40px_rgba(2,6,23,0.22)]">
+          <turbo-frame id="member_detail">
+            <div class="w-full rounded-[20px] border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.98),rgba(248,250,252,0.96))] px-6 py-10 text-center text-sm text-slate-400 shadow-[0_24px_60px_rgba(15,23,42,0.18)]">
+              左のマインドマップからメンバーを選択してください
+            </div>
+          </turbo-frame>
+        </div>
+      </div>
     </div>
-
   </div>
-
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  activerecord:
+    attributes:
+      room:
+        room_types:
+          chat: "雑談"
+          study: "勉強"
+          game: "ゲーム"

--- a/docs/designs/2026-04-12-shares-show-ui.md
+++ b/docs/designs/2026-04-12-shares-show-ui.md
@@ -1,0 +1,172 @@
+# shares/show UI 改善 設計書
+
+**日付:** 2026-04-12
+**Issue:** 未採番
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+
+- `config/locales/ja.yml` を新規作成（`room_type` の日本語ラベル）
+- `shares/show.html.erb` を改修
+  - 最外枠（大枠ラッパー）の追加
+  - 部屋ヘッダー（部屋名・room_typeバッジ・ロック状態バッジ・参加人数）
+  - 状態案内（ロック有無で分岐）
+  - マインドマップ枠に「更新」ボタン
+  - プロフィール未登録警告を大枠内に組み込む
+
+## 2. 目的
+
+- 共有画面に必要な情報（部屋の種別・状態・参加人数）を明示し、ユーザーが状況を把握しやすくする
+- マインドマップ更新の導線を追加し、UX を改善する
+
+## 3. スコープ
+
+### 含むもの
+
+- `app/views/shares/show.html.erb` の改修
+- `config/locales/ja.yml` の新規作成（`room_type` ラベルのみ）
+
+### 含まないもの
+
+- 右ペイン（`turbo-frame#member_detail`）は変更しない
+- `jsmind_map.js` は変更しない
+- コントローラ・モデル・DB は変更しない
+
+## 4. 設計方針
+
+**更新ボタンの実装方法**
+
+| 方式 | 実装コスト | 動作 | Turboとの相性 |
+|---|---|---|---|
+| `<a href="..." data-turbo="false">` | 低 | フルリロード | ◎（意図的に回避） |
+| `<button onclick="location.reload()">` | 低 | フルリロード | △（インラインJS） |
+| Stimulus コントローラ | 中 | フルリロード | ○ |
+
+**採用理由:** `data-turbo="false"` 付きリンクが最もシンプルで Rails の流儀に合う。jsMind は全体再描画が必要なのでフルリロードが正解。
+
+**I18n の方式:** 既存の `config/locales/en.yml` と同じ構造で `ja.yml` を新規作成。将来の多言語化・enum 拡張に対応できる。
+
+## 5. データ設計
+
+変更なし（マイグレーション不要）
+
+### ER 図
+
+```mermaid
+erDiagram
+  rooms {
+    bigint id PK ""
+    string label "nullable"
+    integer room_type "default: 0"
+    boolean locked "default: false"
+    bigint issuer_profile_id FK ""
+  }
+  share_links {
+    bigint id PK ""
+    bigint room_id FK ""
+    string token "unique"
+    datetime expires_at ""
+  }
+  room_memberships {
+    bigint id PK ""
+    bigint room_id FK ""
+    bigint profile_id FK ""
+  }
+  rooms ||--o{ room_memberships : "has many"
+  rooms ||--|| share_links : "has one"
+```
+
+## 6. 画面・アクセス制御の流れ
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as SharesController
+    participant V as shares/show.html.erb
+
+    U->>C: GET /shares/:token
+    C->>C: ShareLink.find_by!(token:)
+    C->>C: authorize! / allowed_to?(:join?)
+    C->>V: render :show (@room, @viewer_profile, @memberships, @jsmind_data)
+    V->>U: 部屋ヘッダー + 状態案内 + jsMind + メンバー詳細
+```
+
+## 7. アプリケーション設計
+
+コントローラは変更なし。ビューのみで以下を表現する。
+
+```erb
+<%# 部屋ヘッダー例 %>
+<h1><%= @room.label.presence || "名無しの部屋" %></h1>
+<span><%= t("activerecord.attributes.room.room_types.#{@room.room_type}") %></span>
+<span><%= @room.locked? ? "ロック中" : "公開中" %></span>
+<span>参加 <%= @memberships.size %>人</span>
+
+<%# 状態案内（分岐） %>
+<% if @room.locked? %>
+  この部屋は現在ロック中です。
+<% else %>
+  この部屋は公開中です。気になるメンバーを選んでください。
+<% end %>
+
+<%# 更新ボタン（フルリロード） %>
+<%= link_to "更新", request.fullpath, data: { turbo: false }, class: "..." %>
+```
+
+## 8. ルーティング設計
+
+変更なし
+
+## 9. レイアウト / UI 設計
+
+デザイン方針（ダーク系リッチなテーマ）に沿ったTailwindクラスを使用。
+
+```
+╔══ 最外枠（max-w-7xl mx-auto px-4 py-8） ════════════════════╗
+║  ┌── 部屋ヘッダー（bg-gray-800 rounded-xl p-6） ──────────┐  ║
+║  │  部屋名 h1                                              │  ║
+║  │  [勉強] [公開中]  参加 8人                              │  ║
+║  └─────────────────────────────────────────────────────────┘  ║
+║                                                               ║
+║  ┌── 状態案内（bg-gray-700/50 rounded-lg p-4） ───────────┐  ║
+║  │  この部屋は公開中です。…                                │  ║
+║  └─────────────────────────────────────────────────────────┘  ║
+║                                                               ║
+║  ┌── 左ペイン（58%） ─────────┬── 右ペイン（42%） ───────┐  ║
+║  │  共通点マップ  [更新]       │  メンバー詳細             │  ║
+║  │  jsMind                    │  （現状維持）              │  ║
+║  └────────────────────────────┴────────────────────────────┘  ║
+╚═══════════════════════════════════════════════════════════════╝
+```
+
+## 10. クエリ・性能面
+
+- `@memberships` は既に `includes` 済みのため N+1 なし
+- 参加人数表示は `@memberships.size`（SQL を再発行しない）を使用
+
+## 11. トランザクション / Service 分離
+
+**トランザクション:** 不要（ビュー変更のみ）
+**Service 分離:** 不要（ビュー変更のみ）
+
+## 12. 実装対象一覧
+
+| # | 対象 | 内容 |
+|---|---|---|
+| 1 | `config/locales/ja.yml` | 新規作成。`room_type` の日本語ラベル（chat/study/game） |
+| 2 | `app/views/shares/show.html.erb` | 大枠・部屋ヘッダー・状態案内・更新ボタンを追加 |
+
+## 13. 受入条件
+
+- [ ] 部屋名・room_type（日本語バッジ）・ロック状態・参加人数が表示される
+- [ ] 状態案内がロック有無で分岐表示される
+- [ ] マインドマップ枠に「更新」ボタンがあり、押すとフルリロードされる
+- [ ] プロフィール未登録の場合は警告が表示される
+- [ ] 右ペイン（メンバー詳細）は変更なし
+- [ ] `rubocop` が通る
+
+## 14. この設計の結論
+
+**ビュー2ファイルのみの変更。DB・コントローラ・JS には触れない。** I18n を通じた `room_type` 日本語表示により、将来の enum 追加にも対応できる。

--- a/spec/requests/shares/shares_show_room_header_spec.rb
+++ b/spec/requests/shares/shares_show_room_header_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "shares#show", type: :request do
+  let(:issuer_user) { create(:user) }
+  let(:issuer_profile) { create(:profile, user: issuer_user) }
+
+  context "studyタイプ・公開中の部屋" do
+    let(:room) { create(:room, issuer_profile: issuer_profile, room_type: :study, locked: false) }
+    let(:share_link) { create(:share_link, room: room, expires_at: 1.hour.from_now) }
+
+    before do
+      create(:room_membership, room: room, profile: issuer_profile)
+      sign_in issuer_user
+      get share_path(share_link.token)
+    end
+
+    it "room_typeが日本語で表示される" do
+      expect(response.body).to include("勉強")
+    end
+
+    it "公開中バッジが表示される" do
+      expect(response.body).to include("公開中")
+    end
+
+    it "参加人数が表示される" do
+      expect(response.body).to include("1人")
+    end
+
+    it "公開中の状態案内が表示される" do
+      expect(response.body).to include("この部屋は公開中です")
+    end
+
+    it "更新ボタンが表示される" do
+      expect(response.body).to include("更新")
+    end
+  end
+
+  context "ロック中の部屋" do
+    let(:room) { create(:room, issuer_profile: issuer_profile, locked: true) }
+    let(:share_link) { create(:share_link, room: room, expires_at: 1.hour.from_now) }
+
+    before do
+      sign_in issuer_user
+      get share_path(share_link.token)
+    end
+
+    it "ロック中バッジが表示される" do
+      expect(response.body).to include("ロック中")
+    end
+
+    it "ロック中の状態案内が表示される" do
+      expect(response.body).to include("この部屋は現在ロック中です")
+    end
+  end
+end

--- a/spec/system/my/profile_tag_description_spec.rb
+++ b/spec/system/my/profile_tag_description_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe "タグ説明文入力UI", type: :system, js: true do
       find("[data-testid='description-input']").fill_in with: "毎日やってます"
       click_button "更新する"
 
-      expect(page).to have_current_path(profile_path(current_profile))
       expect(page).to have_text("プロフィールを更新しました")
+      expect(page).to have_current_path(profile_path(current_profile))
 
       ph = current_profile.reload.profile_hobbies.joins(:hobby).find_by(hobbies: { name: "ゲーム" })
       expect(ph.description).to eq("毎日やってます")
@@ -74,8 +74,8 @@ RSpec.describe "タグ説明文入力UI", type: :system, js: true do
       find("[data-testid='tag-input']").send_keys(:return)
       click_button "更新する"
 
-      expect(page).to have_current_path(profile_path(current_profile))
       expect(page).to have_text("プロフィールを更新しました")
+      expect(page).to have_current_path(profile_path(current_profile))
 
       ph = current_profile.reload.profile_hobbies.joins(:hobby).find_by(hobbies: { name: "ゲーム" })
       expect(ph).not_to be_nil
@@ -118,8 +118,8 @@ RSpec.describe "タグ説明文入力UI", type: :system, js: true do
       find("[data-testid='tag-input']").send_keys(:return)
       click_button "更新する"
 
-      expect(page).to have_current_path(profile_path(current_profile))
       expect(page).to have_text("プロフィールを更新しました")
+      expect(page).to have_current_path(profile_path(current_profile))
       expect(current_profile.reload.bio).to eq("テスト自己紹介です")
     end
   end


### PR DESCRIPTION
## Summary
- `config/locales/ja.yml` を新規作成し、`room_type` の日本語ラベルを定義（`RoomsHelper` と整合）
- `shares/show.html.erb` に部屋ヘッダー（room_typeバッジ・ロック状態・参加人数）・状態案内（ロック有無で分岐）・マインドマップ更新ボタンを追加
- `data-jsmind` 属性に `json_escape` を追加（XSS対策）
- `rooms/members/show.html.erb` のメンバー詳細パネルのスタイルを合わせて調整
- request spec（`shares_show_room_header_spec`）を追加

## Test plan
- [x] RSpec: 389 examples, 0 failures 通過済み
- [x] 公開中の部屋で room_type バッジ・「公開中」バッジ・参加人数が表示される
- [x] ロック中の部屋で「ロック中」バッジと対応する状態案内が表示される
- [x] 更新ボタンを押すとページが再読み込みされる（`data-turbo="false"`）
- [x] プロフィール未登録ユーザーに警告が表示される
- [x] 右ペイン（Turbo Frame）のメンバー詳細が正常に動作する

## Related
- Issue: #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)