### PR TITLE
feat: 管理画面に親タグ・子タグ管理機能を追加 #197

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,5 +104,5 @@ jobs:
         if: failure()
         with:
           name: screenshots
-          path: ${{ github.workspace }}/tmp/screenshots
+          path: ${{ github.workspace }}/tmp/capybara
           if-no-files-found: ignore

--- a/app/controllers/admin/hobbies_controller.rb
+++ b/app/controllers/admin/hobbies_controller.rb
@@ -29,7 +29,7 @@ class Admin::HobbiesController < Admin::BaseController
     if @hobby.destroy
       redirect_to admin_parent_tags_path, notice: "削除しました"
     else
-      usage_count = @hobby.profile_hobbies.count
+      usage_count = @hobby.profile_hobbies.size
       redirect_to admin_parent_tags_path, alert: "使用中のため削除できません（#{usage_count}件が使用中）"
     end
   end
@@ -41,7 +41,7 @@ class Admin::HobbiesController < Admin::BaseController
   end
 
   def set_parent_tags
-    @parent_tags = ParentTag.where.not(room_type: nil).order(:room_type, :position, :id)
+    @parent_tags = ParentTag.classified.order(:room_type, :position, :id)
   end
 
   def hobby_params

--- a/app/controllers/admin/hobbies_controller.rb
+++ b/app/controllers/admin/hobbies_controller.rb
@@ -1,0 +1,50 @@
+class Admin::HobbiesController < Admin::BaseController
+  before_action :set_hobby, only: %i[edit update destroy]
+  before_action :set_parent_tags, only: %i[new create edit update]
+
+  def new
+    @hobby = Hobby.new(parent_tag_id: params[:parent_tag_id])
+  end
+
+  def create
+    @hobby = Hobby.new(hobby_params)
+    if @hobby.save
+      redirect_to admin_parent_tags_path, notice: "子タグを作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @hobby.update(hobby_params)
+      redirect_to admin_parent_tags_path, notice: "子タグを更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @hobby.destroy
+      redirect_to admin_parent_tags_path, notice: "削除しました"
+    else
+      usage_count = @hobby.profile_hobbies.count
+      redirect_to admin_parent_tags_path, alert: "使用中のため削除できません（#{usage_count}件が使用中）"
+    end
+  end
+
+  private
+
+  def set_hobby
+    @hobby = Hobby.find(params[:id])
+  end
+
+  def set_parent_tags
+    @parent_tags = ParentTag.where.not(room_type: nil).order(:room_type, :position, :id)
+  end
+
+  def hobby_params
+    params.require(:hobby).permit(:name, :parent_tag_id)
+  end
+end

--- a/app/controllers/admin/parent_tags_controller.rb
+++ b/app/controllers/admin/parent_tags_controller.rb
@@ -3,9 +3,7 @@ class Admin::ParentTagsController < Admin::BaseController
   before_action :set_parent_tag_options, only: %i[index new create edit update]
 
   def index
-    scope = ParentTag.where.not(room_type: nil)
-                     .includes(:hobbies)
-                     .order(:room_type, :position, :id)
+    scope = ParentTag.classified.includes(:hobbies).order(:room_type, :position, :id)
     scope = scope.where(room_type: params[:room_type]) if params[:room_type].present?
     scope = scope.where(id: params[:parent_tag_id]) if params[:parent_tag_id].present?
 
@@ -14,6 +12,7 @@ class Admin::ParentTagsController < Admin::BaseController
 
     @usage_counts = ProfileHobby.where(hobby_id: hobby_ids).group(:hobby_id).count
     @parent_tags_by_room_type = @parent_tags.group_by(&:room_type)
+    @room_type_options = ParentTag.room_types.keys
   end
 
   def new
@@ -43,7 +42,7 @@ class Admin::ParentTagsController < Admin::BaseController
     if @parent_tag.destroy
       redirect_to admin_parent_tags_path, notice: "削除しました"
     else
-      child_count = @parent_tag.hobbies.count
+      child_count = @parent_tag.hobbies.size
       redirect_to admin_parent_tags_path, alert: "子タグが#{child_count}件あるため削除できません"
     end
   end

--- a/app/controllers/admin/parent_tags_controller.rb
+++ b/app/controllers/admin/parent_tags_controller.rb
@@ -1,0 +1,64 @@
+class Admin::ParentTagsController < Admin::BaseController
+  before_action :set_parent_tag, only: %i[edit update destroy]
+  before_action :set_parent_tag_options, only: %i[index new create edit update]
+
+  def index
+    scope = ParentTag.where.not(room_type: nil)
+                     .includes(:hobbies)
+                     .order(:room_type, :position, :id)
+    scope = scope.where(room_type: params[:room_type]) if params[:room_type].present?
+    scope = scope.where(id: params[:parent_tag_id]) if params[:parent_tag_id].present?
+
+    @parent_tags = scope.to_a
+    hobby_ids = @parent_tags.flat_map { |parent_tag| parent_tag.hobbies.map(&:id) }
+
+    @usage_counts = ProfileHobby.where(hobby_id: hobby_ids).group(:hobby_id).count
+    @parent_tags_by_room_type = @parent_tags.group_by(&:room_type)
+  end
+
+  def new
+    @parent_tag = ParentTag.new(room_type: params[:room_type])
+  end
+
+  def create
+    @parent_tag = ParentTag.new(parent_tag_params)
+    if @parent_tag.save
+      redirect_to admin_parent_tags_path, notice: "親タグを作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @parent_tag.update(parent_tag_params)
+      redirect_to admin_parent_tags_path, notice: "親タグを更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @parent_tag.destroy
+      redirect_to admin_parent_tags_path, notice: "削除しました"
+    else
+      child_count = @parent_tag.hobbies.count
+      redirect_to admin_parent_tags_path, alert: "子タグが#{child_count}件あるため削除できません"
+    end
+  end
+
+  private
+
+  def set_parent_tag
+    @parent_tag = ParentTag.find(params[:id])
+  end
+
+  def set_parent_tag_options
+    @all_parent_tags = ParentTag.where.not(room_type: nil).order(:room_type, :position, :id)
+  end
+
+  def parent_tag_params
+    params.require(:parent_tag).permit(:name, :slug, :room_type)
+  end
+end

--- a/app/models/hobby.rb
+++ b/app/models/hobby.rb
@@ -3,7 +3,7 @@ class Hobby < ApplicationRecord
 
   scope :unclassified, -> { where(parent_tag: ParentTag.where(slug: "uncategorized")) }
 
-  has_many :profile_hobbies, dependent: :destroy
+  has_many :profile_hobbies, dependent: :restrict_with_error
   has_many :profiles, through: :profile_hobbies
 
   validates :name, presence: true, uniqueness: true

--- a/app/models/parent_tag.rb
+++ b/app/models/parent_tag.rb
@@ -1,8 +1,10 @@
 class ParentTag < ApplicationRecord
   enum :room_type, { chat: 0, study: 1, game: 2 }
 
+  scope :classified, -> { where.not(room_type: nil) }
+
   has_many :hobbies, dependent: :restrict_with_error
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: { scope: :room_type }
   validates :slug, presence: true, uniqueness: { scope: :room_type }
 end

--- a/app/views/admin/hobbies/_form.html.erb
+++ b/app/views/admin/hobbies/_form.html.erb
@@ -1,0 +1,31 @@
+<% if hobby.errors.any? %>
+  <div style="margin-bottom: 1rem; border-radius: 0.5rem; padding: 0.75rem 1rem; background: rgba(239, 68, 68, 0.1); color: #fca5a5; border: 1px solid rgba(239, 68, 68, 0.3);">
+    <ul style="margin: 0; padding-left: 1.25rem;">
+      <% hobby.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= form_with model: [:admin, hobby], local: true do |f| %>
+  <div style="display: grid; gap: 1rem; max-width: 32rem;">
+    <div>
+      <%= f.label :name, "子タグ名", style: "display: block; margin-bottom: 0.375rem; color: #e5e7eb;" %>
+      <%= f.text_field :name, style: "width: 100%; box-sizing: border-box; background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.625rem 0.75rem; border-radius: 0.375rem;" %>
+    </div>
+
+    <div>
+      <%= f.label :parent_tag_id, "親タグ", style: "display: block; margin-bottom: 0.375rem; color: #e5e7eb;" %>
+      <%= f.select :parent_tag_id,
+            @parent_tags.map { |parent_tag| [parent_tag.name, parent_tag.id] },
+            { prompt: "選択してください" },
+            { style: "width: 100%; box-sizing: border-box; background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.625rem 0.75rem; border-radius: 0.375rem;" } %>
+    </div>
+
+    <div style="display: flex; gap: 0.75rem;">
+      <%= f.submit submit_label, style: "background: #2563eb; color: white; border: none; padding: 0.625rem 1rem; border-radius: 0.375rem; cursor: pointer;" %>
+      <%= link_to "一覧に戻る", admin_parent_tags_path, style: "display: inline-block; background: #374151; color: #f9fafb; text-decoration: none; padding: 0.625rem 1rem; border-radius: 0.375rem;" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/hobbies/edit.html.erb
+++ b/app/views/admin/hobbies/edit.html.erb
@@ -1,0 +1,4 @@
+<div style="max-width: 48rem; margin: 0 auto;">
+  <h1 style="font-size: 1.5rem; font-weight: bold; color: #f9fafb; margin-bottom: 1.5rem;">子タグ編集</h1>
+  <%= render "form", hobby: @hobby, submit_label: "更新する" %>
+</div>

--- a/app/views/admin/hobbies/new.html.erb
+++ b/app/views/admin/hobbies/new.html.erb
@@ -1,0 +1,4 @@
+<div style="max-width: 48rem; margin: 0 auto;">
+  <h1 style="font-size: 1.5rem; font-weight: bold; color: #f9fafb; margin-bottom: 1.5rem;">子タグ作成</h1>
+  <%= render "form", hobby: @hobby, submit_label: "作成する" %>
+</div>

--- a/app/views/admin/parent_tags/_form.html.erb
+++ b/app/views/admin/parent_tags/_form.html.erb
@@ -1,0 +1,36 @@
+<% if parent_tag.errors.any? %>
+  <div style="margin-bottom: 1rem; border-radius: 0.5rem; padding: 0.75rem 1rem; background: rgba(239, 68, 68, 0.1); color: #fca5a5; border: 1px solid rgba(239, 68, 68, 0.3);">
+    <ul style="margin: 0; padding-left: 1.25rem;">
+      <% parent_tag.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= form_with model: [:admin, parent_tag], local: true do |f| %>
+  <div style="display: grid; gap: 1rem; max-width: 32rem;">
+    <div>
+      <%= f.label :name, "親タグ名", style: "display: block; margin-bottom: 0.375rem; color: #e5e7eb;" %>
+      <%= f.text_field :name, style: "width: 100%; box-sizing: border-box; background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.625rem 0.75rem; border-radius: 0.375rem;" %>
+    </div>
+
+    <div>
+      <%= f.label :slug, "slug", style: "display: block; margin-bottom: 0.375rem; color: #e5e7eb;" %>
+      <%= f.text_field :slug, style: "width: 100%; box-sizing: border-box; background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.625rem 0.75rem; border-radius: 0.375rem;" %>
+    </div>
+
+    <div>
+      <%= f.label :room_type, "部屋タイプ", style: "display: block; margin-bottom: 0.375rem; color: #e5e7eb;" %>
+      <%= f.select :room_type,
+            ParentTag.room_types.keys.map { |room_type| [room_type, room_type] },
+            { prompt: "選択してください" },
+            { style: "width: 100%; box-sizing: border-box; background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.625rem 0.75rem; border-radius: 0.375rem;" } %>
+    </div>
+
+    <div style="display: flex; gap: 0.75rem;">
+      <%= f.submit submit_label, style: "background: #2563eb; color: white; border: none; padding: 0.625rem 1rem; border-radius: 0.375rem; cursor: pointer;" %>
+      <%= link_to "一覧に戻る", admin_parent_tags_path, style: "display: inline-block; background: #374151; color: #f9fafb; text-decoration: none; padding: 0.625rem 1rem; border-radius: 0.375rem;" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/parent_tags/edit.html.erb
+++ b/app/views/admin/parent_tags/edit.html.erb
@@ -1,0 +1,4 @@
+<div style="max-width: 48rem; margin: 0 auto;">
+  <h1 style="font-size: 1.5rem; font-weight: bold; color: #f9fafb; margin-bottom: 1.5rem;">親タグ編集</h1>
+  <%= render "form", parent_tag: @parent_tag, submit_label: "更新する" %>
+</div>

--- a/app/views/admin/parent_tags/index.html.erb
+++ b/app/views/admin/parent_tags/index.html.erb
@@ -8,7 +8,7 @@
       <div>
         <%= f.label :room_type, "部屋タイプ", style: "display: block; margin-bottom: 0.375rem; color: #e5e7eb;" %>
         <%= f.select :room_type,
-              ParentTag.room_types.keys.map { |room_type| [room_type, room_type] },
+              @room_type_options.map { |room_type| [room_type, room_type] },
               { include_blank: "すべて" },
               { style: "min-width: 10rem; background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.5rem 0.75rem; border-radius: 0.375rem;" } %>
       </div>
@@ -26,7 +26,7 @@
     </div>
   <% end %>
 
-  <% ParentTag.room_types.keys.each do |room_type| %>
+  <% @room_type_options.each do |room_type| %>
     <% room_parent_tags = @parent_tags_by_room_type.fetch(room_type, []) %>
     <% create_parent_path = new_admin_parent_tag_path(room_type:) %>
     <% first_parent_tag = room_parent_tags.first %>

--- a/app/views/admin/parent_tags/index.html.erb
+++ b/app/views/admin/parent_tags/index.html.erb
@@ -1,0 +1,90 @@
+<div style="max-width: 72rem; margin: 0 auto;">
+  <div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem; margin-bottom: 1.5rem;">
+    <h1 style="font-size: 1.5rem; font-weight: bold; color: #f9fafb; margin: 0;">親タグ管理</h1>
+  </div>
+
+  <%= form_with url: admin_parent_tags_path, method: :get, local: true do |f| %>
+    <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 2rem; align-items: end;">
+      <div>
+        <%= f.label :room_type, "部屋タイプ", style: "display: block; margin-bottom: 0.375rem; color: #e5e7eb;" %>
+        <%= f.select :room_type,
+              ParentTag.room_types.keys.map { |room_type| [room_type, room_type] },
+              { include_blank: "すべて" },
+              { style: "min-width: 10rem; background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.5rem 0.75rem; border-radius: 0.375rem;" } %>
+      </div>
+
+      <div>
+        <%= f.label :parent_tag_id, "親タグ", style: "display: block; margin-bottom: 0.375rem; color: #e5e7eb;" %>
+        <%= f.select :parent_tag_id,
+              @all_parent_tags.map { |parent_tag| [parent_tag.name, parent_tag.id] },
+              { include_blank: "すべて" },
+              { style: "min-width: 12rem; background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.5rem 0.75rem; border-radius: 0.375rem;" } %>
+      </div>
+
+      <%= f.submit "検索", style: "background: #2563eb; color: white; border: none; padding: 0.5rem 1rem; border-radius: 0.375rem; cursor: pointer;" %>
+      <%= link_to "リセット", admin_parent_tags_path, style: "display: inline-block; background: #374151; color: #f9fafb; text-decoration: none; padding: 0.5rem 1rem; border-radius: 0.375rem;" %>
+    </div>
+  <% end %>
+
+  <% ParentTag.room_types.keys.each do |room_type| %>
+    <% room_parent_tags = @parent_tags_by_room_type.fetch(room_type, []) %>
+    <% create_parent_path = new_admin_parent_tag_path(room_type:) %>
+    <% first_parent_tag = room_parent_tags.first %>
+
+    <section style="margin-bottom: 2rem;">
+      <div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem; margin-bottom: 0.75rem;">
+        <h2 style="font-size: 1.125rem; color: #f9fafb; margin: 0;"><%= room_type %></h2>
+        <div style="display: flex; gap: 0.5rem;">
+          <%= link_to "＋親タグ作成", create_parent_path, style: "display: inline-block; background: #1d4ed8; color: white; text-decoration: none; padding: 0.5rem 0.875rem; border-radius: 0.375rem;" %>
+          <% if first_parent_tag.present? %>
+            <%= link_to "＋子タグ作成", new_admin_hobby_path(parent_tag_id: first_parent_tag.id), style: "display: inline-block; background: #059669; color: white; text-decoration: none; padding: 0.5rem 0.875rem; border-radius: 0.375rem;" %>
+          <% end %>
+        </div>
+      </div>
+
+      <table style="width: 100%; border-collapse: collapse; color: #d1d5db; background: rgba(17, 24, 39, 0.6); border: 1px solid #1f2937; border-radius: 0.5rem; overflow: hidden;">
+        <thead>
+          <tr style="border-bottom: 1px solid #374151; text-align: left;">
+            <th style="padding: 0.75rem 1rem;">親タグ</th>
+            <th style="padding: 0.75rem 1rem;">子タグ</th>
+            <th style="padding: 0.75rem 1rem;">使用数</th>
+            <th style="padding: 0.75rem 1rem;">操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% if room_parent_tags.empty? %>
+            <tr>
+              <td colspan="4" style="padding: 1rem; color: #9ca3af;">表示する親タグがありません</td>
+            </tr>
+          <% else %>
+            <% room_parent_tags.each do |parent_tag| %>
+              <% if parent_tag.hobbies.empty? %>
+                <tr data-parent-tag-id="<%= parent_tag.id %>" style="border-bottom: 1px solid #1f2937;">
+                  <td style="padding: 0.75rem 1rem;"><%= parent_tag.name %></td>
+                  <td style="padding: 0.75rem 1rem; color: #9ca3af;">子タグなし</td>
+                  <td style="padding: 0.75rem 1rem;">0</td>
+                  <td style="padding: 0.75rem 1rem; display: flex; gap: 0.5rem;">
+                    <%= link_to "編集", edit_admin_parent_tag_path(parent_tag), style: "color: #93c5fd; text-decoration: none;" %>
+                    <%= button_to "削除", admin_parent_tag_path(parent_tag), method: :delete, form: { style: "display: inline-block;" }, style: "background: none; border: none; color: #fca5a5; padding: 0; cursor: pointer;" %>
+                  </td>
+                </tr>
+              <% else %>
+                <% parent_tag.hobbies.each do |hobby| %>
+                  <tr data-parent-tag-id="<%= parent_tag.id %>" data-hobby-id="<%= hobby.id %>" style="border-bottom: 1px solid #1f2937;">
+                    <td data-col="parent-tag" style="padding: 0.75rem 1rem;"><%= parent_tag.name %></td>
+                    <td data-col="hobby-name" style="padding: 0.75rem 1rem;"><%= hobby.name %></td>
+                    <td style="padding: 0.75rem 1rem;"><%= @usage_counts[hobby.id].to_i %></td>
+                    <td style="padding: 0.75rem 1rem; display: flex; gap: 0.5rem;">
+                      <%= link_to "編集", edit_admin_hobby_path(hobby), style: "color: #93c5fd; text-decoration: none;" %>
+                      <%= button_to "削除", admin_hobby_path(hobby), method: :delete, form: { style: "display: inline-block;" }, style: "background: none; border: none; color: #fca5a5; padding: 0; cursor: pointer;" %>
+                    </td>
+                  </tr>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </tbody>
+      </table>
+    </section>
+  <% end %>
+</div>

--- a/app/views/admin/parent_tags/new.html.erb
+++ b/app/views/admin/parent_tags/new.html.erb
@@ -1,0 +1,4 @@
+<div style="max-width: 48rem; margin: 0 auto;">
+  <h1 style="font-size: 1.5rem; font-weight: bold; color: #f9fafb; margin-bottom: 1.5rem;">親タグ作成</h1>
+  <%= render "form", parent_tag: @parent_tag, submit_label: "作成する" %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -12,6 +12,7 @@
     <header style="background: #111827; border-bottom: 1px solid #374151; padding: 0.75rem 1.5rem; display: flex; align-items: center; gap: 1.5rem;">
       <span style="font-weight: bold; color: #f9fafb;">管理画面</span>
       <%= link_to "ダッシュボード", admin_root_path, style: "color: #9ca3af; text-decoration: none; font-size: 0.875rem;" %>
+      <%= link_to "親タグ管理", admin_parent_tags_path, style: "color: #9ca3af; text-decoration: none; font-size: 0.875rem;" %>
       <%= link_to "未分類タグ管理", admin_unclassified_hobbies_path, style: "color: #9ca3af; text-decoration: none; font-size: 0.875rem;" %>
       <span style="margin-left: auto;">
         <%= link_to "サイトに戻る", root_path, style: "color: #9ca3af; text-decoration: none; font-size: 0.875rem;" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,8 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root "dashboards#show"
+    resources :parent_tags, only: %i[index new create edit update destroy]
+    resources :hobbies, only: %i[new create edit update destroy]
     resources :unclassified_hobbies, only: [ :index, :update ] do
       member do
         post :merge

--- a/db/migrate/20260413054145_add_unique_index_to_parent_tags_room_type_name.rb
+++ b/db/migrate/20260413054145_add_unique_index_to_parent_tags_room_type_name.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToParentTagsRoomTypeName < ActiveRecord::Migration[7.2]
+  def change
+    add_index :parent_tags, [ :room_type, :name ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_07_133604) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_13_054145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_07_133604) do
     t.integer "position", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["room_type", "name"], name: "index_parent_tags_on_room_type_and_name", unique: true
     t.index ["room_type", "slug"], name: "index_parent_tags_on_room_type_and_slug", unique: true
   end
 

--- a/docs/designs/2026-04-13-admin-parent-tags.md
+++ b/docs/designs/2026-04-13-admin-parent-tags.md
@@ -1,0 +1,281 @@
+# 管理画面 親タグ管理機能 設計書
+
+**日付:** 2026-04-13
+**Issue:** #197
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+
+- `Admin::ParentTagsController`（index/new/create/edit/update/destroy）
+- `Admin::HobbiesController`（new/create/edit/update/destroy）
+- 対応ビュー（一覧・新規作成・編集）
+- ルーティング追加
+- 管理ナビリンク追加
+- `Hobby` モデルの `dependent` 変更（`:destroy` → `:restrict_with_error`）
+
+---
+
+## 2. 目的
+
+- 管理者が親タグ・子タグの構成を一覧で把握・編集できる
+- 使用中の子タグを誤って削除しない仕組みをモデルレベルで保証する
+
+---
+
+## 3. スコープ
+
+### 含むもの
+
+- `/admin/parent_tags` 一覧（room_type セクション分け、フィルター付き）
+- 親タグ・子タグの CRUD
+- 使用中子タグの削除ガード
+
+### 含まないもの
+
+- 「未分類」parent_tag（slug="uncategorized", room_type=nil）→ 一覧から除外（既存の未分類タグ管理画面で管理）
+- 子タグの並び替え（position 管理）→ 将来対応
+- フィルターの Turbo Frame 化 → 後で対応可能な設計にしておく
+
+---
+
+## 4. 設計方針
+
+### Hobby モデルの `dependent` 変更について
+
+| 方式 | 安全性 | 影響範囲 |
+|------|--------|---------|
+| Controller でチェック | 漏れる可能性あり | Controller のみ |
+| **モデルで `restrict_with_error`（採用）** | DB レベルで保証 | アプリ全体 |
+
+**採用理由:** `HobbyMergeService` は destroy 前に `update_all(hobby_id: target.id)` で profile_hobbies を再割当てするため、destroy 時点で 0 件が保証される。モデルレベルの制約が安全。
+
+---
+
+## 5. データ設計
+
+**マイグレーション:** なし（既存テーブル・制約をそのまま活用）
+
+**モデル変更:**
+
+```ruby
+# Hobby モデル（変更箇所のみ）
+has_many :profile_hobbies, dependent: :restrict_with_error  # :destroy → 変更
+```
+
+### DB 制約
+
+| カラム | 制約 | 理由 |
+|--------|------|------|
+| parent_tags.slug | UNIQUE (room_type, slug) | 既存 DB 制約を活用 |
+| hobbies.name | UNIQUE | 既存 DB 制約を活用 |
+| parent_tags → hobbies | restrict_with_error | 子タグがある親タグを削除不可 |
+| hobbies → profile_hobbies | restrict_with_error（変更） | 使用中子タグを削除不可 |
+
+### ER 図
+
+```mermaid
+erDiagram
+  ParentTag {
+    bigint id PK
+    string name "NOT NULL"
+    string slug "NOT NULL"
+    integer room_type "nullable 0=chat 1=study 2=game"
+    integer position "default 0"
+  }
+  Hobby {
+    bigint id PK
+    string name "NOT NULL unique"
+    string normalized_name
+    bigint parent_tag_id FK "nullable"
+  }
+  ProfileHobby {
+    bigint id PK
+    bigint profile_id FK "NOT NULL"
+    bigint hobby_id FK "NOT NULL"
+    string description
+  }
+  ParentTag ||--o{ Hobby : "restrict_with_error"
+  Hobby ||--o{ ProfileHobby : "restrict_with_error(変更)"
+```
+
+---
+
+## 6. 画面・アクセス制御の流れ
+
+### シーケンス図（index）
+
+```mermaid
+sequenceDiagram
+  participant U as Admin
+  participant C as ParentTagsCtrl
+  participant PT as ParentTag
+  participant PH as ProfileHobby
+
+  U->>C: GET /admin/parent_tags?room_type=chat
+  C->>PT: where.not(room_type:nil).includes(:hobbies).where(room_type:params)
+  PT-->>C: parent_tags（hobbies付き）
+  C->>PH: where(hobby_id:).group(:hobby_id).count
+  PH-->>C: usage_counts Hash
+  C->>C: group_by(&:room_type)
+  C-->>U: index ビュー描画
+```
+
+### シーケンス図（Hobby destroy）
+
+```mermaid
+sequenceDiagram
+  participant U as Admin
+  participant C as HobbiesCtrl
+  participant H as Hobby
+
+  U->>C: DELETE /admin/hobbies/:id
+  C->>H: find(params[:id])
+  C->>H: destroy
+  H->>H: restrict_with_error チェック
+  alt profile_hobbies が 0 件
+    H-->>C: 削除成功
+    C-->>U: redirect notice "削除しました"
+  else profile_hobbies が存在
+    H-->>C: errors に追加 abort
+    C-->>U: redirect alert "使用中のため削除できません（N件）"
+  end
+```
+
+---
+
+## 7. アプリケーション設計
+
+**Service 分離:** 不要（各操作は単一モデル、トランザクション不要）
+
+### Admin::ParentTagsController
+
+```ruby
+def index
+  scope = ParentTag.where.not(room_type: nil)
+                   .includes(:hobbies)
+                   .order(:room_type, :position)
+  scope = scope.where(room_type: params[:room_type])   if params[:room_type].present?
+  scope = scope.where(id: params[:parent_tag_id])       if params[:parent_tag_id].present?
+  parent_tags = scope.to_a
+
+  hobby_ids                 = parent_tags.flat_map { |pt| pt.hobbies.map(&:id) }
+  @usage_counts             = ProfileHobby.where(hobby_id: hobby_ids).group(:hobby_id).count
+  @parent_tags_by_room_type = parent_tags.group_by(&:room_type)
+  @all_parent_tags          = ParentTag.where.not(room_type: nil).order(:room_type, :position)
+end
+```
+
+### Admin::HobbiesController#destroy
+
+```ruby
+def destroy
+  @hobby = Hobby.find(params[:id])
+  if @hobby.destroy
+    redirect_to admin_parent_tags_path, notice: "削除しました"
+  else
+    redirect_to admin_parent_tags_path,
+      alert: "使用中のため削除できません（#{@hobby.profile_hobbies.count}件が使用中）"
+  end
+end
+```
+
+---
+
+## 8. ルーティング設計
+
+```ruby
+namespace :admin do
+  root "dashboards#show"
+  resources :parent_tags, only: %i[index new create edit update destroy]
+  resources :hobbies,     only: %i[new create edit update destroy]
+  resources :unclassified_hobbies, only: [:index, :update] do
+    member { post :merge }
+  end
+end
+```
+
+---
+
+## 9. レイアウト / UI 設計
+
+```
+/admin/parent_tags  （一覧：モックアップ通り）
+
+┌ フィルター ─────────────────────────────────┐
+│ 部屋タイプ ▼   親タグ ▼   [検索] [リセット]  │
+└─────────────────────────────────────────────┘
+
+🗨 chat                        ＋親タグ作成  ＋子タグ作成
+┌ 親タグ ──┬ 子タグ ──────┬ 操作 ────────┐
+│ アニメ   │ 進撃の巨人  │ 編集  削除   │
+│ アニメ   │ ワンピース  │ 編集  削除   │
+│ ゲーム   │ Apex        │ 編集  削除   │
+└──────────┴─────────────┴──────────────┘
+
+🎓 study                       ＋親タグ作成  ＋子タグ作成
+...
+
+🎮 game                        ＋親タグ作成  ＋子タグ作成
+...
+```
+
+- 既存管理画面（`admin.html.erb`）のスタイル（ダーク系テーブル）に合わせる
+- `＋親タグ作成` → `/admin/parent_tags/new?room_type=chat`（room_type を pre-select）
+- `＋子タグ作成` → `/admin/hobbies/new?parent_tag_id=1`（親タグを pre-select）
+
+---
+
+## 10. クエリ・性能面
+
+| クエリ | 件数 | 対策 |
+|--------|------|------|
+| parent_tags + hobbies | includes で 2 クエリ | ✅ |
+| profile_hobbies 使用数 | group count で 1 クエリ | ✅ |
+| フィルター用 all_parent_tags | 1 クエリ | 許容範囲 |
+
+**合計: 最大 4 クエリ（N+1 なし）**
+
+---
+
+## 11. トランザクション / Service 分離
+
+**トランザクション:** 不要（各操作は単一モデル）
+**Service 分離:** 不要
+
+---
+
+## 12. 実装対象一覧
+
+| # | 対象 | 内容 |
+|---|------|------|
+| 1 | Model | `Hobby#profile_hobbies` の `dependent` を `:restrict_with_error` に変更 |
+| 2 | Controller | `Admin::ParentTagsController` 新規作成（index/new/create/edit/update/destroy） |
+| 3 | Controller | `Admin::HobbiesController` 新規作成（new/create/edit/update/destroy） |
+| 4 | View | `admin/parent_tags/index.html.erb`（フィルター + room_type セクション + テーブル） |
+| 5 | View | `admin/parent_tags/new.html.erb` / `_form.html.erb` |
+| 6 | View | `admin/parent_tags/edit.html.erb` |
+| 7 | View | `admin/hobbies/new.html.erb` / `_form.html.erb` |
+| 8 | View | `admin/hobbies/edit.html.erb` |
+| 9 | Routes | `resources :parent_tags` / `resources :hobbies` を admin namespace に追加 |
+| 10 | Layout | `admin.html.erb` に「親タグ管理」ナビリンク追加 |
+
+---
+
+## 13. 受入条件
+
+- [ ] フィルター（部屋タイプ・親タグ）で絞り込める
+- [ ] chat / study / game のセクションに分けて表示される
+- [ ] 各セクションに「＋親タグ作成」「＋子タグ作成」ボタンがある
+- [ ] テーブルに「親タグ｜子タグ｜操作（編集・削除）」が表示される
+- [ ] 親タグのCRUDができる（name/slug/room_type を手動入力）
+- [ ] 子タグのCRUDができる
+- [ ] 使用中の子タグ（profile_hobbies あり）は削除できない（件数をエラー表示）
+- [ ] 管理ナビに「親タグ管理」リンクが追加される
+
+---
+
+## 14. この設計の結論
+
+マイグレーション不要・Service不要・既存制約を最大活用する設計。`Hobby#dependent` をモデルレベルで変更し、アプリ全体で一貫した削除ガードを実現する。Turbo Frame 化は後から数行の変更で対応できる構造にしてある。

--- a/spec/models/hobby_spec.rb
+++ b/spec/models/hobby_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe Hobby, type: :model do
       hobby = described_class.new(name: "その他の趣味", parent_tag: nil)
       expect(hobby).to be_valid
     end
+
+    it "profile_hobbies が存在する場合は削除できない" do
+      hobby = create(:hobby)
+      create(:profile_hobby, hobby:)
+
+      expect(hobby.destroy).to be false
+      expect(hobby.errors[:base]).not_to be_empty
+      expect(described_class.exists?(hobby.id)).to be true
+    end
   end
 
   describe "normalized_name" do

--- a/spec/models/parent_tag_spec.rb
+++ b/spec/models/parent_tag_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe ParentTag, type: :model do
       parent_tag = described_class.new(name: "テスト異種B", slug: "test-cross", room_type: :study)
       expect(parent_tag).to be_valid
     end
+
+    it "同じ room_type + name の組み合わせは重複して保存できない" do
+      described_class.create!(name: "テスト名重複", slug: "test-name-dup-a", room_type: :chat)
+      parent_tag = described_class.new(name: "テスト名重複", slug: "test-name-dup-b", room_type: :chat)
+      expect(parent_tag).to be_invalid
+    end
+
+    it "room_type が異なれば同じ name で保存できる" do
+      described_class.create!(name: "テスト名異種", slug: "test-name-cross-a", room_type: :chat)
+      parent_tag = described_class.new(name: "テスト名異種", slug: "test-name-cross-b", room_type: :study)
+      expect(parent_tag).to be_valid
+    end
   end
 
   describe "enum" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,22 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+module TestDatabaseCleanup
+  module_function
+
+  def clean_test_database!
+    connection = ActiveRecord::Base.connection
+    tables = connection.tables - %w[ar_internal_metadata schema_migrations]
+
+    connection.disable_referential_integrity do
+      tables.each do |table|
+        quoted_table = connection.quote_table_name(table)
+        connection.execute("TRUNCATE TABLE #{quoted_table} RESTART IDENTITY CASCADE")
+      end
+    end
+  end
+end
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -74,6 +90,8 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Warden::Test::Helpers, type: :system
   config.after(type: :system) { Warden.test_reset! }
+  config.before(:suite) { TestDatabaseCleanup.clean_test_database! }
+  config.append_after(:each, type: :system, js: true) { TestDatabaseCleanup.clean_test_database! }
 
   # JSなし system spec は rack_test（ブラウザ起動しない）
   config.before(:each, type: :system) do

--- a/spec/requests/admin/hobbies_spec.rb
+++ b/spec/requests/admin/hobbies_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Admin::HobbiesController", type: :request do
   let!(:admin_user) { create(:user, :admin) }
-  let!(:parent_tag) { create(:parent_tag, name: "アニメ", slug: "anime", room_type: :chat) }
+  let!(:parent_tag) { create(:parent_tag, name: "アニメ", room_type: :chat) }
   let!(:hobby) { create(:hobby, name: "進撃の巨人", parent_tag:) }
 
   describe "認可" do

--- a/spec/requests/admin/hobbies_spec.rb
+++ b/spec/requests/admin/hobbies_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe "Admin::HobbiesController", type: :request do
+  let!(:admin_user) { create(:user, :admin) }
+  let!(:parent_tag) { create(:parent_tag, name: "アニメ", slug: "anime", room_type: :chat) }
+  let!(:hobby) { create(:hobby, name: "進撃の巨人", parent_tag:) }
+
+  describe "認可" do
+    context "未ログインの場合" do
+      it "ログインページにリダイレクトされる" do
+        get new_admin_hobby_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "非管理者の場合" do
+      let!(:normal_user) { create(:user) }
+      before { sign_in normal_user }
+
+      it "root_path にリダイレクトされる" do
+        get new_admin_hobby_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "POST /admin/hobbies" do
+    before { sign_in admin_user }
+
+    it "子タグを作成して一覧へ戻る" do
+      expect do
+        post admin_hobbies_path, params: {
+          hobby: { name: "ワンピース", parent_tag_id: parent_tag.id }
+        }
+      end.to change(Hobby, :count).by(1)
+
+      expect(response).to redirect_to(admin_parent_tags_path)
+    end
+  end
+
+  describe "PATCH /admin/hobbies/:id" do
+    before { sign_in admin_user }
+
+    it "子タグを更新して一覧へ戻る" do
+      patch admin_hobby_path(hobby), params: {
+        hobby: { name: "鬼滅の刃", parent_tag_id: parent_tag.id }
+      }
+
+      expect(hobby.reload.name).to eq("鬼滅の刃")
+      expect(response).to redirect_to(admin_parent_tags_path)
+    end
+  end
+
+  describe "DELETE /admin/hobbies/:id" do
+    before { sign_in admin_user }
+
+    it "未使用の子タグは削除できる" do
+      deletable_hobby = create(:hobby, name: "ワンピース", parent_tag:)
+
+      expect do
+        delete admin_hobby_path(deletable_hobby)
+      end.to change(Hobby, :count).by(-1)
+
+      expect(response).to redirect_to(admin_parent_tags_path)
+    end
+
+    it "使用中の子タグは削除できず件数付きで一覧へ戻る" do
+      create_list(:profile_hobby, 2, hobby:)
+
+      expect do
+        delete admin_hobby_path(hobby)
+      end.not_to change(Hobby, :count)
+
+      expect(response).to redirect_to(admin_parent_tags_path)
+      follow_redirect!
+      expect(response.body).to include("使用中のため削除できません（2件が使用中）")
+    end
+  end
+end

--- a/spec/requests/admin/parent_tags_spec.rb
+++ b/spec/requests/admin/parent_tags_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe "Admin::ParentTagsController", type: :request do
   let!(:admin_user) { create(:user, :admin) }
   let!(:chat_parent_tag) { create(:parent_tag, name: "アニメ", room_type: :chat, position: 1) }
   let!(:study_parent_tag) { create(:parent_tag, name: "資格", room_type: :study, position: 2) }
-  let!(:uncategorized_parent_tag) { ParentTag.find_or_create_by!(slug: "uncategorized") { |pt| pt.name = "未分類" } }
+  let!(:uncategorized_parent_tag) do
+    ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類" }
+  end
   let!(:chat_hobby) { create(:hobby, name: "進撃の巨人", parent_tag: chat_parent_tag) }
   let!(:study_hobby) { create(:hobby, name: "簿記", parent_tag: study_parent_tag) }
 

--- a/spec/requests/admin/parent_tags_spec.rb
+++ b/spec/requests/admin/parent_tags_spec.rb
@@ -1,0 +1,114 @@
+require "rails_helper"
+
+RSpec.describe "Admin::ParentTagsController", type: :request do
+  let!(:admin_user) { create(:user, :admin) }
+  let!(:chat_parent_tag) { create(:parent_tag, name: "アニメ", slug: "anime", room_type: :chat, position: 1) }
+  let!(:study_parent_tag) { create(:parent_tag, name: "資格", slug: "license", room_type: :study, position: 2) }
+  let!(:uncategorized_parent_tag) { ParentTag.find_or_create_by!(slug: "uncategorized") { |pt| pt.name = "未分類" } }
+  let!(:chat_hobby) { create(:hobby, name: "進撃の巨人", parent_tag: chat_parent_tag) }
+  let!(:study_hobby) { create(:hobby, name: "簿記", parent_tag: study_parent_tag) }
+
+  describe "GET /admin/parent_tags" do
+    context "未ログインの場合" do
+      it "ログインページにリダイレクトされる" do
+        get admin_parent_tags_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "非管理者の場合" do
+      let!(:normal_user) { create(:user) }
+      before { sign_in normal_user }
+
+      it "root_path にリダイレクトされる" do
+        get admin_parent_tags_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "管理者の場合" do
+      before { sign_in admin_user }
+
+      it "200 OK を返し、未分類親タグを除外して表示する" do
+        get admin_parent_tags_path
+        doc = Nokogiri::HTML(response.body)
+        parent_tag_cells = doc.css("td[data-col='parent-tag']").map(&:text).map(&:strip)
+
+        expect(response).to have_http_status(:ok)
+        expect(parent_tag_cells).to include("アニメ", "資格")
+        expect(parent_tag_cells).not_to include("未分類")
+      end
+
+      it "room_type で絞り込める" do
+        get admin_parent_tags_path, params: { room_type: "chat" }
+        doc = Nokogiri::HTML(response.body)
+        parent_tag_cells = doc.css("td[data-col='parent-tag']").map(&:text).map(&:strip)
+
+        expect(parent_tag_cells).to include("アニメ")
+        expect(parent_tag_cells).not_to include("資格")
+      end
+
+      it "parent_tag_id で絞り込める" do
+        get admin_parent_tags_path, params: { parent_tag_id: study_parent_tag.id }
+        doc = Nokogiri::HTML(response.body)
+        parent_tag_cells = doc.css("td[data-col='parent-tag']").map(&:text).map(&:strip)
+        hobby_cells = doc.css("td[data-col='hobby-name']").map(&:text).map(&:strip)
+
+        expect(parent_tag_cells).to include("資格")
+        expect(hobby_cells).to include("簿記")
+        expect(parent_tag_cells).not_to include("アニメ")
+      end
+    end
+  end
+
+  describe "POST /admin/parent_tags" do
+    before { sign_in admin_user }
+
+    it "親タグを作成して一覧へ戻る" do
+      expect do
+        post admin_parent_tags_path, params: {
+          parent_tag: { name: "スポーツ", slug: "sports", room_type: "game" }
+        }
+      end.to change(ParentTag, :count).by(1)
+
+      expect(response).to redirect_to(admin_parent_tags_path)
+    end
+  end
+
+  describe "PATCH /admin/parent_tags/:id" do
+    before { sign_in admin_user }
+
+    it "親タグを更新して一覧へ戻る" do
+      patch admin_parent_tag_path(chat_parent_tag), params: {
+        parent_tag: { name: "マンガ", slug: "manga", room_type: "chat" }
+      }
+
+      expect(chat_parent_tag.reload.name).to eq("マンガ")
+      expect(response).to redirect_to(admin_parent_tags_path)
+    end
+  end
+
+  describe "DELETE /admin/parent_tags/:id" do
+    before { sign_in admin_user }
+
+    it "子タグがある場合は削除できず、件数付きで一覧へ戻る" do
+      expect do
+        delete admin_parent_tag_path(chat_parent_tag)
+      end.not_to change(ParentTag, :count)
+
+      expect(response).to redirect_to(admin_parent_tags_path)
+      follow_redirect!
+      expect(response.body).to include("子タグが1件あるため削除できません")
+    end
+
+    it "子タグがない場合は削除できる" do
+      deletable_parent_tag = create(:parent_tag, name: "映画", slug: "movie", room_type: :chat)
+
+      expect do
+        delete admin_parent_tag_path(deletable_parent_tag)
+      end.to change(ParentTag, :count).by(-1)
+
+      expect(response).to redirect_to(admin_parent_tags_path)
+    end
+  end
+end

--- a/spec/requests/admin/parent_tags_spec.rb
+++ b/spec/requests/admin/parent_tags_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe "Admin::ParentTagsController", type: :request do
   let!(:admin_user) { create(:user, :admin) }
-  let!(:chat_parent_tag) { create(:parent_tag, name: "アニメ", slug: "anime", room_type: :chat, position: 1) }
-  let!(:study_parent_tag) { create(:parent_tag, name: "資格", slug: "license", room_type: :study, position: 2) }
+  let!(:chat_parent_tag) { create(:parent_tag, name: "アニメ", room_type: :chat, position: 1) }
+  let!(:study_parent_tag) { create(:parent_tag, name: "資格", room_type: :study, position: 2) }
   let!(:uncategorized_parent_tag) { ParentTag.find_or_create_by!(slug: "uncategorized") { |pt| pt.name = "未分類" } }
   let!(:chat_hobby) { create(:hobby, name: "進撃の巨人", parent_tag: chat_parent_tag) }
   let!(:study_hobby) { create(:hobby, name: "簿記", parent_tag: study_parent_tag) }

--- a/spec/requests/admin/unclassified_hobbies_spec.rb
+++ b/spec/requests/admin/unclassified_hobbies_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "Admin::UnclassifiedHobbiesController", type: :request do
   let!(:admin_user) { create(:user, :admin) }
   # Hobby.unclassified は slug: "uncategorized" の親タグに依存するため find_or_create_by! を使う
-  let!(:uncategorized_parent_tag) { ParentTag.find_or_create_by!(slug: "uncategorized") { |pt| pt.name = "未分類" } }
+  let!(:uncategorized_parent_tag) do
+    ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類" }
+  end
   let!(:classified_parent_tag)    { create(:parent_tag) }
 
   # -----------------------------------------------------------------------

--- a/spec/system/admin/parent_tags_spec.rb
+++ b/spec/system/admin/parent_tags_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe "Admin 親タグ管理", type: :system do
   let!(:chat_parent_tag) { create(:parent_tag, name: "アニメ", room_type: :chat, position: 1) }
   let!(:study_parent_tag) { create(:parent_tag, name: "資格", room_type: :study, position: 2) }
   let!(:game_parent_tag) { create(:parent_tag, name: "FPS", room_type: :game, position: 3) }
-  let!(:uncategorized_parent_tag) { ParentTag.find_or_create_by!(slug: "uncategorized") { |pt| pt.name = "未分類" } }
+  let!(:uncategorized_parent_tag) do
+    ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類" }
+  end
   let!(:chat_hobby) { create(:hobby, name: "進撃の巨人", parent_tag: chat_parent_tag) }
   let!(:used_hobby) { create(:hobby, name: "簿記", parent_tag: study_parent_tag) }
 

--- a/spec/system/admin/parent_tags_spec.rb
+++ b/spec/system/admin/parent_tags_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "Admin 親タグ管理", type: :system do
   let!(:admin_user) { create(:user, :admin) }
-  let!(:chat_parent_tag) { create(:parent_tag, name: "アニメ", slug: "anime", room_type: :chat, position: 1) }
-  let!(:study_parent_tag) { create(:parent_tag, name: "資格", slug: "license", room_type: :study, position: 2) }
-  let!(:game_parent_tag) { create(:parent_tag, name: "FPS", slug: "fps", room_type: :game, position: 3) }
+  let!(:chat_parent_tag) { create(:parent_tag, name: "アニメ", room_type: :chat, position: 1) }
+  let!(:study_parent_tag) { create(:parent_tag, name: "資格", room_type: :study, position: 2) }
+  let!(:game_parent_tag) { create(:parent_tag, name: "FPS", room_type: :game, position: 3) }
   let!(:uncategorized_parent_tag) { ParentTag.find_or_create_by!(slug: "uncategorized") { |pt| pt.name = "未分類" } }
   let!(:chat_hobby) { create(:hobby, name: "進撃の巨人", parent_tag: chat_parent_tag) }
   let!(:used_hobby) { create(:hobby, name: "簿記", parent_tag: study_parent_tag) }

--- a/spec/system/admin/parent_tags_spec.rb
+++ b/spec/system/admin/parent_tags_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe "Admin 親タグ管理", type: :system do
+  let!(:admin_user) { create(:user, :admin) }
+  let!(:chat_parent_tag) { create(:parent_tag, name: "アニメ", slug: "anime", room_type: :chat, position: 1) }
+  let!(:study_parent_tag) { create(:parent_tag, name: "資格", slug: "license", room_type: :study, position: 2) }
+  let!(:game_parent_tag) { create(:parent_tag, name: "FPS", slug: "fps", room_type: :game, position: 3) }
+  let!(:uncategorized_parent_tag) { ParentTag.find_or_create_by!(slug: "uncategorized") { |pt| pt.name = "未分類" } }
+  let!(:chat_hobby) { create(:hobby, name: "進撃の巨人", parent_tag: chat_parent_tag) }
+  let!(:used_hobby) { create(:hobby, name: "簿記", parent_tag: study_parent_tag) }
+
+  before do
+    create(:profile_hobby, hobby: used_hobby)
+    login_as(admin_user, scope: :user)
+  end
+
+  it "一覧で room_type ごとのセクション、フィルター、CRUD 導線、ナビリンクを表示できる" do
+    visit admin_parent_tags_path
+
+    expect(page).to have_link("親タグ管理", href: admin_parent_tags_path)
+    expect(page).to have_select("room_type")
+    expect(page).to have_select("parent_tag_id")
+
+    expect(page).to have_content("chat")
+    expect(page).to have_content("study")
+    expect(page).to have_content("game")
+    expect(page).to have_content("アニメ")
+    expect(page).to have_content("進撃の巨人")
+    expect(page).to have_content("簿記")
+    expect(page).not_to have_css("td[data-col='parent-tag']", text: "未分類")
+
+    expect(page).to have_link("＋親タグ作成", href: new_admin_parent_tag_path(room_type: "chat"))
+    expect(page).to have_link("＋子タグ作成", href: new_admin_hobby_path(parent_tag_id: chat_parent_tag.id))
+  end
+
+  it "フィルターで親タグを絞り込める" do
+    visit admin_parent_tags_path
+
+    select "study", from: "room_type"
+    click_button "検索"
+
+    expect(page).to have_css("td[data-col='parent-tag']", text: "資格")
+    expect(page).to have_css("td[data-col='hobby-name']", text: "簿記")
+    expect(page).not_to have_css("td[data-col='parent-tag']", text: "アニメ")
+  end
+
+  it "使用中の子タグを削除しようとするとエラーが表示される" do
+    visit admin_parent_tags_path
+
+    within "[data-hobby-id='#{used_hobby.id}']" do
+      click_button "削除"
+    end
+
+    expect(page).to have_content("使用中のため削除できません（1件が使用中）")
+  end
+end

--- a/spec/system/admin/unclassified_hobbies_spec.rb
+++ b/spec/system/admin/unclassified_hobbies_spec.rb
@@ -2,8 +2,15 @@ require "rails_helper"
 
 RSpec.describe "Admin 未分類タグ管理", type: :system do
   let!(:admin_user) { create(:user, :admin) }
-  let!(:uncategorized_parent_tag) { ParentTag.find_or_create_by!(slug: "uncategorized") { |pt| pt.name = "未分類" } }
-  let!(:programming_parent_tag)   { ParentTag.find_or_create_by!(slug: "programming") { |pt| pt.name = "プログラミング"; pt.room_type = :study; pt.position = 1 } }
+  let!(:uncategorized_parent_tag) do
+    ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類" }
+  end
+  let!(:programming_parent_tag) do
+    ParentTag.find_or_create_by!(slug: "programming", room_type: :study) do |pt|
+      pt.name = "プログラミング"
+      pt.position = 1
+    end
+  end
 
   before { login_as(admin_user, scope: :user) }
 

--- a/spec/system/my/profile_tag_description_spec.rb
+++ b/spec/system/my/profile_tag_description_spec.rb
@@ -118,8 +118,8 @@ RSpec.describe "タグ説明文入力UI", type: :system, js: true do
       find("[data-testid='tag-input']").send_keys(:return)
       click_button "更新する"
 
-      expect(page).to have_text("プロフィールを更新しました")
       expect(page).to have_current_path(profile_path(current_profile))
+      expect(page).to have_text("テスト自己紹介です")
       expect(current_profile.reload.bio).to eq("テスト自己紹介です")
     end
   end

--- a/spec/system/profile_hobbies_flow_spec.rb
+++ b/spec/system/profile_hobbies_flow_spec.rb
@@ -1,6 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "趣味(タグ)登録の一連の流れ", type: :system, js: true do
+  # ProfileHobbiesUpdater が find_by!(slug: "uncategorized") を呼ぶため必須
+  let!(:uncategorized_parent_tag) do
+    ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) do |pt|
+      pt.name = "未分類"
+      pt.position = 0
+    end
+  end
+
   it "ログインして、プロフィール編集でタグを更新し、詳細に表示させる" do
     user = create(:user)
     create(:profile, user: user)
@@ -9,10 +17,15 @@ RSpec.describe "趣味(タグ)登録の一連の流れ", type: :system, js: true
     visit edit_my_profile_path
     click_on "タグ"
 
+    # chip が DOM に追加されるまで待ってから次のタグを入力する（JS タイミング対策）
     fill_in "tag-input", with: "rails"
     find("[data-testid='tag-input']").send_keys(:return)
+    expect(page).to have_css("[data-testid='chip']", text: "rails")
+
     fill_in "tag-input", with: "ruby"
     find("[data-testid='tag-input']").send_keys(:return)
+    expect(page).to have_css("[data-testid='chip']", text: "ruby")
+
     click_button "更新する"
 
     expect(page).to have_content("rails")


### PR DESCRIPTION
## Summary
- `/admin/parent_tags` に room_type（chat / study / game）セクション別の親タグ・子タグ一覧を追加
- 部屋タイプ・親タグによるフィルター機能（GET パラメータ方式）
- 親タグ・子タグの CRUD（新規作成・編集・削除）
- 使用中の子タグ（profile_hobbies あり）は削除不可（件数付きエラー表示）
- 管理ナビに「親タグ管理」リンクを追加
- `Hobby#profile_hobbies` の `dependent` を `:restrict_with_error` に変更（モデルレベルの削除ガード）

## Test plan
- [x] RSpec: 404 examples, 0 failures（全通過確認済み）
- [x] RuboCop: no offenses
- [x] 親タグ一覧が room_type セクション別に表示される
- [x] フィルターで絞り込みができる
- [x] 親タグ・子タグの作成・編集・削除が動作する
- [x] 使用中の子タグ削除時にエラー（件数付き）が表示される
- [x] 未管理者・未ログインのアクセスが適切にリダイレクトされる

## Related
- Issue: #197