### PR TITLE
feat: Hobby × ParentTag を多対多にリファクタ（hobby_parent_tags 中間テーブル追加） #218

### DIFF
--- a/app/controllers/admin/hobbies_controller.rb
+++ b/app/controllers/admin/hobbies_controller.rb
@@ -3,12 +3,14 @@ class Admin::HobbiesController < Admin::BaseController
   before_action :set_parent_tags, only: %i[new create edit update]
 
   def new
-    @hobby = Hobby.new(parent_tag_id: params[:parent_tag_id])
+    @hobby = Hobby.new
+    @initial_parent_tag = ParentTag.find_by(id: params[:parent_tag_id])
   end
 
   def create
-    @hobby = Hobby.new(hobby_params)
+    @hobby = Hobby.new(name: hobby_params[:name])
     if @hobby.save
+      classify_hobby(@hobby)
       redirect_to admin_parent_tags_path, notice: "子タグを作成しました"
     else
       render :new, status: :unprocessable_entity
@@ -18,7 +20,8 @@ class Admin::HobbiesController < Admin::BaseController
   def edit; end
 
   def update
-    if @hobby.update(hobby_params)
+    if @hobby.update(name: hobby_params[:name])
+      classify_hobby(@hobby)
       redirect_to admin_parent_tags_path, notice: "子タグを更新しました"
     else
       render :edit, status: :unprocessable_entity
@@ -41,10 +44,25 @@ class Admin::HobbiesController < Admin::BaseController
   end
 
   def set_parent_tags
-    @parent_tags = ParentTag.classified.order(:room_type, :position, :id)
+    @parent_tags_by_room_type = ParentTag.order(:room_type, :position).group_by(&:room_type)
   end
 
   def hobby_params
-    params.require(:hobby).permit(:name, :parent_tag_id)
+    params.require(:hobby).permit(
+      :name,
+      :chat_parent_tag_id,
+      :study_parent_tag_id,
+      :game_parent_tag_id
+    )
+  end
+
+  def classify_hobby(hobby)
+    ParentTag.room_types.each_key do |room_type|
+      parent_tag_id = hobby_params[:"#{room_type}_parent_tag_id"]
+      next if parent_tag_id.blank?
+
+      parent_tag = ParentTag.find(parent_tag_id)
+      Admin::HobbyClassificationService.call(hobby:, parent_tag:)
+    end
   end
 end

--- a/app/controllers/admin/hobbies_controller.rb
+++ b/app/controllers/admin/hobbies_controller.rb
@@ -10,7 +10,7 @@ class Admin::HobbiesController < Admin::BaseController
   def create
     @hobby = Hobby.new(name: hobby_params[:name])
     if @hobby.save
-      classify_hobby(@hobby)
+      Admin::HobbyClassificationService.call_bulk(hobby: @hobby, room_type_to_parent_tag_id: bulk_parent_tag_params)
       redirect_to admin_parent_tags_path, notice: "子タグを作成しました"
     else
       render :new, status: :unprocessable_entity
@@ -21,7 +21,7 @@ class Admin::HobbiesController < Admin::BaseController
 
   def update
     if @hobby.update(name: hobby_params[:name])
-      classify_hobby(@hobby)
+      Admin::HobbyClassificationService.call_bulk(hobby: @hobby, room_type_to_parent_tag_id: bulk_parent_tag_params)
       redirect_to admin_parent_tags_path, notice: "子タグを更新しました"
     else
       render :edit, status: :unprocessable_entity
@@ -56,13 +56,9 @@ class Admin::HobbiesController < Admin::BaseController
     )
   end
 
-  def classify_hobby(hobby)
-    ParentTag.room_types.each_key do |room_type|
-      parent_tag_id = hobby_params[:"#{room_type}_parent_tag_id"]
-      next if parent_tag_id.blank?
-
-      parent_tag = ParentTag.find(parent_tag_id)
-      Admin::HobbyClassificationService.call(hobby:, parent_tag:)
+  def bulk_parent_tag_params
+    ParentTag.room_types.keys.to_h do |room_type|
+      [ room_type, hobby_params[:"#{room_type}_parent_tag_id"] ]
     end
   end
 end

--- a/app/controllers/admin/unclassified_hobbies_controller.rb
+++ b/app/controllers/admin/unclassified_hobbies_controller.rb
@@ -12,11 +12,11 @@ class Admin::UnclassifiedHobbiesController < Admin::BaseController
 
   def update
     @hobby = Hobby.unclassified.find(params[:id])
-    if @hobby.update(parent_tag_id: params[:parent_tag_id])
-      redirect_to admin_unclassified_hobbies_path, notice: "分類しました"
-    else
-      redirect_to admin_unclassified_hobbies_path, alert: "分類に失敗しました"
-    end
+    parent_tag = ParentTag.find(params[:parent_tag_id])
+    Admin::HobbyClassificationService.call(hobby: @hobby, parent_tag:)
+    redirect_to admin_unclassified_hobbies_path, notice: "分類しました"
+  rescue ActiveRecord::RecordInvalid
+    redirect_to admin_unclassified_hobbies_path, alert: "分類に失敗しました"
   end
 
   def merge

--- a/app/controllers/admin/unclassified_hobbies_controller.rb
+++ b/app/controllers/admin/unclassified_hobbies_controller.rb
@@ -7,6 +7,7 @@ class Admin::UnclassifiedHobbiesController < Admin::BaseController
     scope = scope.where("hobbies.name LIKE ?", "%#{ActiveRecord::Base.sanitize_sql_like(params[:q])}%") if params[:q].present?
     @hobbies = scope
     @parent_tags = ParentTag.order(:room_type, :position)
+    @grouped_parent_tag_options = build_grouped_parent_tag_options
     @all_hobbies_grouped = build_all_hobbies_grouped
   end
 
@@ -32,12 +33,20 @@ class Admin::UnclassifiedHobbiesController < Admin::BaseController
 
   private
 
+  def build_grouped_parent_tag_options
+    ParentTag.room_types.keys.to_h do |room_type|
+      [
+        room_type,
+        @parent_tags.select { |pt| pt.room_type == room_type }.map { |pt| [ pt.name, pt.id ] }
+      ]
+    end
+  end
+
   def build_all_hobbies_grouped
     grouped_hobbies = Hobby.includes(:hobby_parent_tags)
                            .order(:name)
                            .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |hobby, hash|
-      room_type = hobby.hobby_parent_tags.min_by(&:room_type_before_type_cast)&.room_type || "unclassified"
-      hash[room_type] << [ hobby.name, hobby.id ]
+      hash[hobby.primary_room_type] << [ hobby.name, hobby.id ]
     end
 
     ParentTag.room_types.keys

--- a/app/controllers/admin/unclassified_hobbies_controller.rb
+++ b/app/controllers/admin/unclassified_hobbies_controller.rb
@@ -37,7 +37,7 @@ class Admin::UnclassifiedHobbiesController < Admin::BaseController
                            .order(:name)
                            .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |hobby, hash|
       room_type = hobby.hobby_parent_tags.min_by(&:room_type_before_type_cast)&.room_type || "unclassified"
-      hash[room_type] << [hobby.name, hobby.id]
+      hash[room_type] << [ hobby.name, hobby.id ]
     end
 
     ParentTag.room_types.keys

--- a/app/controllers/admin/unclassified_hobbies_controller.rb
+++ b/app/controllers/admin/unclassified_hobbies_controller.rb
@@ -7,7 +7,7 @@ class Admin::UnclassifiedHobbiesController < Admin::BaseController
     scope = scope.where("hobbies.name LIKE ?", "%#{ActiveRecord::Base.sanitize_sql_like(params[:q])}%") if params[:q].present?
     @hobbies = scope
     @parent_tags = ParentTag.order(:room_type, :position)
-    @all_hobbies = Hobby.order(:name).pluck(:name, :id)
+    @all_hobbies_grouped = build_all_hobbies_grouped
   end
 
   def update
@@ -28,5 +28,21 @@ class Admin::UnclassifiedHobbiesController < Admin::BaseController
     else
       redirect_to admin_unclassified_hobbies_path, alert: result.error
     end
+  end
+
+  private
+
+  def build_all_hobbies_grouped
+    grouped_hobbies = Hobby.includes(:hobby_parent_tags)
+                           .order(:name)
+                           .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |hobby, hash|
+      room_type = hobby.hobby_parent_tags.min_by(&:room_type_before_type_cast)&.room_type || "unclassified"
+      hash[room_type] << [hobby.name, hobby.id]
+    end
+
+    ParentTag.room_types.keys
+             .append("unclassified")
+             .index_with { |room_type| grouped_hobbies[room_type] }
+             .reject { |_, hobbies| hobbies.empty? }
   end
 end

--- a/app/controllers/my/profiles_controller.rb
+++ b/app/controllers/my/profiles_controller.rb
@@ -11,14 +11,15 @@ class My::ProfilesController < ApplicationController
     @profile = current_user.build_profile(profile_params.except(:hobbies_text))
     @profile.hobbies_text = profile_params[:hobbies_text]
 
-    if @profile.save
+    ApplicationRecord.transaction do
+      @profile.save!
       @profile.update_hobbies_from_json(@profile.hobbies_text)
-      redirect_to profile_path(@profile), notice: "プロフィールを作成しました"
-    else
-      @hobbies_text = @profile.hobbies_text
-      flash.now[:alert] = "プロフィールを作成できませんでした"
-      render :new, status: :unprocessable_entity
     end
+    redirect_to profile_path(@profile), notice: "プロフィールを作成しました"
+  rescue ActiveRecord::RecordInvalid
+    @hobbies_text = @profile.hobbies_text
+    flash.now[:alert] = "プロフィールを作成できませんでした"
+    render :new, status: :unprocessable_entity
   end
 
   def edit
@@ -29,14 +30,16 @@ class My::ProfilesController < ApplicationController
 
   def update
     @profile.hobbies_text = profile_params[:hobbies_text]
-    if @profile.update(profile_params.except(:hobbies_text))
+
+    ApplicationRecord.transaction do
+      @profile.update!(profile_params.except(:hobbies_text))
       @profile.update_hobbies_from_json(@profile.hobbies_text) if @profile.hobbies_text.present?
-      redirect_to profile_path(@profile), notice: "プロフィールを更新しました"
-    else
-      @hobbies_text = @profile.hobbies_text
-      flash.now[:alert] = "プロフィールを更新できませんでした"
-      render :edit, status: :unprocessable_entity
     end
+    redirect_to profile_path(@profile), notice: "プロフィールを更新しました"
+  rescue ActiveRecord::RecordInvalid
+    @hobbies_text = @profile.hobbies_text
+    flash.now[:alert] = "プロフィールを更新できませんでした"
+    render :edit, status: :unprocessable_entity
   end
 
   def destroy

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -12,7 +12,7 @@ class ProfilesController < ApplicationController
   def show
     @profile = Profile.includes(
       :hobbies,
-      profile_hobbies: { hobby: :parent_tag },
+      profile_hobbies: { hobby: :hobby_parent_tags },
       user: { avatar_attachment: :blob }
     ).find_by(id: params[:id])
     return redirect_to profiles_path, alert: "プロフィールが見つかりません" unless @profile

--- a/app/controllers/rooms/members_controller.rb
+++ b/app/controllers/rooms/members_controller.rb
@@ -20,7 +20,7 @@ module Rooms
       # 1. 表示対象プロフィールを取得
       # user / hobbies を eager load して N+1 クエリを防ぐ
       # --------------------------------------------------
-      @profile = Profile.includes(:user, profile_hobbies: { hobby: :parent_tag }).find(params[:id])
+      @profile = Profile.includes(:user, profile_hobbies: { hobby: :hobby_parent_tags }).find(params[:id])
 
       # --------------------------------------------------
       # 2. 部屋のroom_typeに一致する親タグを持つ子タグのみ抽出
@@ -29,7 +29,7 @@ module Rooms
       # メモリ内で比較可能。eager load 済みなので追加クエリなし。
       # --------------------------------------------------
       @room_related_phs = @profile.profile_hobbies.select do |ph|
-        ph.hobby.parent_tag&.room_type == @room.room_type
+        ph.hobby.hobby_parent_tags.any? { |hpt| hpt.room_type == @room.room_type }
       end
     end
 

--- a/app/controllers/shares_controller.rb
+++ b/app/controllers/shares_controller.rb
@@ -25,7 +25,7 @@ class SharesController < ApplicationController
 
   def memberships_for_display
     @room.room_memberships
-         .includes(profile: [ :user, { profile_hobbies: { hobby: :parent_tag } } ])
+         .includes(profile: [ :user, { profile_hobbies: { hobby: :hobby_parent_tags } } ])
          .order(created_at: :asc)
   end
 

--- a/app/models/hobby.rb
+++ b/app/models/hobby.rb
@@ -3,6 +3,9 @@ class Hobby < ApplicationRecord
 
   scope :unclassified, -> { where(parent_tag: ParentTag.where(slug: "uncategorized")) }
 
+  has_many :hobby_parent_tags, dependent: :destroy
+  has_many :parent_tags, through: :hobby_parent_tags
+
   has_many :profile_hobbies, dependent: :restrict_with_error
   has_many :profiles, through: :profile_hobbies
 

--- a/app/models/hobby.rb
+++ b/app/models/hobby.rb
@@ -1,7 +1,7 @@
 class Hobby < ApplicationRecord
   belongs_to :parent_tag, optional: true
 
-  scope :unclassified, -> { where(parent_tag: ParentTag.where(slug: "uncategorized")) }
+  scope :unclassified, -> { left_joins(:hobby_parent_tags).where(hobby_parent_tags: { id: nil }) }
 
   has_many :hobby_parent_tags, dependent: :destroy
   has_many :parent_tags, through: :hobby_parent_tags

--- a/app/models/hobby.rb
+++ b/app/models/hobby.rb
@@ -1,6 +1,4 @@
 class Hobby < ApplicationRecord
-  belongs_to :parent_tag, optional: true
-
   scope :unclassified, -> { left_joins(:hobby_parent_tags).where(hobby_parent_tags: { id: nil }) }
 
   has_many :hobby_parent_tags, dependent: :destroy

--- a/app/models/hobby.rb
+++ b/app/models/hobby.rb
@@ -4,6 +4,10 @@ class Hobby < ApplicationRecord
   has_many :hobby_parent_tags, dependent: :destroy
   has_many :parent_tags, through: :hobby_parent_tags
 
+  def primary_room_type
+    hobby_parent_tags.min_by { |hpt| HobbyParentTag.room_types[hpt.room_type] }&.room_type || "unclassified"
+  end
+
   has_many :profile_hobbies, dependent: :restrict_with_error
   has_many :profiles, through: :profile_hobbies
 

--- a/app/models/hobby_parent_tag.rb
+++ b/app/models/hobby_parent_tag.rb
@@ -12,7 +12,7 @@ class HobbyParentTag < ApplicationRecord
   private
 
   def sync_room_type
-    return unless parent_tag.present? && room_type.blank?
+    return unless parent_tag_id.present? && room_type.nil?
 
     self.room_type = parent_tag.room_type
   end

--- a/app/models/hobby_parent_tag.rb
+++ b/app/models/hobby_parent_tag.rb
@@ -1,0 +1,19 @@
+class HobbyParentTag < ApplicationRecord
+  belongs_to :hobby
+  belongs_to :parent_tag
+
+  enum :room_type, { chat: 0, study: 1, game: 2 }
+
+  validates :hobby_id, uniqueness: { scope: :room_type }
+  validates :parent_tag_id, uniqueness: { scope: :hobby_id }
+
+  before_validation :sync_room_type
+
+  private
+
+  def sync_room_type
+    return unless parent_tag.present? && room_type.blank?
+
+    self.room_type = parent_tag.room_type
+  end
+end

--- a/app/models/parent_tag.rb
+++ b/app/models/parent_tag.rb
@@ -3,7 +3,8 @@ class ParentTag < ApplicationRecord
 
   scope :classified, -> { where.not(room_type: nil) }
 
-  has_many :hobbies, dependent: :restrict_with_error
+  has_many :hobby_parent_tags, dependent: :restrict_with_error
+  has_many :hobbies, through: :hobby_parent_tags
 
   validates :name, presence: true, uniqueness: { scope: :room_type }
   validates :slug, presence: true, uniqueness: { scope: :room_type }

--- a/app/queries/profile_search_query.rb
+++ b/app/queries/profile_search_query.rb
@@ -41,7 +41,7 @@ class ProfileSearchQuery
   end
 
   def base_scope
-    Profile.includes(profile_hobbies: { hobby: :parent_tag }, user: { avatar_attachment: :blob }).order(created_at: :desc)
+    Profile.includes(profile_hobbies: { hobby: :hobby_parent_tags }, user: { avatar_attachment: :blob }).order(created_at: :desc)
   end
 
   def sanitize_sql_like(str)

--- a/app/services/admin/hobby_classification_service.rb
+++ b/app/services/admin/hobby_classification_service.rb
@@ -1,0 +1,13 @@
+class Admin::HobbyClassificationService
+  def self.call(hobby:, parent_tag:)
+    ApplicationRecord.transaction do
+      hobby_parent_tag = hobby.hobby_parent_tags.find_by(room_type: parent_tag.room_type)
+
+      if hobby_parent_tag
+        hobby_parent_tag.update!(parent_tag:)
+      else
+        hobby.hobby_parent_tags.create!(parent_tag:)
+      end
+    end
+  end
+end

--- a/app/services/admin/hobby_classification_service.rb
+++ b/app/services/admin/hobby_classification_service.rb
@@ -10,4 +10,24 @@ class Admin::HobbyClassificationService
       end
     end
   end
+
+  # room_type ごとの parent_tag_id を一括処理する。parent_tags を一括取得して N+1 を防ぐ。
+  # room_type_to_parent_tag_id: { "chat" => "1", "study" => "", "game" => "3" } のような Hash
+  def self.call_bulk(hobby:, room_type_to_parent_tag_id:)
+    ids = room_type_to_parent_tag_id.values.reject(&:blank?).map(&:to_i)
+    return if ids.empty?
+
+    parent_tags = ParentTag.where(id: ids).index_by { |pt| pt.id.to_s }
+
+    ApplicationRecord.transaction do
+      room_type_to_parent_tag_id.each_value do |parent_tag_id|
+        next if parent_tag_id.blank?
+
+        parent_tag = parent_tags[parent_tag_id.to_s]
+        next unless parent_tag
+
+        call(hobby:, parent_tag:)
+      end
+    end
+  end
 end

--- a/app/services/jsmind_data_builder.rb
+++ b/app/services/jsmind_data_builder.rb
@@ -59,6 +59,8 @@ class JsmindDataBuilder
   end
 
   # room_memberships は DB 制約でユニーク保証済みだが、防御的に uniq を適用
+  # 呼び出し元で以下の includes が必須（未設定時に N+1 が発生する）:
+  #   includes(profile: [:user, { profile_hobbies: { hobby: :hobby_parent_tags } }])
   def all_profiles
     @all_profiles ||= @memberships.map(&:profile).uniq(&:id)
   end

--- a/app/services/jsmind_data_builder.rb
+++ b/app/services/jsmind_data_builder.rb
@@ -78,7 +78,11 @@ class JsmindDataBuilder
   def profiles_by_parent_tag_id
     @profiles_by_parent_tag_id ||=
       all_profiles.each_with_object(Hash.new { |h, k| h[k] = [] }) do |profile, hash|
-        profile.profile_hobbies.each { |ph| hash[ph.hobby.parent_tag_id] << profile }
+        profile.profile_hobbies.each do |profile_hobby|
+          profile_hobby.hobby.hobby_parent_tags.each do |hobby_parent_tag|
+            hash[hobby_parent_tag.parent_tag_id] << profile
+          end
+        end
       end
   end
 

--- a/app/services/profile_hobbies_updater.rb
+++ b/app/services/profile_hobbies_updater.rb
@@ -6,9 +6,6 @@ class ProfileHobbiesUpdater
       .reject { |t| t[:name].blank? }
       .uniq { |t| t[:name] }
 
-    # 辞書にない新規 Hobby に自動設定する未分類の親タグ
-    uncategorized = ParentTag.find_by!(slug: "uncategorized", room_type: nil)
-
     ApplicationRecord.transaction do
       target_names = normalized.map { |t| t[:name] }
 
@@ -38,7 +35,6 @@ class ProfileHobbiesUpdater
         hobby = existing_hobbies[tag[:name]] ||
                 Hobby.find_or_create_by!(normalized_name: tag[:name]) do |h|
                   h.name = tag[:name]
-                  h.parent_tag_id = uncategorized.id
                 end
 
         ph = existing_phs[tag[:name]] || ProfileHobby.new(profile:, hobby:)

--- a/app/views/admin/hobbies/_form.html.erb
+++ b/app/views/admin/hobbies/_form.html.erb
@@ -15,7 +15,7 @@
       <%= f.text_field :name, style: "width: 100%; box-sizing: border-box; background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.625rem 0.75rem; border-radius: 0.375rem;" %>
     </div>
 
-    <% room_type_labels = { "chat" => "チャット", "study" => "スタディ", "game" => "ゲーム" } %>
+    <% room_type_labels = { "chat" => "chat", "study" => "study", "game" => "game" } %>
     <% ParentTag.room_types.each_key do |room_type| %>
       <%
         param_name = "#{room_type}_parent_tag_id"

--- a/app/views/admin/hobbies/_form.html.erb
+++ b/app/views/admin/hobbies/_form.html.erb
@@ -15,13 +15,27 @@
       <%= f.text_field :name, style: "width: 100%; box-sizing: border-box; background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.625rem 0.75rem; border-radius: 0.375rem;" %>
     </div>
 
-    <div>
-      <%= f.label :parent_tag_id, "親タグ", style: "display: block; margin-bottom: 0.375rem; color: #e5e7eb;" %>
-      <%= f.select :parent_tag_id,
-            @parent_tags.map { |parent_tag| [parent_tag.name, parent_tag.id] },
-            { prompt: "選択してください" },
-            { style: "width: 100%; box-sizing: border-box; background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.625rem 0.75rem; border-radius: 0.375rem;" } %>
-    </div>
+    <% room_type_labels = { "chat" => "チャット", "study" => "スタディ", "game" => "ゲーム" } %>
+    <% ParentTag.room_types.each_key do |room_type| %>
+      <%
+        param_name = "#{room_type}_parent_tag_id"
+        current_hobby_parent_tag = hobby.hobby_parent_tags.find { |hobby_parent_tag| hobby_parent_tag.room_type == room_type }
+        current_id = if defined?(@initial_parent_tag) && @initial_parent_tag&.room_type == room_type
+                       @initial_parent_tag.id
+                     else
+                       current_hobby_parent_tag&.parent_tag_id
+                     end
+        options = (@parent_tags_by_room_type[room_type] || []).map { |parent_tag| [parent_tag.name, parent_tag.id] }
+      %>
+      <div>
+        <%= f.label param_name, "#{room_type_labels[room_type]}の親タグ",
+              style: "display: block; margin-bottom: 0.375rem; color: #e5e7eb;" %>
+        <%= f.select param_name,
+              options,
+              { include_blank: "（なし）", selected: current_id },
+              { style: "width: 100%; box-sizing: border-box; background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.625rem 0.75rem; border-radius: 0.375rem;" } %>
+      </div>
+    <% end %>
 
     <div style="display: flex; gap: 0.75rem;">
       <%= f.submit submit_label, style: "background: #2563eb; color: white; border: none; padding: 0.625rem 1rem; border-radius: 0.375rem; cursor: pointer;" %>

--- a/app/views/admin/hobbies/_form.html.erb
+++ b/app/views/admin/hobbies/_form.html.erb
@@ -15,7 +15,6 @@
       <%= f.text_field :name, style: "width: 100%; box-sizing: border-box; background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.625rem 0.75rem; border-radius: 0.375rem;" %>
     </div>
 
-    <% room_type_labels = { "chat" => "chat", "study" => "study", "game" => "game" } %>
     <% ParentTag.room_types.each_key do |room_type| %>
       <%
         param_name = "#{room_type}_parent_tag_id"
@@ -28,7 +27,7 @@
         options = (@parent_tags_by_room_type[room_type] || []).map { |parent_tag| [parent_tag.name, parent_tag.id] }
       %>
       <div>
-        <%= f.label param_name, "#{room_type_labels[room_type]}の親タグ",
+        <%= f.label param_name, "#{room_type}の親タグ",
               style: "display: block; margin-bottom: 0.375rem; color: #e5e7eb;" %>
         <%= f.select param_name,
               options,

--- a/app/views/admin/unclassified_hobbies/index.html.erb
+++ b/app/views/admin/unclassified_hobbies/index.html.erb
@@ -26,16 +26,8 @@
           <td style="padding: 0.5rem 1rem;"><%= hobby.user_count %></td>
           <td style="padding: 0.5rem 1rem;">
             <%= form_with url: admin_unclassified_hobby_path(hobby), method: :patch, local: true do |f| %>
-              <% grouped_parent_tag_options = ParentTag.room_types.keys.to_h do |room_type|
-                   [
-                     room_type,
-                     @parent_tags
-                       .select { |parent_tag| parent_tag.room_type == room_type }
-                       .map { |parent_tag| [parent_tag.name, parent_tag.id] }
-                   ]
-                 end %>
               <%= select_tag :parent_tag_id,
-                    grouped_options_for_select(grouped_parent_tag_options),
+                    grouped_options_for_select(@grouped_parent_tag_options),
                     prompt: "選択してください",
                     style: "background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.25rem;" %>
               <%= f.submit "分類",

--- a/app/views/admin/unclassified_hobbies/index.html.erb
+++ b/app/views/admin/unclassified_hobbies/index.html.erb
@@ -26,8 +26,16 @@
           <td style="padding: 0.5rem 1rem;"><%= hobby.user_count %></td>
           <td style="padding: 0.5rem 1rem;">
             <%= form_with url: admin_unclassified_hobby_path(hobby), method: :patch, local: true do |f| %>
+              <% grouped_parent_tag_options = ParentTag.room_types.keys.to_h do |room_type|
+                   [
+                     room_type,
+                     @parent_tags
+                       .select { |parent_tag| parent_tag.room_type == room_type }
+                       .map { |parent_tag| [parent_tag.name, parent_tag.id] }
+                   ]
+                 end %>
               <%= select_tag :parent_tag_id,
-                    options_for_select(@parent_tags.map { |pt| [pt.name, pt.id] }),
+                    grouped_options_for_select(grouped_parent_tag_options),
                     prompt: "選択してください",
                     style: "background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.25rem;" %>
               <%= f.submit "分類",
@@ -36,8 +44,11 @@
           </td>
           <td style="padding: 0.5rem 1rem;">
             <%= form_with url: merge_admin_unclassified_hobby_path(hobby), method: :post, local: true do |f| %>
+              <% target_hobby_groups = @all_hobbies_grouped.transform_values do |grouped_hobbies|
+                   grouped_hobbies.reject { |(_, id)| id == hobby.id }
+                 end.reject { |_, grouped_hobbies| grouped_hobbies.empty? } %>
               <%= select_tag :target_hobby_id,
-                    options_for_select(@all_hobbies.reject { |(_, id)| id == hobby.id }),
+                    grouped_options_for_select(target_hobby_groups),
                     prompt: "選択してください",
                     style: "background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.25rem;" %>
               <%= submit_tag "統合",

--- a/db/migrate/20260414090001_create_hobby_parent_tags.rb
+++ b/db/migrate/20260414090001_create_hobby_parent_tags.rb
@@ -1,0 +1,44 @@
+class CreateHobbyParentTags < ActiveRecord::Migration[7.2]
+  def up
+    create_table :hobby_parent_tags do |t|
+      t.references :hobby, null: false, foreign_key: true
+      t.references :parent_tag, null: false, foreign_key: true
+      t.integer :room_type, null: false
+      t.timestamps
+    end
+
+    add_index :hobby_parent_tags, [ :hobby_id, :parent_tag_id ], unique: true
+    add_index :hobby_parent_tags, [ :hobby_id, :room_type ], unique: true
+
+    execute <<~SQL
+      INSERT INTO hobby_parent_tags (hobby_id, parent_tag_id, room_type, created_at, updated_at)
+      SELECT h.id, pt.id, pt.room_type, NOW(), NOW()
+      FROM hobbies h
+      JOIN parent_tags pt ON h.parent_tag_id = pt.id
+      WHERE h.parent_tag_id IS NOT NULL
+        AND pt.slug != 'uncategorized'
+        AND pt.room_type IS NOT NULL
+    SQL
+
+    execute <<~SQL
+      UPDATE hobbies SET parent_tag_id = NULL
+      WHERE parent_tag_id IN (
+        SELECT id FROM parent_tags WHERE slug = 'uncategorized' AND room_type IS NULL
+      )
+    SQL
+
+    execute "DELETE FROM parent_tags WHERE slug = 'uncategorized' AND room_type IS NULL"
+
+    [ 0, 1, 2 ].each do |room_type|
+      execute <<~SQL
+        INSERT INTO parent_tags (name, slug, room_type, position, created_at, updated_at)
+        VALUES ('未分類', 'uncategorized', #{room_type}, 999, NOW(), NOW())
+        ON CONFLICT (room_type, slug) DO NOTHING
+      SQL
+    end
+  end
+
+  def down
+    drop_table :hobby_parent_tags
+  end
+end

--- a/db/migrate/20260414090001_create_hobby_parent_tags.rb
+++ b/db/migrate/20260414090001_create_hobby_parent_tags.rb
@@ -39,6 +39,6 @@ class CreateHobbyParentTags < ActiveRecord::Migration[7.2]
   end
 
   def down
-    drop_table :hobby_parent_tags
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20260414090002_remove_parent_tag_id_from_hobbies.rb
+++ b/db/migrate/20260414090002_remove_parent_tag_id_from_hobbies.rb
@@ -1,0 +1,12 @@
+class RemoveParentTagIdFromHobbies < ActiveRecord::Migration[7.2]
+  def up
+    remove_foreign_key :hobbies, :parent_tags
+    remove_column :hobbies, :parent_tag_id
+  end
+
+  def down
+    add_column :hobbies, :parent_tag_id, :bigint
+    add_foreign_key :hobbies, :parent_tags
+    add_index :hobbies, :parent_tag_id
+  end
+end

--- a/db/migrate/20260414090003_add_index_to_hobby_parent_tags.rb
+++ b/db/migrate/20260414090003_add_index_to_hobby_parent_tags.rb
@@ -1,0 +1,5 @@
+class AddIndexToHobbyParentTags < ActiveRecord::Migration[7.2]
+  def change
+    add_index :hobby_parent_tags, [ :parent_tag_id, :room_type ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_14_090000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_14_090001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,18 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_090000) do
     t.index ["name"], name: "index_hobbies_on_name", unique: true
     t.index ["normalized_name"], name: "index_hobbies_on_normalized_name"
     t.index ["parent_tag_id"], name: "index_hobbies_on_parent_tag_id"
+  end
+
+  create_table "hobby_parent_tags", force: :cascade do |t|
+    t.bigint "hobby_id", null: false
+    t.bigint "parent_tag_id", null: false
+    t.integer "room_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["hobby_id", "parent_tag_id"], name: "index_hobby_parent_tags_on_hobby_id_and_parent_tag_id", unique: true
+    t.index ["hobby_id", "room_type"], name: "index_hobby_parent_tags_on_hobby_id_and_room_type", unique: true
+    t.index ["hobby_id"], name: "index_hobby_parent_tags_on_hobby_id"
+    t.index ["parent_tag_id"], name: "index_hobby_parent_tags_on_parent_tag_id"
   end
 
   create_table "parent_tags", force: :cascade do |t|
@@ -142,6 +154,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_090000) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "hobbies", "parent_tags"
+  add_foreign_key "hobby_parent_tags", "hobbies"
+  add_foreign_key "hobby_parent_tags", "parent_tags"
   add_foreign_key "profile_hobbies", "hobbies"
   add_foreign_key "profile_hobbies", "profiles"
   add_foreign_key "profiles", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_14_090002) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_14_090003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_090002) do
     t.index ["hobby_id", "parent_tag_id"], name: "index_hobby_parent_tags_on_hobby_id_and_parent_tag_id", unique: true
     t.index ["hobby_id", "room_type"], name: "index_hobby_parent_tags_on_hobby_id_and_room_type", unique: true
     t.index ["hobby_id"], name: "index_hobby_parent_tags_on_hobby_id"
+    t.index ["parent_tag_id", "room_type"], name: "index_hobby_parent_tags_on_parent_tag_id_and_room_type"
     t.index ["parent_tag_id"], name: "index_hobby_parent_tags_on_parent_tag_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_14_090001) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_14_090002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,11 +46,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_090001) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "parent_tag_id"
     t.string "normalized_name"
     t.index ["name"], name: "index_hobbies_on_name", unique: true
     t.index ["normalized_name"], name: "index_hobbies_on_normalized_name"
-    t.index ["parent_tag_id"], name: "index_hobbies_on_parent_tag_id"
   end
 
   create_table "hobby_parent_tags", force: :cascade do |t|
@@ -153,7 +151,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_14_090001) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "hobbies", "parent_tags"
   add_foreign_key "hobby_parent_tags", "hobbies"
   add_foreign_key "hobby_parent_tags", "parent_tags"
   add_foreign_key "profile_hobbies", "hobbies"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,16 +5,17 @@ parent_tags = [
   { name: "ゲーム", slug: "game", room_type: :chat, position: 1 },
   { name: "音楽", slug: "music", room_type: :chat, position: 2 },
   { name: "カフェ", slug: "cafe", room_type: :chat, position: 3 },
+  { name: "未分類", slug: "uncategorized", room_type: :chat, position: 999 },
   # 勉強系（study）
   { name: "プログラミング", slug: "programming", room_type: :study, position: 0 },
   { name: "デザイン", slug: "design", room_type: :study, position: 1 },
   { name: "学習スタイル", slug: "learning-style", room_type: :study, position: 2 },
+  { name: "未分類", slug: "uncategorized", room_type: :study, position: 999 },
   # ゲーム系（game）
   { name: "協力ゲーム", slug: "coop", room_type: :game, position: 0 },
   { name: "対戦ゲーム", slug: "versus", room_type: :game, position: 1 },
   { name: "カジュアル", slug: "casual", room_type: :game, position: 2 },
-  # 共通（未分類）
-  { name: "未分類", slug: "uncategorized", room_type: nil, position: 0 }
+  { name: "未分類", slug: "uncategorized", room_type: :game, position: 999 }
 ]
 
 parent_tags.each do |attrs|
@@ -50,14 +51,20 @@ HOBBY_DICTIONARY = {
   "カフェ巡り" => "cafe", "コーヒー" => "cafe", "スタバ" => "cafe"
 }.freeze
 
-# 既存 hobbies の parent_tag_id を一括設定（冪等: nil のものだけ対象）
-parent_tag_map = ParentTag.all.index_by(&:slug)
-uncategorized = ParentTag.find_by!(slug: "uncategorized", room_type: nil)
+# 既存 hobbies を hobby_parent_tags で分類（冪等: 既に分類済みの room_type は skip）
+parent_tag_by_slug = ParentTag.all.group_by(&:slug)
+classified_count = 0
 
-Hobby.where(parent_tag_id: nil).find_each do |hobby|
+Hobby.find_each do |hobby|
   slug = HOBBY_DICTIONARY[hobby.normalized_name]
-  parent_tag = slug ? parent_tag_map[slug] : uncategorized
-  hobby.update_columns(parent_tag_id: parent_tag.id)
+  next unless slug
+
+  parent_tag_by_slug[slug]&.each do |parent_tag|
+    next if hobby.hobby_parent_tags.exists?(room_type: parent_tag.room_type)
+
+    Admin::HobbyClassificationService.call(hobby:, parent_tag:)
+    classified_count += 1
+  end
 end
 
-puts "Hobbies parent_tag set: #{Hobby.where.not(parent_tag_id: nil).count} 件"
+puts "Hobbies classified: #{classified_count} 件"

--- a/spec/factories/hobby_parent_tags.rb
+++ b/spec/factories/hobby_parent_tags.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :hobby_parent_tag do
+    association :hobby
+    association :parent_tag, room_type: :chat
+  end
+end

--- a/spec/models/hobby_parent_tag_spec.rb
+++ b/spec/models/hobby_parent_tag_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe HobbyParentTag, type: :model do
+  describe "アソシエーション" do
+    it "hobby に属する" do
+      association = described_class.reflect_on_association(:hobby)
+
+      expect(association.macro).to eq(:belongs_to)
+    end
+
+    it "parent_tag に属する" do
+      association = described_class.reflect_on_association(:parent_tag)
+
+      expect(association.macro).to eq(:belongs_to)
+    end
+  end
+
+  describe "バリデーション" do
+    let(:chat_tag) { create(:parent_tag, room_type: :chat) }
+    let(:chat_tag2) { create(:parent_tag, room_type: :chat) }
+    let(:game_tag) { create(:parent_tag, room_type: :game) }
+    let(:hobby) { create(:hobby) }
+
+    it "同一 room_type に 2 つ目の parent_tag を紐付けようとすると無効になる" do
+      create(:hobby_parent_tag, hobby:, parent_tag: chat_tag)
+      duplicate = described_class.new(hobby:, parent_tag: chat_tag2)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:hobby_id]).not_to be_empty
+    end
+
+    it "異なる room_type なら同じ hobby に複数の parent_tag を紐付けられる" do
+      create(:hobby_parent_tag, hobby:, parent_tag: chat_tag)
+      another = described_class.new(hobby:, parent_tag: game_tag)
+
+      expect(another).to be_valid
+    end
+
+    it "同じ (hobby_id, parent_tag_id) の重複は無効になる" do
+      create(:hobby_parent_tag, hobby:, parent_tag: chat_tag)
+      duplicate = described_class.new(hobby:, parent_tag: chat_tag)
+
+      expect(duplicate).not_to be_valid
+    end
+  end
+
+  describe "before_validation :sync_room_type" do
+    it "parent_tag の room_type を自動セットする" do
+      game_tag = create(:parent_tag, room_type: :game)
+      hobby_parent_tag = described_class.new(hobby: create(:hobby), parent_tag: game_tag)
+
+      hobby_parent_tag.valid?
+
+      expect(hobby_parent_tag.room_type).to eq("game")
+    end
+  end
+end

--- a/spec/models/hobby_spec.rb
+++ b/spec/models/hobby_spec.rb
@@ -28,6 +28,26 @@ RSpec.describe Hobby, type: :model do
       expect(hobby).to be_valid
     end
 
+    it "has_many :hobby_parent_tags を持つ" do
+      association = described_class.reflect_on_association(:hobby_parent_tags)
+
+      expect(association.macro).to eq(:has_many)
+    end
+
+    it "has_many :parent_tags through :hobby_parent_tags を持つ" do
+      association = described_class.reflect_on_association(:parent_tags)
+
+      expect(association.macro).to eq(:has_many)
+    end
+
+    it "hobby を削除すると hobby_parent_tags も削除される" do
+      hobby = create(:hobby)
+      parent_tag = create(:parent_tag, room_type: :chat)
+      create(:hobby_parent_tag, hobby:, parent_tag:)
+
+      expect { hobby.destroy }.to change(HobbyParentTag, :count).by(-1)
+    end
+
     it "profile_hobbies が存在する場合は削除できない" do
       hobby = create(:hobby)
       create(:profile_hobby, hobby:)

--- a/spec/models/hobby_spec.rb
+++ b/spec/models/hobby_spec.rb
@@ -17,17 +17,6 @@ RSpec.describe Hobby, type: :model do
   end
 
   describe "関連" do
-    it "parent_tag に属することができる" do
-      parent_tag = ParentTag.create!(name: "テスト親タグ", slug: "test-parent", room_type: :chat)
-      hobby = described_class.create!(name: "テスト趣味D", parent_tag: parent_tag)
-      expect(hobby.parent_tag).to eq(parent_tag)
-    end
-
-    it "parent_tag が nil でも有効（optional）" do
-      hobby = described_class.new(name: "その他の趣味", parent_tag: nil)
-      expect(hobby).to be_valid
-    end
-
     it "has_many :hobby_parent_tags を持つ" do
       association = described_class.reflect_on_association(:hobby_parent_tags)
 

--- a/spec/models/parent_tag_spec.rb
+++ b/spec/models/parent_tag_spec.rb
@@ -52,16 +52,23 @@ RSpec.describe ParentTag, type: :model do
   end
 
   describe "関連" do
-    it "hobbies を複数持てる" do
-      parent_tag = described_class.create!(name: "テスト関連", slug: "test-assoc", room_type: :chat)
-      parent_tag.hobbies.create!(name: "テスト趣味A")
-      parent_tag.hobbies.create!(name: "テスト趣味B")
-      expect(parent_tag.hobbies.count).to eq(2)
+    it "has_many :hobby_parent_tags を持つ" do
+      association = described_class.reflect_on_association(:hobby_parent_tags)
+
+      expect(association.macro).to eq(:has_many)
     end
 
-    it "子 hobby がある場合は削除できない" do
+    it "has_many :hobbies through :hobby_parent_tags を持つ" do
+      association = described_class.reflect_on_association(:hobbies)
+
+      expect(association.macro).to eq(:has_many)
+    end
+
+    it "hobby_parent_tags がある場合は削除できない" do
       parent_tag = described_class.create!(name: "テスト削除", slug: "test-delete", room_type: :chat)
-      parent_tag.hobbies.create!(name: "テスト趣味C")
+      hobby = create(:hobby, name: "テスト趣味C")
+      create(:hobby_parent_tag, hobby:, parent_tag:)
+
       expect { parent_tag.destroy }.not_to change(described_class, :count)
       expect(parent_tag.errors[:base]).to be_present
     end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe Profile, type: :model do
   end
 
   describe "#update_hobbies_from_json" do
-    let!(:uncategorized) { ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類"; pt.position = 0 } }
-
     it "JSONからhobbyを作成/取得しdescriptionを保存する" do
       profile = create(:profile)
       old = create(:hobby, name: "old")

--- a/spec/requests/admin/hobbies_spec.rb
+++ b/spec/requests/admin/hobbies_spec.rb
@@ -2,8 +2,13 @@ require "rails_helper"
 
 RSpec.describe "Admin::HobbiesController", type: :request do
   let!(:admin_user) { create(:user, :admin) }
-  let!(:parent_tag) { create(:parent_tag, name: "アニメ", room_type: :chat) }
-  let!(:hobby) { create(:hobby, name: "進撃の巨人", parent_tag:) }
+  let!(:chat_tag) { create(:parent_tag, name: "アニメ", room_type: :chat) }
+  let!(:study_tag) { create(:parent_tag, name: "プログラミング", room_type: :study) }
+  let!(:hobby) do
+    hobby = create(:hobby, name: "進撃の巨人")
+    create(:hobby_parent_tag, hobby:, parent_tag: chat_tag)
+    hobby
+  end
 
   describe "認可" do
     context "未ログインの場合" do
@@ -15,6 +20,7 @@ RSpec.describe "Admin::HobbiesController", type: :request do
 
     context "非管理者の場合" do
       let!(:normal_user) { create(:user) }
+
       before { sign_in normal_user }
 
       it "root_path にリダイレクトされる" do
@@ -27,13 +33,28 @@ RSpec.describe "Admin::HobbiesController", type: :request do
   describe "POST /admin/hobbies" do
     before { sign_in admin_user }
 
-    it "子タグを作成して一覧へ戻る" do
+    it "子タグを作成して hobby_parent_tag も作成し一覧へ戻る" do
       expect do
         post admin_hobbies_path, params: {
-          hobby: { name: "ワンピース", parent_tag_id: parent_tag.id }
+          hobby: { name: "ワンピース", chat_parent_tag_id: chat_tag.id }
+        }
+      end.to change(Hobby, :count).by(1)
+        .and change(HobbyParentTag, :count).by(1)
+
+      expect(response).to redirect_to(admin_parent_tags_path)
+      new_hobby = Hobby.find_by(name: "ワンピース")
+      expect(new_hobby.hobby_parent_tags.find_by(room_type: :chat)&.parent_tag).to eq(chat_tag)
+    end
+
+    it "chat_parent_tag_id が空でも hobby だけ作成される" do
+      expect do
+        post admin_hobbies_path, params: {
+          hobby: { name: "ワンピース", chat_parent_tag_id: "" }
         }
       end.to change(Hobby, :count).by(1)
 
+      new_hobby = Hobby.find_by(name: "ワンピース")
+      expect(new_hobby.hobby_parent_tags).to be_empty
       expect(response).to redirect_to(admin_parent_tags_path)
     end
   end
@@ -41,13 +62,21 @@ RSpec.describe "Admin::HobbiesController", type: :request do
   describe "PATCH /admin/hobbies/:id" do
     before { sign_in admin_user }
 
-    it "子タグを更新して一覧へ戻る" do
+    it "子タグ名を更新して一覧へ戻る" do
       patch admin_hobby_path(hobby), params: {
-        hobby: { name: "鬼滅の刃", parent_tag_id: parent_tag.id }
+        hobby: { name: "鬼滅の刃", chat_parent_tag_id: chat_tag.id }
       }
 
       expect(hobby.reload.name).to eq("鬼滅の刃")
       expect(response).to redirect_to(admin_parent_tags_path)
+    end
+
+    it "study_parent_tag_id を指定すると hobby_parent_tag が追加される" do
+      patch admin_hobby_path(hobby), params: {
+        hobby: { name: "進撃の巨人", study_parent_tag_id: study_tag.id }
+      }
+
+      expect(hobby.hobby_parent_tags.reload.find_by(room_type: :study)&.parent_tag).to eq(study_tag)
     end
   end
 
@@ -55,7 +84,8 @@ RSpec.describe "Admin::HobbiesController", type: :request do
     before { sign_in admin_user }
 
     it "未使用の子タグは削除できる" do
-      deletable_hobby = create(:hobby, name: "ワンピース", parent_tag:)
+      deletable_hobby = create(:hobby, name: "ワンピース")
+      create(:hobby_parent_tag, hobby: deletable_hobby, parent_tag: chat_tag)
 
       expect do
         delete admin_hobby_path(deletable_hobby)

--- a/spec/requests/admin/parent_tags_spec.rb
+++ b/spec/requests/admin/parent_tags_spec.rb
@@ -7,8 +7,16 @@ RSpec.describe "Admin::ParentTagsController", type: :request do
   let!(:uncategorized_parent_tag) do
     ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類" }
   end
-  let!(:chat_hobby) { create(:hobby, name: "進撃の巨人", parent_tag: chat_parent_tag) }
-  let!(:study_hobby) { create(:hobby, name: "簿記", parent_tag: study_parent_tag) }
+  let!(:chat_hobby) do
+    hobby = create(:hobby, name: "進撃の巨人")
+    create(:hobby_parent_tag, hobby:, parent_tag: chat_parent_tag)
+    hobby
+  end
+  let!(:study_hobby) do
+    hobby = create(:hobby, name: "簿記")
+    create(:hobby_parent_tag, hobby:, parent_tag: study_parent_tag)
+    hobby
+  end
 
   describe "GET /admin/parent_tags" do
     context "未ログインの場合" do

--- a/spec/requests/admin/unclassified_hobbies_spec.rb
+++ b/spec/requests/admin/unclassified_hobbies_spec.rb
@@ -2,30 +2,25 @@ require "rails_helper"
 
 RSpec.describe "Admin::UnclassifiedHobbiesController", type: :request do
   let!(:admin_user) { create(:user, :admin) }
-  # Hobby.unclassified は slug: "uncategorized" の親タグに依存するため find_or_create_by! を使う
-  let!(:uncategorized_parent_tag) do
-    ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類" }
+  let!(:classified_parent_tag) { create(:parent_tag, room_type: :study) }
+
+  let!(:unclassified_hobby) { create(:hobby, name: "rails") }
+  let!(:classified_hobby) do
+    hobby = create(:hobby, name: "Ruby")
+    create(:hobby_parent_tag, hobby:, parent_tag: classified_parent_tag)
+    hobby
   end
-  let!(:classified_parent_tag)    { create(:parent_tag) }
 
-  # -----------------------------------------------------------------------
-  # GET /admin/unclassified_hobbies
-  # -----------------------------------------------------------------------
   describe "GET /admin/unclassified_hobbies" do
-    let!(:unclassified_hobby) { create(:hobby, name: "rails",  parent_tag: uncategorized_parent_tag) }
-    let!(:classified_hobby)   { create(:hobby, name: "Ruby",   parent_tag: classified_parent_tag) }
-
     context "管理者の場合" do
       before { sign_in admin_user }
 
       it "200 OK を返す" do
-        # 管理者がアクセスする
         get admin_unclassified_hobbies_path
         expect(response).to have_http_status(:ok)
       end
 
       it "未分類タグが名前列に含まれる" do
-        # 未分類の "rails" が一覧に表示されること
         get admin_unclassified_hobbies_path
         doc = Nokogiri::HTML(response.body)
         name_cells = doc.css("td[data-col='name']").map(&:text).map(&:strip)
@@ -33,7 +28,6 @@ RSpec.describe "Admin::UnclassifiedHobbiesController", type: :request do
       end
 
       it "分類済みタグは名前列に含まれない" do
-        # 分類済みの "Ruby" は一覧エリアの名前列に出ない
         get admin_unclassified_hobbies_path
         doc = Nokogiri::HTML(response.body)
         name_cells = doc.css("td[data-col='name']").map(&:text).map(&:strip)
@@ -41,32 +35,28 @@ RSpec.describe "Admin::UnclassifiedHobbiesController", type: :request do
       end
 
       it "検索クエリに一致する未分類タグだけが名前列に含まれる" do
-        # rails と一致しない未分類タグを追加
-        create(:hobby, name: "python", parent_tag: uncategorized_parent_tag)
+        create(:hobby, name: "python")
 
-        # "rails" で検索
         get admin_unclassified_hobbies_path, params: { q: "rails" }
         doc = Nokogiri::HTML(response.body)
         name_cells = doc.css("td[data-col='name']").map(&:text).map(&:strip)
-        expect(name_cells).to     include("rails")
+        expect(name_cells).to include("rails")
         expect(name_cells).not_to include("python")
       end
 
       context "usage_count / user_count の集計" do
-        let!(:first_owner_profile)  { create(:profile) }
+        let!(:first_owner_profile) { create(:profile) }
         let!(:second_owner_profile) { create(:profile) }
-        let!(:counted_hobby)        { create(:hobby, name: "python", parent_tag: uncategorized_parent_tag) }
+        let!(:counted_hobby) { create(:hobby, name: "python") }
 
         before do
-          # 2ユーザーが counted_hobby を使用している状態を作る
-          create(:profile_hobby, profile: first_owner_profile,  hobby: counted_hobby)
+          create(:profile_hobby, profile: first_owner_profile, hobby: counted_hobby)
           create(:profile_hobby, profile: second_owner_profile, hobby: counted_hobby)
         end
 
         it "usage_count と user_count が 2 と集計されてレスポンスに含まれる" do
           get admin_unclassified_hobbies_path
           doc = Nokogiri::HTML(response.body)
-          # data-hobby-id 属性の行に使用回数 "2" が含まれる
           row = doc.at_css("[data-hobby-id='#{counted_hobby.id}']")
           expect(row.text).to include("2")
         end
@@ -79,7 +69,6 @@ RSpec.describe "Admin::UnclassifiedHobbiesController", type: :request do
       before { sign_in normal_user }
 
       it "root_path にリダイレクトされる" do
-        # 一般ユーザーはアクセス拒否される
         get admin_unclassified_hobbies_path
         expect(response).to redirect_to(root_path)
       end
@@ -87,35 +76,28 @@ RSpec.describe "Admin::UnclassifiedHobbiesController", type: :request do
 
     context "未ログインの場合" do
       it "ログインページにリダイレクトされる" do
-        # 未ログインは認証ページへ
         get admin_unclassified_hobbies_path
         expect(response).to redirect_to(new_user_session_path)
       end
     end
   end
 
-  # -----------------------------------------------------------------------
-  # PATCH /admin/unclassified_hobbies/:id
-  # -----------------------------------------------------------------------
   describe "PATCH /admin/unclassified_hobbies/:id" do
-    let!(:unclassified_hobby) { create(:hobby, name: "rails", parent_tag: uncategorized_parent_tag) }
-
     context "管理者の場合" do
       before { sign_in admin_user }
 
-      it "parent_tag_id が更新されて一覧にリダイレクトされる" do
-        # 1回のリクエストで DB 更新とリダイレクトを両方確認する
+      it "hobby_parent_tag が作成されて一覧にリダイレクトされる" do
         patch admin_unclassified_hobby_path(unclassified_hobby),
               params: { parent_tag_id: classified_parent_tag.id }
+
         aggregate_failures do
-          expect(unclassified_hobby.reload.parent_tag_id).to eq classified_parent_tag.id
+          hobby_parent_tag = unclassified_hobby.hobby_parent_tags.reload.find_by(room_type: classified_parent_tag.room_type)
+          expect(hobby_parent_tag&.parent_tag).to eq(classified_parent_tag)
           expect(response).to redirect_to(admin_unclassified_hobbies_path)
         end
       end
 
       it "分類済み hobby を対象にすると 404 を返す" do
-        # Hobby.unclassified.find は未分類でない hobby で RecordNotFound を発生させる
-        classified_hobby = create(:hobby, name: "Ruby", parent_tag: classified_parent_tag)
         patch admin_unclassified_hobby_path(classified_hobby),
               params: { parent_tag_id: classified_parent_tag.id }
         expect(response).to have_http_status(:not_found)
@@ -135,16 +117,12 @@ RSpec.describe "Admin::UnclassifiedHobbiesController", type: :request do
     end
   end
 
-  # -----------------------------------------------------------------------
-  # POST /admin/unclassified_hobbies/:id/merge
-  # -----------------------------------------------------------------------
   describe "POST /admin/unclassified_hobbies/:id/merge" do
-    let!(:source_hobby)               { create(:hobby, name: "rails", parent_tag: uncategorized_parent_tag) }
-    let!(:target_hobby)               { create(:hobby, name: "Rails") }
+    let!(:source_hobby) { create(:hobby, name: "rails-merge-source") }
+    let!(:target_hobby) { create(:hobby, name: "rails-merge-target") }
     let!(:source_hobby_owner_profile) { create(:profile) }
 
     before do
-      # source タグを持つプロフィールを用意する
       create(:profile_hobby, profile: source_hobby_owner_profile, hobby: source_hobby)
     end
 
@@ -152,9 +130,9 @@ RSpec.describe "Admin::UnclassifiedHobbiesController", type: :request do
       before { sign_in admin_user }
 
       it "profile_hobbies が付け替えられ source が削除されて一覧にリダイレクトされる" do
-        # 1回のリクエストで付け替え・削除・リダイレクトをまとめて確認する
         post merge_admin_unclassified_hobby_path(source_hobby),
              params: { target_hobby_id: target_hobby.id }
+
         aggregate_failures do
           expect(
             ProfileHobby.where(hobby_id: target_hobby.id, profile_id: source_hobby_owner_profile.id)
@@ -165,7 +143,6 @@ RSpec.describe "Admin::UnclassifiedHobbiesController", type: :request do
       end
 
       it "source と target が同じ場合は alert とともにリダイレクトされる" do
-        # Admin::HobbyMergeService が「統合元と統合先が同じです」で失敗する
         post merge_admin_unclassified_hobby_path(source_hobby),
              params: { target_hobby_id: source_hobby.id }
         expect(response).to redirect_to(admin_unclassified_hobbies_path)

--- a/spec/requests/my/profile_spec.rb
+++ b/spec/requests/my/profile_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe "My::Profile", type: :request do
 
   describe "PATCH /my/profile" do
     let!(:profile) { create(:profile, user:) }
-    let!(:uncategorized) { ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類"; pt.position = 0 } }
 
     it "11個のタグで更新するとバリデーションエラーになる" do
       hobbies_text = (1..11).map { |i| { name: "タグ#{i}", description: "" } }.to_json

--- a/spec/requests/profiles/profiles_hobbies_spec.rb
+++ b/spec/requests/profiles/profiles_hobbies_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe "Profile hobbies", type: :request do
   let(:user)    { create(:user) }
   let!(:profile) { create(:profile, user:) } # ← current_user の profile を明示
-  let!(:uncategorized) { ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類"; pt.position = 0 } }
 
   before do
     sign_in user

--- a/spec/requests/rooms/members_show_spec.rb
+++ b/spec/requests/rooms/members_show_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe "Rooms::Members#show", type: :request do
     end
 
     it "部屋のroom_typeに一致する親タグを持つ子タグを返す" do
-      # game親タグに紐づく趣味をオーナープロフィールに追加
-      game_hobby = create(:hobby, name: "マイクラ", parent_tag: game_parent_tag)
+      game_hobby = create(:hobby, name: "マイクラ")
+      create(:hobby_parent_tag, hobby: game_hobby, parent_tag: game_parent_tag)
       room_owner_profile.hobbies << game_hobby
 
       get room_member_path(room_id: room.id, id: room_owner_profile.id)
@@ -61,9 +61,9 @@ RSpec.describe "Rooms::Members#show", type: :request do
     end
 
     it "部屋のroom_typeと一致しない親タグの子タグは返さない" do
-      # study親タグに紐づく趣味をオーナープロフィールに追加
       study_parent_tag = create(:parent_tag, room_type: :study)
-      study_hobby = create(:hobby, name: "読書", parent_tag: study_parent_tag)
+      study_hobby = create(:hobby, name: "読書")
+      create(:hobby_parent_tag, hobby: study_hobby, parent_tag: study_parent_tag)
       room_owner_profile.hobbies << study_hobby
 
       get room_member_path(room_id: room.id, id: room_owner_profile.id)

--- a/spec/requests/shares/shares_show_jsmind_spec.rb
+++ b/spec/requests/shares/shares_show_jsmind_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe "Shares#show jsMind data", type: :request do
   end
 
   it "親タグ名がjsMindデータとしてレスポンスに含まれる" do
-    # chat 部屋で chat タイプの親タグに属する趣味を持つ
-    hobby = create(:hobby, name: "ワンピース", parent_tag: chat_parent_tag)
+    hobby = create(:hobby, name: "ワンピース")
+    create(:hobby_parent_tag, hobby:, parent_tag: chat_parent_tag)
     current_profile.hobbies << hobby
 
     get share_path(share_link.token)
@@ -25,7 +25,8 @@ RSpec.describe "Shares#show jsMind data", type: :request do
   end
 
   it "ユーザーのnicknameがjsMindデータとしてレスポンスに含まれる" do
-    hobby = create(:hobby, name: "読書", parent_tag: chat_parent_tag)
+    hobby = create(:hobby, name: "読書")
+    create(:hobby_parent_tag, hobby:, parent_tag: chat_parent_tag)
     current_profile.hobbies << hobby
 
     get share_path(share_link.token)
@@ -34,7 +35,8 @@ RSpec.describe "Shares#show jsMind data", type: :request do
   end
 
   it "人ノードの詳細URLがレスポンスに含まれる" do
-    hobby = create(:hobby, name: "料理", parent_tag: chat_parent_tag)
+    hobby = create(:hobby, name: "料理")
+    create(:hobby_parent_tag, hobby:, parent_tag: chat_parent_tag)
     current_profile.hobbies << hobby
 
     get share_path(share_link.token)

--- a/spec/services/admin/hobby_classification_service_spec.rb
+++ b/spec/services/admin/hobby_classification_service_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe Admin::HobbyClassificationService do
+  describe ".call" do
+    let(:hobby) { create(:hobby) }
+    let(:chat_tag) { create(:parent_tag, room_type: :chat) }
+    let(:chat_tag2) { create(:parent_tag, room_type: :chat) }
+    let(:game_tag) { create(:parent_tag, room_type: :game) }
+
+    context "新規分類（該当 room_type の hobby_parent_tag がない）" do
+      it "hobby_parent_tag を 1 件作成する" do
+        expect do
+          described_class.call(hobby:, parent_tag: chat_tag)
+        end.to change(HobbyParentTag, :count).by(1)
+      end
+
+      it "指定した parent_tag が設定される" do
+        described_class.call(hobby:, parent_tag: chat_tag)
+
+        hobby_parent_tag = hobby.hobby_parent_tags.find_by(room_type: :chat)
+        expect(hobby_parent_tag.parent_tag).to eq(chat_tag)
+      end
+    end
+
+    context "同 room_type の上書き（既存の hobby_parent_tag がある）" do
+      before { create(:hobby_parent_tag, hobby:, parent_tag: chat_tag) }
+
+      it "hobby_parent_tag を新規作成しない" do
+        expect do
+          described_class.call(hobby:, parent_tag: chat_tag2)
+        end.not_to change(HobbyParentTag, :count)
+      end
+
+      it "parent_tag を新しい値に更新する" do
+        described_class.call(hobby:, parent_tag: chat_tag2)
+
+        expect(hobby.hobby_parent_tags.find_by(room_type: :chat).parent_tag).to eq(chat_tag2)
+      end
+    end
+
+    context "異なる room_type への追加分類" do
+      before { create(:hobby_parent_tag, hobby:, parent_tag: chat_tag) }
+
+      it "hobby_parent_tag を追加で 1 件作成する" do
+        expect do
+          described_class.call(hobby:, parent_tag: game_tag)
+        end.to change(HobbyParentTag, :count).by(1)
+      end
+    end
+  end
+end

--- a/spec/services/jsmind_data_builder_spec.rb
+++ b/spec/services/jsmind_data_builder_spec.rb
@@ -1,24 +1,28 @@
 require "rails_helper"
 
 RSpec.describe JsmindDataBuilder do
-  # 部屋タイプ: chat
   let(:chat_parent_tag)  { create(:parent_tag, name: "アニメ",        room_type: :chat,  position: 1) }
   let(:chat_parent_tag2) { create(:parent_tag, name: "ゲーム",        room_type: :chat,  position: 2) }
   let(:study_parent_tag) { create(:parent_tag, name: "プログラミング", room_type: :study, position: 1) }
 
-  let(:hobby_anime) { create(:hobby, name: "ワンピース", parent_tag: chat_parent_tag) }
-  let(:hobby_game)  { create(:hobby, name: "マイクラ",  parent_tag: chat_parent_tag2) }
-  let(:hobby_prog)  { create(:hobby, name: "Rails",    parent_tag: study_parent_tag) }
+  let(:hobby_anime) { create(:hobby, name: "ワンピース") }
+  let(:hobby_game)  { create(:hobby, name: "マイクラ") }
+  let(:hobby_prog)  { create(:hobby, name: "Rails") }
+
+  before do
+    create(:hobby_parent_tag, hobby: hobby_anime, parent_tag: chat_parent_tag)
+    create(:hobby_parent_tag, hobby: hobby_game, parent_tag: chat_parent_tag2)
+    create(:hobby_parent_tag, hobby: hobby_prog, parent_tag: study_parent_tag)
+  end
 
   let(:chat_room) { create(:room, room_type: :chat) }
 
   let(:current_user)    { create(:user, nickname: "user1") }
   let(:current_profile) { create(:profile, user: current_user) }
 
-  # memberships は before ブロックで membership を作成してから評価する
   let(:memberships) do
     chat_room.room_memberships
-             .includes(profile: [ :user, { profile_hobbies: { hobby: :parent_tag } } ])
+             .includes(profile: [ :user, { profile_hobbies: { hobby: :hobby_parent_tags } } ])
   end
 
   subject(:result) { described_class.new(chat_room, memberships).build }
@@ -59,7 +63,6 @@ RSpec.describe JsmindDataBuilder do
 
     context "複数の親タグに趣味を持つユーザーがいる場合" do
       before do
-        # chat_parent_tag（アニメ）と chat_parent_tag2（ゲーム）両方に趣味を持つ
         current_profile.hobbies << hobby_anime
         current_profile.hobbies << hobby_game
       end
@@ -95,8 +98,6 @@ RSpec.describe JsmindDataBuilder do
     end
 
     context "趣味未登録のユーザーがいる場合" do
-      # 趣味なし（before ブロックに追記なし）
-
       it "「その他」ノードに表示される" do
         other_node = result[:data][:children].find { |n| n[:topic] == "その他" }
         expect(other_node[:children].map { |n| n[:topic] }).to include("user1")
@@ -105,9 +106,8 @@ RSpec.describe JsmindDataBuilder do
 
     context "対象ユーザーが0人の親タグがある場合" do
       before do
-        # chat_parent_tag（アニメ）のみ持つ → chat_parent_tag2（ゲーム）は0人
         current_profile.hobbies << hobby_anime
-        chat_parent_tag2 # 事前生成して DB に存在させる
+        chat_parent_tag2
       end
 
       it "対象ユーザーが0人の親タグノードは表示されない" do

--- a/spec/services/profile_hobbies_updater_spec.rb
+++ b/spec/services/profile_hobbies_updater_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe ProfileHobbiesUpdater do
   describe ".call" do
     let(:profile) { create(:profile) }
-    let!(:uncategorized) { ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類"; pt.position = 0 } }
 
     it "新規タグを追加しdescriptionを保存する" do
       described_class.call(profile, [ { name: "ruby", description: "3年やってます" } ])
@@ -85,15 +84,28 @@ RSpec.describe ProfileHobbiesUpdater do
       expect(Hobby.where(name: "ゲーム").count).to eq(1)
     end
 
-    context "parent_tag の自動設定" do
-      it "辞書にない新規タグは未分類 parent_tag に設定される" do
-        described_class.call(profile, [ { name: "newtagxyz", description: "" } ])
+    context "新規 hobby の parent_tags" do
+      it "辞書にない新規タグは hobby_parent_tags を持たない（未分類）" do
+        described_class.call(profile, [ { name: "brandnewtag", description: "" } ])
 
-        hobby = Hobby.find_by(normalized_name: "newtagxyz")
+        hobby = Hobby.find_by(normalized_name: "brandnewtag")
         expect(hobby).not_to be_nil
-        expect(hobby.parent_tag).to eq(uncategorized)
+        expect(hobby.hobby_parent_tags).to be_empty
       end
 
+      it "normalized_name で削除対象を判定する" do
+        hobby_rails = create(:hobby, name: "rails")
+        hobby_ruby = create(:hobby, name: "ruby")
+        create(:profile_hobby, profile:, hobby: hobby_rails)
+        create(:profile_hobby, profile:, hobby: hobby_ruby)
+
+        described_class.call(profile, [ { name: "rails", description: "" } ])
+
+        expect(profile.hobbies.pluck(:name)).to eq([ "rails" ])
+      end
+    end
+
+    context "既存 hobby の parent_tag は維持する" do
       it "parent_tag_id が設定済みの既存 hobby は parent_tag を変更しない" do
         programming = ParentTag.find_or_create_by!(slug: "programming", room_type: 1) { |pt| pt.name = "プログラミング"; pt.position = 0 }
         hobby = create(:hobby, name: "rails", parent_tag: programming)
@@ -102,7 +114,9 @@ RSpec.describe ProfileHobbiesUpdater do
 
         expect(hobby.reload.parent_tag).to eq(programming)
       end
+    end
 
+    context "削除対象の判定" do
       it "normalized_name で削除対象を判定する" do
         hobby_rails = create(:hobby, name: "rails")
         hobby_ruby  = create(:hobby, name: "ruby")

--- a/spec/services/profile_hobbies_updater_spec.rb
+++ b/spec/services/profile_hobbies_updater_spec.rb
@@ -105,14 +105,15 @@ RSpec.describe ProfileHobbiesUpdater do
       end
     end
 
-    context "既存 hobby の parent_tag は維持する" do
-      it "parent_tag_id が設定済みの既存 hobby は parent_tag を変更しない" do
+    context "既存 hobby の分類は維持する" do
+      it "既存の hobby_parent_tags は変更しない" do
         programming = ParentTag.find_or_create_by!(slug: "programming", room_type: 1) { |pt| pt.name = "プログラミング"; pt.position = 0 }
-        hobby = create(:hobby, name: "rails", parent_tag: programming)
+        hobby = create(:hobby, name: "rails")
+        create(:hobby_parent_tag, hobby:, parent_tag: programming)
 
         described_class.call(profile, [ { name: "rails", description: "" } ])
 
-        expect(hobby.reload.parent_tag).to eq(programming)
+        expect(hobby.reload.hobby_parent_tags.find_by(room_type: :study)&.parent_tag).to eq(programming)
       end
     end
 

--- a/spec/system/admin/parent_tags_spec.rb
+++ b/spec/system/admin/parent_tags_spec.rb
@@ -8,8 +8,16 @@ RSpec.describe "Admin 親タグ管理", type: :system do
   let!(:uncategorized_parent_tag) do
     ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類" }
   end
-  let!(:chat_hobby) { create(:hobby, name: "進撃の巨人", parent_tag: chat_parent_tag) }
-  let!(:used_hobby) { create(:hobby, name: "簿記", parent_tag: study_parent_tag) }
+  let!(:chat_hobby) do
+    hobby = create(:hobby, name: "進撃の巨人")
+    create(:hobby_parent_tag, hobby:, parent_tag: chat_parent_tag)
+    hobby
+  end
+  let!(:used_hobby) do
+    hobby = create(:hobby, name: "簿記")
+    create(:hobby_parent_tag, hobby:, parent_tag: study_parent_tag)
+    hobby
+  end
 
   before do
     create(:profile_hobby, hobby: used_hobby)

--- a/spec/system/admin/unclassified_hobbies_spec.rb
+++ b/spec/system/admin/unclassified_hobbies_spec.rb
@@ -2,21 +2,19 @@ require "rails_helper"
 
 RSpec.describe "Admin 未分類タグ管理", type: :system do
   let!(:admin_user) { create(:user, :admin) }
-  let!(:uncategorized_parent_tag) do
-    ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類" }
-  end
   let!(:programming_parent_tag) do
-    ParentTag.find_or_create_by!(slug: "programming", room_type: :study) do |pt|
-      pt.name = "プログラミング"
-      pt.position = 1
-    end
+    create(:parent_tag, name: "プログラミング", slug: "programming", room_type: :study, position: 1)
   end
 
   before { login_as(admin_user, scope: :user) }
 
   describe "一覧表示" do
-    let!(:unclassified_hobby) { create(:hobby, name: "rails", parent_tag: uncategorized_parent_tag) }
-    let!(:classified_hobby)   { create(:hobby, name: "Ruby", parent_tag: programming_parent_tag) }
+    let!(:unclassified_hobby) { create(:hobby, name: "rails") }
+    let!(:classified_hobby) do
+      hobby = create(:hobby, name: "Ruby")
+      create(:hobby_parent_tag, hobby:, parent_tag: programming_parent_tag)
+      hobby
+    end
 
     before { visit admin_unclassified_hobbies_path }
 
@@ -25,7 +23,6 @@ RSpec.describe "Admin 未分類タグ管理", type: :system do
     end
 
     it "分類済みタグは表示されない" do
-      # 名前列にのみ絞って確認（mergeドロップダウンは全タグを含む）
       expect(page).not_to have_css("td[data-col='name']", text: "Ruby")
     end
 
@@ -37,13 +34,12 @@ RSpec.describe "Admin 未分類タグ管理", type: :system do
   end
 
   describe "使用回数・ユーザー数の集計" do
-    let!(:target_hobby) { create(:hobby, name: "python", parent_tag: uncategorized_parent_tag) }
-    let!(:first_profile)  { create(:profile) }
+    let!(:target_hobby) { create(:hobby, name: "python") }
+    let!(:first_profile) { create(:profile) }
     let!(:second_profile) { create(:profile) }
 
     before do
-      # 2ユーザーがpythonタグを使用している
-      create(:profile_hobby, profile: first_profile,  hobby: target_hobby)
+      create(:profile_hobby, profile: first_profile, hobby: target_hobby)
       create(:profile_hobby, profile: second_profile, hobby: target_hobby)
       visit admin_unclassified_hobbies_path
     end
@@ -56,37 +52,35 @@ RSpec.describe "Admin 未分類タグ管理", type: :system do
   end
 
   describe "検索" do
-    let!(:rails_hobby)  { create(:hobby, name: "rails",  parent_tag: uncategorized_parent_tag) }
-    let!(:python_hobby) { create(:hobby, name: "python", parent_tag: uncategorized_parent_tag) }
+    let!(:rails_hobby) { create(:hobby, name: "rails") }
+    let!(:python_hobby) { create(:hobby, name: "python") }
 
     before { visit admin_unclassified_hobbies_path }
 
     it "検索ワードに一致するタグだけが表示される" do
-      # rails で検索
       fill_in "q", with: "rails"
       click_button "検索"
-      # 名前列にのみ絞って確認（mergeドロップダウンは全タグを含む）
-      expect(page).to     have_css("td[data-col='name']", text: "rails")
+      expect(page).to have_css("td[data-col='name']", text: "rails")
       expect(page).not_to have_css("td[data-col='name']", text: "python")
     end
   end
 
   describe "分類" do
-    let!(:unclassified_rails) { create(:hobby, name: "rails", parent_tag: uncategorized_parent_tag) }
+    let!(:unclassified_rails) { create(:hobby, name: "rails") }
 
     before { visit admin_unclassified_hobbies_path }
 
     it "親タグを選択して保存するとフラッシュが表示される" do
-      # parent_tag_id selectで親タグを選択して分類ボタンを押す
       select "プログラミング", from: "parent_tag_id"
       click_button "分類"
       expect(page).to have_content "分類しました"
     end
 
-    it "分類後にparent_tag_idが更新される" do
+    it "分類後に hobby_parent_tag が作成される" do
       select "プログラミング", from: "parent_tag_id"
       click_button "分類"
-      expect(unclassified_rails.reload.parent_tag_id).to eq programming_parent_tag.id
+      hobby_parent_tag = unclassified_rails.hobby_parent_tags.reload.find_by(room_type: programming_parent_tag.room_type)
+      expect(hobby_parent_tag&.parent_tag).to eq(programming_parent_tag)
     end
 
     it "分類後に一覧から消える" do
@@ -97,12 +91,11 @@ RSpec.describe "Admin 未分類タグ管理", type: :system do
   end
 
   describe "統合" do
-    let!(:source_rails_hobby)  { create(:hobby, name: "rails",  parent_tag: uncategorized_parent_tag) }
-    let!(:target_Rails_hobby)  { create(:hobby, name: "Rails") }
+    let!(:source_rails_hobby) { create(:hobby, name: "rails") }
+    let!(:target_rails_hobby) { create(:hobby, name: "Rails") }
     let!(:source_hobby_owner_profile) { create(:profile) }
 
     before do
-      # sourceタグを持つプロフィールを作成
       create(:profile_hobby, profile: source_hobby_owner_profile, hobby: source_rails_hobby)
       visit admin_unclassified_hobbies_path
     end
@@ -120,7 +113,7 @@ RSpec.describe "Admin 未分類タグ管理", type: :system do
         select "Rails", from: "target_hobby_id"
         click_button "統合"
       end
-      expect(ProfileHobby.where(hobby_id: target_Rails_hobby.id, profile_id: source_hobby_owner_profile.id)).to exist
+      expect(ProfileHobby.where(hobby_id: target_rails_hobby.id, profile_id: source_hobby_owner_profile.id)).to exist
     end
 
     it "統合後にsource hobbyが削除される" do
@@ -136,7 +129,6 @@ RSpec.describe "Admin 未分類タグ管理", type: :system do
     let!(:normal_user) { create(:user) }
 
     it "一般ユーザーはrootにリダイレクトされる" do
-      # 一般ユーザーでログイン
       login_as(normal_user, scope: :user)
       visit admin_unclassified_hobbies_path
       expect(page).to have_current_path root_path

--- a/spec/system/my/profile_tag_autocomplete_spec.rb
+++ b/spec/system/my/profile_tag_autocomplete_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe "タグ入力チップUI", type: :system, js: true do
   let(:current_user) { create(:user) }
   let!(:current_profile) { create(:profile, user: current_user) }
-  let!(:uncategorized) { ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類"; pt.position = 0 } }
 
   before do
     # タグ操作はタグタブで行う

--- a/spec/system/my/profile_tag_description_spec.rb
+++ b/spec/system/my/profile_tag_description_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe "タグ説明文入力UI", type: :system, js: true do
   let(:current_user) { create(:user) }
   let!(:current_profile) { create(:profile, user: current_user) }
-  let!(:uncategorized) { ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) { |pt| pt.name = "未分類"; pt.position = 0 } }
 
   before do
     login_as(current_user, scope: :user)

--- a/spec/system/profile_hobbies_flow_spec.rb
+++ b/spec/system/profile_hobbies_flow_spec.rb
@@ -1,14 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "趣味(タグ)登録の一連の流れ", type: :system, js: true do
-  # ProfileHobbiesUpdater が find_by!(slug: "uncategorized") を呼ぶため必須
-  let!(:uncategorized_parent_tag) do
-    ParentTag.find_or_create_by!(slug: "uncategorized", room_type: nil) do |pt|
-      pt.name = "未分類"
-      pt.position = 0
-    end
-  end
-
   it "ログインして、プロフィール編集でタグを更新し、詳細に表示させる" do
     user = create(:user)
     create(:profile, user: user)

--- a/spec/system/rooms/member_detail_tag_toggle_spec.rb
+++ b/spec/system/rooms/member_detail_tag_toggle_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe "部屋メンバー詳細タブ切り替え", type: :system, js: 
   let!(:member_profile) { create(:profile, user: member_user, bio: "メンバー自己紹介です") }
   let!(:game_parent_tag) { create(:parent_tag, room_type: :game) }
   let!(:room) { create(:room, issuer_profile: viewer_profile, room_type: :game) }
-  let!(:hobby) { create(:hobby, name: "ゲーム", parent_tag: game_parent_tag) }
+  let!(:hobby) do
+    hobby = create(:hobby, name: "ゲーム")
+    create(:hobby_parent_tag, hobby:, parent_tag: game_parent_tag)
+    hobby
+  end
 
   before do
     create(:room_membership, room:, profile: viewer_profile)
@@ -40,7 +44,11 @@ RSpec.describe "部屋メンバー詳細タブ切り替え", type: :system, js: 
   end
 
   context "説明文が未入力のタブがある場合" do
-    let!(:hobby2) { create(:hobby, name: "釣り", parent_tag: game_parent_tag) }
+    let!(:hobby2) do
+      hobby = create(:hobby, name: "釣り")
+      create(:hobby_parent_tag, hobby:, parent_tag: game_parent_tag)
+      hobby
+    end
 
     before do
       create(:profile_hobby, profile: member_profile, hobby: hobby2, description: nil)


### PR DESCRIPTION
## Summary
- `hobbies` と `parent_tags` の関係を 1対多 → 多対多に変更
- `hobby_parent_tags` 中間テーブルを追加（`hobby_id`, `parent_tag_id`, `room_type` denormalize）
- `(hobby_id, room_type)` unique 制約により「同一 room_type 内は 1 hobby = 1 parent_tag」を DB レベルで保証
- `hobbies.parent_tag_id` カラムを削除（辞書とタグ文脈を分離）
- 未分類の定義を「`hobby_parent_tags` レコードが存在しない状態」に変更
- `Admin::HobbyClassificationService` を新規追加（分類操作の Service 化）
- サブエージェントレビュー（rails-reviewer / performance-checker）指摘を全件対応

## Test plan
- [x] RSpec 428 examples, 0 failures 確認済み
- [x] RuboCop no offenses 確認済み
- [x] Apex 1件が chat と game の両方の親タグに紐付けられる
- [x] 同一 room_type への二重分類は DB エラーで拒否される
- [x] ProfileHobbiesUpdater で作った新規 hobby が未分類管理に表示される
- [x] 管理画面から hobby を分類すると未分類管理から消える
- [x] JsmindDataBuilder が正しい room_type のツリーを生成する

## Related
- Issue: #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)