### PR TITLE
feat: プロフィール一覧カードのUI改善（高さ統一・情報制限・編集導線）

### DIFF
--- a/app/views/profiles/_profile_card.html.erb
+++ b/app/views/profiles/_profile_card.html.erb
@@ -1,36 +1,34 @@
-<div class="transition-shadow duration-300 hover:shadow-[0_0_20px_rgba(99,102,241,0.2)]"
+<div class="flex h-full flex-col transition-shadow duration-300 hover:shadow-[0_0_20px_rgba(99,102,241,0.2)]"
      style="border-radius: 1rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); padding: 1.5rem; box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
-
-  <!-- アバター + ユーザー名 -->
-  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem;">
+  <div class="mb-2 flex items-center gap-3">
     <%= avatar_image_tag(profile.user, size: :small) %>
-    <p style="font-size: 0.875rem; font-weight: 500; color: #d1d5db; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+    <p class="truncate text-sm font-medium text-gray-300">
       <%= profile.user.nickname %>
     </p>
   </div>
 
-  <!-- タグ -->
-  <div style="margin-top: 0.75rem;">
-    <%= render "shared/hobby_tags", hobbies: profile.hobbies, limit: 5 %>
+  <div class="mb-2">
+    <%= render "shared/hobby_tags", hobbies: profile.hobbies, limit: 2 %>
   </div>
 
-  <!-- 自己紹介 -->
-  <p class="line-clamp-3" style="color: #9ca3af; font-size: 0.875rem; line-height: 1.5; white-space: pre-line; margin-top: 0.5rem;">
-    <%= profile.bio.presence || "説明文は未入力です" %>
+  <p class="<%= class_names('line-clamp-3 text-sm leading-relaxed',
+                            'text-gray-400' => profile.bio.present?,
+                            'text-gray-600 italic' => profile.bio.blank?) %>"
+     style="white-space: pre-line;">
+    <%= profile.bio.presence || "自己紹介はまだありません" %>
   </p>
 
-  <div style="margin-top: 1rem; display: flex; align-items: center; gap: 1rem;">
+  <div class="mt-auto flex items-center gap-4 pt-4">
     <%= link_to "詳細を見る",
                 profile_path(profile),
                 data: { turbo_frame: "_top" },
                 style: "color: #60a5fa; text-decoration: none; font-size: 0.875rem; font-weight: 500;" %>
 
-    <% if current_user.own?(profile) %>
+    <% if user_signed_in? && current_user.own?(profile) %>
       <%= link_to "編集する",
                   edit_my_profile_path,
                   data: { turbo_frame: "_top" },
                   style: "color: #60a5fa; text-decoration: none; font-size: 0.875rem; font-weight: 500;" %>
     <% end %>
   </div>
-
 </div>

--- a/app/views/profiles/_profile_list.html.erb
+++ b/app/views/profiles/_profile_list.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "profile_list" do %>
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+  <div class="grid grid-cols-1 gap-6 items-stretch sm:grid-cols-2 lg:grid-cols-4">
     <% profiles.each do |profile| %>
       <%= render "profile_card", profile: profile %>
     <% end %>

--- a/spec/system/profiles/profile_card_bio_spec.rb
+++ b/spec/system/profiles/profile_card_bio_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "プロフィールカードのbio表示", type: :system, js: tru
       create(:profile, bio: nil)
       visit profiles_path
 
-      expect(page).to have_text("説明文は未入力です")
+      expect(page).to have_text("自己紹介はまだありません")
     end
   end
 end


### PR DESCRIPTION
## Summary
- カード構成をアイコン→名前→タグ→説明文→アクションの順に統一し、視線の流れを揃えた
- タグ表示を最大2件+nに制限し、タグ多数カードだけ目立つ問題を解消
- 説明文を`line-clamp-3`で3行省略・未入力時は薄いイタリック体でプレースホルダー表示
- `flex flex-col h-full` + `mt-auto` でアクションをカード下部に固定し、高さを統一
- `user_signed_in?` ガード追加で未ログイン時の NoMethodError を防止
- `class_names` ヘルパーでERB内クォート入れ子を解消
- bio未入力プレースホルダーのテキスト変更に合わせてsystem specを更新

## Test plan
- [x] RSpec: 429 examples, 0 failures（全通過）
- [x] RuboCop: 173 files, no offenses
- [x] タグあり・なし・説明文あり・なしのカードが同じ行内で高さが揃う
- [x] タグ3件以上のプロフィールで `+n` が表示される
- [x] 自分のカードにのみ「編集する」が表示される
- [x] 説明文が長い場合に3行で省略される
- [x] 「詳細を見る」リンクが正しく遷移する

## Related
- Issue: #221