### PR TITLE
feat: プロフィール検索にローディング状態を追加

### DIFF
--- a/app/javascript/controllers/profile_search_controller.js
+++ b/app/javascript/controllers/profile_search_controller.js
@@ -5,12 +5,32 @@ export default class extends Controller {
 
   connect() {
     this._debounceTimer = null
+    this.loadingContainer = document.getElementById("profile_list_loading_container")
+    this.loadingIndicator = document.getElementById("profile_list_loading_indicator")
+
+    this.hideLoading()
+
+    this.boundHideLoading = this.hideLoading.bind(this)
+    document.addEventListener("turbo:load", this.boundHideLoading)
+    document.addEventListener("turbo:frame-load", this.boundHideLoading)
+    document.addEventListener("turbo:submit-end", this.boundHideLoading)
+    document.addEventListener("turbo:fetch-request-error", this.boundHideLoading)
+    document.addEventListener("turbo:before-cache", this.boundHideLoading)
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:load", this.boundHideLoading)
+    document.removeEventListener("turbo:frame-load", this.boundHideLoading)
+    document.removeEventListener("turbo:submit-end", this.boundHideLoading)
+    document.removeEventListener("turbo:fetch-request-error", this.boundHideLoading)
+    document.removeEventListener("turbo:before-cache", this.boundHideLoading)
   }
 
   // テキスト入力時に debounce 経由でサブミット
   search() {
     clearTimeout(this._debounceTimer)
     this._debounceTimer = setTimeout(() => {
+      this.showLoading()
       this.formTarget.requestSubmit()
     }, 300)
   }
@@ -30,6 +50,21 @@ export default class extends Controller {
     andBtn.style.cssText = `padding: 0.375rem 0.75rem; border-radius: 0.5rem 0 0 0.5rem; border: 1px solid; font-size: 0.875rem; font-weight: 500; cursor: pointer; ${mode === "and" ? activeStyle : inactiveStyle}`
     orBtn.style.cssText  = `padding: 0.375rem 0.75rem; border-radius: 0 0.5rem 0.5rem 0; border: 1px solid; border-left: none; font-size: 0.875rem; font-weight: 500; cursor: pointer; ${mode === "or" ? activeStyle : inactiveStyle}`
 
+    this.showLoading()
     this.formTarget.requestSubmit()
+  }
+
+  showLoading() {
+    if (!this.loadingContainer || !this.loadingIndicator) return
+
+    this.loadingContainer.setAttribute("aria-busy", "true")
+    this.loadingIndicator.hidden = false
+  }
+
+  hideLoading(event) {
+    if (!this.loadingContainer || !this.loadingIndicator) return
+
+    this.loadingContainer.setAttribute("aria-busy", "false")
+    this.loadingIndicator.hidden = true
   }
 }

--- a/app/views/profiles/_search_form.html.erb
+++ b/app/views/profiles/_search_form.html.erb
@@ -44,6 +44,7 @@
 
     <!-- 検索ボタン -->
     <%= f.submit "検索",
+          data: { action: "click->profile-search#showLoading" },
           style: "padding: 0.375rem 1rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border-radius: 0.5rem; border: none; cursor: pointer;" %>
 
     <!-- リセット -->

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -7,5 +7,20 @@
   </div>
 
   <!-- カードグリッド：4列 -->
-  <%= render "profile_list", profiles: @profiles %>
+  <div id="profile_list_loading_container"
+       aria-busy="false"
+       style="position: relative;">
+    <div data-loading-target="indicator"
+         id="profile_list_loading_indicator"
+         data-testid="profile-list-loading"
+         hidden
+         style="position: absolute; inset: 0; z-index: 10; display: flex; align-items: center; justify-content: center; border-radius: 1rem; background: rgba(10, 14, 26, 0.56); backdrop-filter: blur(2px);">
+      <div style="display: inline-flex; align-items: center; gap: 0.75rem; padding: 0.875rem 1rem; border-radius: 9999px; background: rgba(15, 23, 42, 0.92); border: 1px solid rgba(96, 165, 250, 0.3); box-shadow: 0 14px 32px rgba(2, 6, 23, 0.32); color: #e5eefc;">
+        <span style="width: 1rem; height: 1rem; border-radius: 9999px; border: 2px solid rgba(191, 219, 254, 0.3); border-top-color: #60a5fa; animation: spin 0.8s linear infinite;"></span>
+        <span style="font-size: 0.875rem; font-weight: 600;">検索結果を更新しています...</span>
+      </div>
+    </div>
+
+    <%= render "profile_list", profiles: @profiles %>
+  </div>
 </div>

--- a/spec/system/loading_states_spec.rb
+++ b/spec/system/loading_states_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "Loading states", type: :system, js: true do
+  let(:user) { create(:user) }
+
+  before do
+    login_as(user, scope: :user)
+    visit profiles_path
+  end
+
+  it "検索結果フレームの更新イベントに応じて部分ローディングを表示・解除する" do
+    expect(hidden?("[data-testid='profile-list-loading']")).to be(true)
+
+    page.execute_script(<<~JS)
+      const form = document.querySelector("form[data-controller='profile-search']")
+      const controller = window.Stimulus.getControllerForElementAndIdentifier(form, "profile-search")
+      controller.showLoading()
+    JS
+
+    expect(hidden?("[data-testid='profile-list-loading']")).to be(false)
+
+    page.execute_script(<<~JS)
+      const form = document.querySelector("form[data-controller='profile-search']")
+      const controller = window.Stimulus.getControllerForElementAndIdentifier(form, "profile-search")
+      controller.hideLoading()
+    JS
+
+    expect(hidden?("[data-testid='profile-list-loading']")).to be(true)
+  end
+
+  def hidden?(selector)
+    page.evaluate_script(<<~JS)
+      (() => {
+        const element = document.querySelector(#{selector.to_json})
+        return element.hidden
+      })()
+    JS
+  end
+end


### PR DESCRIPTION
## Summary
- 検索テキスト入力・AND/OR切替時に部分ローディングオーバーレイを表示
- Turbo Frame の更新完了後にローディングを非表示にするイベントリスナーを追加
- `profile_search_controller.js` に `showLoading` / `hideLoading` メソッドを追加

## Test plan
- [x] `spec/system/loading_states_spec.rb` 1 example, 0 failures
- [x] RuboCop 174 files, no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)