### PR TITLE
fix: ロック中の共有リンクは参加者のみ閲覧可能にする

### DIFF
--- a/app/controllers/shares_controller.rb
+++ b/app/controllers/shares_controller.rb
@@ -4,18 +4,11 @@ class SharesController < ApplicationController
   rescue_from ActionPolicy::Unauthorized, with: :handle_unauthorized
 
   def show
-    share_link      = ShareLink.includes(:room).find_by!(token: params[:token])
-    @room           = share_link.room
+    @share_link     = ShareLink.includes(:room).find_by!(token: params[:token])
+    @room           = @share_link.room
     @viewer_profile = current_user.profile
 
-    authorize! share_link, to: :show?
-
-    unless allowed_to?(:join?, share_link)
-      flash.now[:alert] = "この部屋は現在ロック中のため参加できません"
-      @memberships = memberships_for_display
-      @jsmind_data = JsmindDataBuilder.new(@room, @memberships).build
-      return render :show
-    end
+    authorize! @share_link, to: :show?
 
     RoomMembership.find_or_create_by!(room: @room, profile: @viewer_profile) if @viewer_profile
     @memberships = memberships_for_display
@@ -31,7 +24,9 @@ class SharesController < ApplicationController
   end
 
   def handle_unauthorized
-    head :gone
+    return head :gone if @share_link&.expired?
+
+    head :not_found
   end
 
   def require_profile!

--- a/app/policies/share_link_policy.rb
+++ b/app/policies/share_link_policy.rb
@@ -4,7 +4,10 @@ class ShareLinkPolicy < ApplicationPolicy
 
   # 期限切れでも既存メンバーなら閲覧継続可
   def show?
-    !record.expired? || member?
+    return true if member? || owner?
+    return false if record.expired?
+
+    !record.room.locked?
   end
 
   # ロック中は既存メンバー or オーナーのみ参加可

--- a/spec/policies/share_link_policy_spec.rb
+++ b/spec/policies/share_link_policy_spec.rb
@@ -26,6 +26,23 @@ RSpec.describe ShareLinkPolicy do
       end
     end
 
+    context "ロック中の部屋の場合" do
+      before { room.update!(locked: true) }
+
+      it "非メンバー・非オーナーは false を返す" do
+        expect(policy(active_link, viewer_user).show?).to be false
+      end
+
+      it "既存メンバーは true を返す" do
+        create(:room_membership, room: room, profile: viewer_profile)
+        expect(policy(active_link, viewer_user).show?).to be true
+      end
+
+      it "オーナーは true を返す" do
+        expect(policy(active_link, room_owner_user).show?).to be true
+      end
+    end
+
     context "期限切れリンクの場合" do
       it "非メンバーは false を返す" do
         # 閲覧者は未参加かつリンクは期限切れ → アクセス不可

--- a/spec/requests/shares_spec.rb
+++ b/spec/requests/shares_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Shares", type: :request do
   describe "GET /share/:token" do
     context "ロック中の部屋に未参加ユーザーがアクセスした場合" do
-      it "ページは表示されるが RoomMembership は作成されない" do
+      it "404 を返し RoomMembership は作成されない" do
         # ロック中の部屋と共有リンクを準備
         room_owner = create(:user)
         room_owner_profile = create(:profile, user: room_owner)
@@ -20,8 +20,7 @@ RSpec.describe "Shares", type: :request do
           get share_path(share_link.token)
         }.not_to change(RoomMembership, :count)
 
-        # ページは表示されること
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:not_found)
       end
     end
 


### PR DESCRIPTION
## 概要
ロック中の部屋に対して、参加者とオーナー以外が共有リンク経由で閲覧できてしまう挙動を修正しました

## 変更内容
- `ShareLinkPolicy#show?` を見直し
- ロック中の部屋は、既存メンバーまたはオーナーのみ閲覧可能に変更
- 期限切れリンクは従来どおり、既存メンバーのみ閲覧可能
- `SharesController` の unauthorized 時のレスポンスを整理
- 期限切れは `410 Gone`
- それ以外の閲覧不可は `404 Not Found`
- request spec / policy spec を新仕様に合わせて更新

## 期待される挙動
- 公開中の部屋
  - 未参加ユーザーは共有リンクから閲覧でき、そのまま参加できる
- ロック中の部屋
  - 既存メンバーとオーナーのみ閲覧できる
  - 非参加ユーザーは `404` を返す
- 期限切れリンク
  - 既存メンバーは閲覧継続できる
  - 非メンバーは `410` を返す

## テスト
以下を `docker compose exec web` 経由で実行しました

```bash
bundle exec rspec \
  spec/policies/share_link_policy_spec.rb \
  spec/requests/shares_spec.rb \
  spec/requests/shares/shares_show_auth_spec.rb \
  spec/requests/shares/shares_show_expired_spec.rb \
  spec/requests/shares/shares_show_room_header_spec.rb \
  spec/requests/shares/shares_show_members_order_spec.rb \
  spec/views/shares/show.html.erb_spec.rb
