### PR TITLE
fix: プロフィール詳細の改行表示を安定化

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -54,11 +54,13 @@
 
             <div class="min-h-[9rem] rounded-2xl border border-slate-700/50 bg-slate-950/40 p-5">
               <div data-tabs-target="panel"
-                   class="hidden text-sm leading-8 text-slate-300 whitespace-pre-line"><%= @profile.bio.presence || "未入力" %></div>
+                   class="hidden text-sm leading-8 text-slate-300 whitespace-pre-line"
+                   style="white-space: pre-line;"><%= @profile.bio.presence || "未入力" %></div>
 
               <% @profile.profile_hobbies.each do |ph| %>
                 <div data-tabs-target="panel"
-                     class="hidden text-sm leading-8 text-slate-300 whitespace-pre-line"><%= ph.description.presence || "未入力" %></div>
+                     class="hidden text-sm leading-8 text-slate-300 whitespace-pre-line"
+                     style="white-space: pre-line;"><%= ph.description.presence || "未入力" %></div>
               <% end %>
             </div>
           </div>


### PR DESCRIPTION
## 概要
- マージ済みPRの後追いで入ってしまった改行表示修正を、独立したブランチへ載せ替えました
- プロフィール詳細ページで、保存済みの改行がより確実に反映されるようにしています

## 変更内容
- `app/views/profiles/show.html.erb` の本文パネルに `white-space: pre-line;` を追加
- 既存の `whitespace-pre-line` と合わせて、改行表示を安定化

## テスト
- `docker compose exec web bundle exec rspec spec/system/profiles/show_tag_toggle_spec.rb spec/requests/profiles/profiles_show_shared_hobbies_spec.rb --no-color`
- `docker compose exec web bundle exec rubocop spec/system/profiles/show_tag_toggle_spec.rb spec/requests/profiles/profiles_show_shared_hobbies_spec.rb --no-color`

## 補足
- 対象は view の軽微修正のみです
- PR #241 に後から積まれた `ec818ad` を、新しいブランチへ cherry-pick して載せ替えています