### PR TITLE
feat: マイページにプロフィール一覧への導線を追加 #228

### DIFF
--- a/app/views/mypage/dashboards/show.html.erb
+++ b/app/views/mypage/dashboards/show.html.erb
@@ -49,7 +49,7 @@
   </div>
 
   <%# メニュー %>
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
     <%# 趣味プロフィール %>
     <% if current_user.profile %>
       <%= link_to edit_my_profile_path,
@@ -78,6 +78,15 @@
       </svg>
       <span style="font-size: 0.875rem; font-weight: 500; color: #d1d5db;">部屋管理</span>
       <span style="font-size: 0.75rem; color: #6b7280;"><%= rooms_count %> 部屋</span>
+    <% end %>
+
+    <%# プロフィール一覧 %>
+    <%= link_to profiles_path,
+                style: "display: flex; flex-direction: column; align-items: center; gap: 0.75rem; padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); text-decoration: none; transition: all 0.3s;" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" style="height: 2rem; width: 2rem; color: #60a5fa;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+      </svg>
+      <span style="font-size: 0.875rem; font-weight: 500; color: #d1d5db;">プロフィール一覧</span>
     <% end %>
 
     <%# 設定 %>

--- a/docs/designs/2026-04-19-mypage-profiles-link.md
+++ b/docs/designs/2026-04-19-mypage-profiles-link.md
@@ -1,0 +1,96 @@
+# マイページにプロフィール一覧への導線を追加 設計書
+
+**日付:** 2026-04-19
+**Issue:** #228
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+- `app/views/mypage/dashboards/show.html.erb` にプロフィール一覧ブロックを追加（`/profiles` リンク）
+
+## 2. 目的
+- マイページからプロフィール一覧への導線を追加し、回遊性を改善する
+
+## 3. スコープ
+### 含むもの
+- `show.html.erb` のメニューグリッドへのブロック追加
+
+### 含まないもの
+- プロフィール一覧ページ自体の変更
+- DB変更・マイグレーション
+
+## 4. 設計方針
+現在グリッドは `grid-cols-1 md:grid-cols-3`（3ブロック）。4ブロック目を追加するにあたり `md:grid-cols-2 lg:grid-cols-4` に変更し、4つが均等に並ぶレイアウトにする。
+
+| 方式 | 見た目 | コスト |
+|---|---|---|
+| A: グリッドをそのまま（3+1） | デスクトップで4つ目が左寄り | 低 |
+| B: `md:grid-cols-2 lg:grid-cols-4` に変更（2+2 → 4並び） | 均等でスッキリ | 低 |
+
+**採用理由:** 案B。4ブロックが均等に並び見た目が整う。
+
+## 5. データ設計
+なし（ビューのみ）
+
+### ER 図
+```mermaid
+erDiagram
+  users {
+    int id PK
+    string nickname
+  }
+  profiles {
+    int id PK
+    int user_id FK
+  }
+  users ||--o| profiles : "has one"
+```
+
+## 6. 画面・アクセス制御の流れ
+
+### シーケンス図
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant C as Mypage::DashboardsController
+  participant V as show.html.erb
+
+  U->>C: GET /mypage/dashboard
+  C->>V: render
+  V-->>U: プロフィール一覧ブロック含むマイページ
+  U->>U: ブロッククリック → GET /profiles
+```
+
+## 7. アプリケーション設計
+- コントローラ変更なし
+- ビューに `link_to profiles_path` ブロックを追加
+- アイコンは既存ブロックと同スタイル（人型SVG）
+
+## 8. ルーティング設計
+変更なし。`profiles_path` は既存ルート。
+
+## 9. レイアウト / UI 設計
+既存3ブロックと同スタイル（ダーク系カード・青いアイコン）。グリッドを `md:grid-cols-2 lg:grid-cols-4` に変更。
+
+## 10. クエリ・性能面
+追加クエリなし。N+1の心配なし。
+
+## 11. トランザクション / Service 分離
+**トランザクション:** 不要
+**Service 分離:** 不要（ビューのみ）
+
+## 12. 実装対象一覧
+
+| # | 対象 | 内容 |
+|---|---|---|
+| 1 | View | `app/views/mypage/dashboards/show.html.erb` グリッドを `md:grid-cols-2 lg:grid-cols-4` に変更 + プロフィール一覧ブロック追加 |
+
+## 13. 受入条件
+- [ ] マイページに「プロフィール一覧」ブロックが追加されている
+- [ ] クリックで `/profiles` へ遷移する
+- [ ] 既存ブロックに影響しない
+- [ ] RSpec / RuboCop が全通過する
+
+## 14. この設計の結論
+ビュー1ファイルのみの変更。グリッドを4列対応に変更しつつ、既存デザインと統一したブロックを追加する。

--- a/spec/requests/mypage/dashboards_spec.rb
+++ b/spec/requests/mypage/dashboards_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Mypage::Dashboards", type: :request do
 
         get mypage_root_path
 
-        menu_links = Nokogiri::HTML.parse(response.body).css("div.grid.grid-cols-1.md\\:grid-cols-3.gap-4 > a")
+        menu_links = Nokogiri::HTML.parse(response.body).css("div.grid.grid-cols-1.md\\:grid-cols-2.lg\\:grid-cols-4.gap-4 > a")
 
         expect(menu_links.map(&:text).map(&:strip)).to include("プロフィールを作成する")
         expect(response.body).to include(new_my_profile_path)
@@ -52,12 +52,14 @@ RSpec.describe "Mypage::Dashboards", type: :request do
 
         get mypage_root_path
 
-        menu_links = Nokogiri::HTML.parse(response.body).css("div.grid.grid-cols-1.md\\:grid-cols-3.gap-4 > a")
+        menu_links = Nokogiri::HTML.parse(response.body).css("div.grid.grid-cols-1.md\\:grid-cols-2.lg\\:grid-cols-4.gap-4 > a")
         menu_texts = menu_links.map(&:text).map { |text| text.gsub(/\s+/, " ").strip }
 
-        expect(menu_links.size).to eq(3)
+        # 4ブロック（プロフィール作成・部屋管理・プロフィール一覧・設定）が表示されている
+        expect(menu_links.size).to eq(4)
         expect(menu_texts).to include("プロフィールを作成する")
         expect(menu_texts).to include("部屋管理 0 部屋")
+        expect(menu_texts).to include("プロフィール一覧")
         expect(menu_texts).to include("設定")
       end
 
@@ -72,6 +74,20 @@ RSpec.describe "Mypage::Dashboards", type: :request do
 
         expect(response.body).to include(mypage_rooms_path)
         expect(response.body).to include("2")
+      end
+
+      it "プロフィール一覧へのリンクが表示される" do
+        current_user = create(:user)
+        sign_in current_user
+
+        # マイページにアクセス
+        get mypage_root_path
+
+        # メニューグリッド内のリンク一覧を取得
+        menu_links = Nokogiri::HTML.parse(response.body).css("div.grid.grid-cols-1.md\\:grid-cols-2.lg\\:grid-cols-4.gap-4 > a")
+
+        # プロフィール一覧パスへのリンクがメニュー内に含まれている
+        expect(menu_links.map { |a| a["href"] }).to include(profiles_path)
       end
 
       it "設定ページへのリンクが表示される" do


### PR DESCRIPTION
## Summary
- マイページのメニューグリッドに「プロフィール一覧」ブロックを追加
- クリックで `/profiles`（全ユーザーのプロフィール一覧）へ遷移
- グリッドレイアウトを `md:grid-cols-3` → `md:grid-cols-2 lg:grid-cols-4` に変更し4ブロックを均等配置

## Test plan
- [x] マイページに「プロフィール一覧」ブロックが表示される
- [x] クリックで `/profiles` へ遷移する
- [x] 既存ブロック（趣味プロフィール・部屋管理・設定）に影響しない
- [x] RSpec 456 examples, 0 failures
- [x] RuboCop no offenses

## Related
- Issue: #228