### PR TITLE
feat: プロフィール画面にヘルプモーダルを追加 #231

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -39,3 +39,7 @@ application.register("tag-toggle", TagToggleController)
 
 import ToggleController from "./toggle_controller"
 application.register("toggle", ToggleController)
+
+// ヘルプモーダルの開閉制御
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["panel"]
+
+  // モーダルを開き、背景スクロールを無効化する
+  open() {
+    this.panelTarget.classList.remove("hidden")
+    document.body.classList.add("overflow-hidden")
+  }
+
+  // モーダルを閉じ、背景スクロールを復元する
+  close() {
+    this.panelTarget.classList.add("hidden")
+    document.body.classList.remove("overflow-hidden")
+  }
+}

--- a/app/views/my/profiles/_help_content_edit.html.erb
+++ b/app/views/my/profiles/_help_content_edit.html.erb
@@ -1,0 +1,31 @@
+<%# プロフィール編集画面のヘルプ本文 %>
+<%# 各セクションは薄い枠付きカードで区切る %>
+
+<%# 自己紹介（ひとこと）を書くときのヒント %>
+<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
+  <h3 class="mb-2 text-sm font-semibold text-slate-200">自己紹介のヒント</h3>
+  <ul class="space-y-1 text-slate-400">
+    <li>・初めて通話やチャットで会う相手に、最初に知ってほしいことを書いてみましょう</li>
+    <li>・好きなことや、最近ハマっていることを書くと会話のきっかけになります</li>
+    <li>・話しかけてもらえるとうれしい話題を書くのもおすすめです</li>
+  </ul>
+</section>
+
+<%# タグ入力のコツ %>
+<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
+  <h3 class="mb-2 text-sm font-semibold text-slate-200">タグのコツ</h3>
+  <ul class="space-y-1 text-slate-400">
+    <li>・まずは2〜5個くらいからで大丈夫です</li>
+    <li>・具体的な名前にすると伝わりやすくなります</li>
+    <li>・自己紹介で伝えきれないことは、タグごとの説明で少し詳しく書けます</li>
+  </ul>
+</section>
+
+<%# 安心感を伝えるメッセージ %>
+<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
+  <h3 class="mb-2 text-sm font-semibold text-slate-200">気軽に大丈夫です</h3>
+  <ul class="space-y-1 text-slate-400">
+    <li>・何度でも編集できます</li>
+    <li>・少しずつ整えていく形でも大丈夫です</li>
+  </ul>
+</section>

--- a/app/views/my/profiles/_help_content_edit.html.erb
+++ b/app/views/my/profiles/_help_content_edit.html.erb
@@ -1,31 +1,12 @@
 <%# プロフィール編集画面のヘルプ本文 %>
-<%# 各セクションは薄い枠付きカードで区切る %>
+<%# 共通セクションを読み込み、画面固有のセクションを末尾に追加 %>
 
-<%# 自己紹介（ひとこと）を書くときのヒント %>
-<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
-  <h3 class="mb-2 text-sm font-semibold text-slate-200">自己紹介のヒント</h3>
-  <ul class="space-y-1 text-slate-400">
-    <li>・初めて通話やチャットで会う相手に、最初に知ってほしいことを書いてみましょう</li>
-    <li>・好きなことや、最近ハマっていることを書くと会話のきっかけになります</li>
-    <li>・話しかけてもらえるとうれしい話題を書くのもおすすめです</li>
-  </ul>
-</section>
+<%= render "my/profiles/help_content_shared" %>
 
-<%# タグ入力のコツ %>
-<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
-  <h3 class="mb-2 text-sm font-semibold text-slate-200">タグのコツ</h3>
-  <ul class="space-y-1 text-slate-400">
-    <li>・まずは2〜5個くらいからで大丈夫です</li>
-    <li>・具体的な名前にすると伝わりやすくなります</li>
-    <li>・自己紹介で伝えきれないことは、タグごとの説明で少し詳しく書けます</li>
-  </ul>
-</section>
-
-<%# 安心感を伝えるメッセージ %>
+<%# 安心感を伝えるメッセージ（編集画面専用） %>
 <section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
   <h3 class="mb-2 text-sm font-semibold text-slate-200">気軽に大丈夫です</h3>
-  <ul class="space-y-1 text-slate-400">
-    <li>・何度でも編集できます</li>
-    <li>・少しずつ整えていく形でも大丈夫です</li>
-  </ul>
+  <p class="text-slate-400">
+    何度でも編集できます。少しずつ整えていく形でも大丈夫です。
+  </p>
 </section>

--- a/app/views/my/profiles/_help_content_new.html.erb
+++ b/app/views/my/profiles/_help_content_new.html.erb
@@ -1,0 +1,40 @@
+<%# プロフィール作成画面のヘルプ本文 %>
+<%# 各セクションは薄い枠付きカードで区切る %>
+
+<%# この画面でできること %>
+<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
+  <h3 class="mb-2 text-sm font-semibold text-slate-200">この画面でできること</h3>
+  <ul class="space-y-1 text-slate-400">
+    <li>・自分のプロフィールを作成できます</li>
+    <li>・自己紹介と趣味タグを登録できます</li>
+  </ul>
+</section>
+
+<%# 自己紹介（ひとこと）を書くときのヒント %>
+<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
+  <h3 class="mb-2 text-sm font-semibold text-slate-200">自己紹介のヒント</h3>
+  <ul class="space-y-1 text-slate-400">
+    <li>・初めて通話やチャットで会う相手に、最初に知ってほしいことを書いてみましょう</li>
+    <li>・好きなことや、最近ハマっていることを書くと会話のきっかけになります</li>
+    <li>・話しかけてもらえるとうれしい話題を書くのもおすすめです</li>
+  </ul>
+</section>
+
+<%# タグ入力のコツ %>
+<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
+  <h3 class="mb-2 text-sm font-semibold text-slate-200">タグのコツ</h3>
+  <ul class="space-y-1 text-slate-400">
+    <li>・まずは2〜5個くらいからで大丈夫です</li>
+    <li>・具体的な名前にすると伝わりやすくなります</li>
+    <li>・自己紹介で伝えきれないことは、タグごとの説明で少し詳しく書けます</li>
+  </ul>
+</section>
+
+<%# 安心感を伝えるメッセージ %>
+<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
+  <h3 class="mb-2 text-sm font-semibold text-slate-200">気軽に大丈夫です</h3>
+  <ul class="space-y-1 text-slate-400">
+    <li>・あとから編集できます</li>
+    <li>・最初から完璧に書かなくても大丈夫です</li>
+  </ul>
+</section>

--- a/app/views/my/profiles/_help_content_new.html.erb
+++ b/app/views/my/profiles/_help_content_new.html.erb
@@ -1,40 +1,12 @@
 <%# プロフィール作成画面のヘルプ本文 %>
-<%# 各セクションは薄い枠付きカードで区切る %>
+<%# 共通セクションを読み込み、画面固有のセクションを末尾に追加 %>
 
-<%# この画面でできること %>
-<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
-  <h3 class="mb-2 text-sm font-semibold text-slate-200">この画面でできること</h3>
-  <ul class="space-y-1 text-slate-400">
-    <li>・自分のプロフィールを作成できます</li>
-    <li>・自己紹介と趣味タグを登録できます</li>
-  </ul>
-</section>
+<%= render "my/profiles/help_content_shared" %>
 
-<%# 自己紹介（ひとこと）を書くときのヒント %>
-<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
-  <h3 class="mb-2 text-sm font-semibold text-slate-200">自己紹介のヒント</h3>
-  <ul class="space-y-1 text-slate-400">
-    <li>・初めて通話やチャットで会う相手に、最初に知ってほしいことを書いてみましょう</li>
-    <li>・好きなことや、最近ハマっていることを書くと会話のきっかけになります</li>
-    <li>・話しかけてもらえるとうれしい話題を書くのもおすすめです</li>
-  </ul>
-</section>
-
-<%# タグ入力のコツ %>
-<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
-  <h3 class="mb-2 text-sm font-semibold text-slate-200">タグのコツ</h3>
-  <ul class="space-y-1 text-slate-400">
-    <li>・まずは2〜5個くらいからで大丈夫です</li>
-    <li>・具体的な名前にすると伝わりやすくなります</li>
-    <li>・自己紹介で伝えきれないことは、タグごとの説明で少し詳しく書けます</li>
-  </ul>
-</section>
-
-<%# 安心感を伝えるメッセージ %>
+<%# 安心感を伝えるメッセージ（作成画面専用） %>
 <section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
   <h3 class="mb-2 text-sm font-semibold text-slate-200">気軽に大丈夫です</h3>
-  <ul class="space-y-1 text-slate-400">
-    <li>・あとから編集できます</li>
-    <li>・最初から完璧に書かなくても大丈夫です</li>
-  </ul>
+  <p class="text-slate-400">
+    最初から完璧に書かなくても大丈夫です。あとからいつでも編集できます。
+  </p>
 </section>

--- a/app/views/my/profiles/_help_content_shared.html.erb
+++ b/app/views/my/profiles/_help_content_shared.html.erb
@@ -1,0 +1,20 @@
+<%# new / edit 共通のヘルプセクション（自己紹介のヒント + タグのコツ） %>
+
+<%# 自己紹介（ひとこと）を書くときのヒント %>
+<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
+  <h3 class="mb-2 text-sm font-semibold text-slate-200">自己紹介のヒント</h3>
+  <p class="text-slate-400">
+    初めて通話やチャットで会う相手に、最初に知ってほしいことを書いてみましょう。
+    好きなことや最近ハマっていることは会話のきっかけになります。
+    話しかけてもらえるとうれしい話題を書くのもおすすめです。
+  </p>
+</section>
+
+<%# タグ入力のコツ %>
+<section class="rounded-xl border border-slate-700/40 bg-slate-800/40 px-4 py-3">
+  <h3 class="mb-2 text-sm font-semibold text-slate-200">タグのコツ</h3>
+  <p class="text-slate-400">
+    まずは2〜5個くらいからで大丈夫です。具体的な名前にすると伝わりやすくなります。
+    自己紹介で伝えきれないことは、タグごとの説明欄で少し詳しく書くこともできます。
+  </p>
+</section>

--- a/app/views/my/profiles/edit.html.erb
+++ b/app/views/my/profiles/edit.html.erb
@@ -1,8 +1,21 @@
 <div class="w-full max-w-4xl space-y-6">
-  <div class="rounded-2xl border border-slate-700/40 bg-white/[0.03] p-8 shadow-[0_4px_20px_rgba(0,0,0,0.3)]">
-    <h1 class="mb-4 text-2xl font-bold text-center text-white">
-      プロフィール編集
-    </h1>
+  <%# モーダルコントローラはカード全体を囲む %>
+  <div class="rounded-2xl border border-slate-700/40 bg-white/[0.03] p-8 shadow-[0_4px_20px_rgba(0,0,0,0.3)]"
+       data-controller="modal">
+
+    <%# タイトル + ？ボタン（relative で中央を維持しつつ absolute でボタンを右端へ） %>
+    <div class="relative mb-4 flex items-center justify-center">
+      <h1 class="text-2xl font-bold text-white">プロフィール編集</h1>
+      <button type="button"
+              aria-label="プロフィール編集のヘルプを開く"
+              data-action="click->modal#open"
+              class="absolute right-0 flex h-7 w-7 items-center justify-center rounded-full border border-slate-500/50 bg-slate-800/60 text-sm font-bold text-slate-300 shadow-[0_0_8px_rgba(148,163,184,0.2)] transition hover:border-slate-400 hover:shadow-[0_0_12px_rgba(148,163,184,0.35)] focus:outline-none focus:ring-2 focus:ring-slate-400/50">?</button>
+    </div>
+
+    <%# ヘルプモーダル（初期状態は hidden） %>
+    <%= render "shared/help_modal",
+          title: "プロフィール編集のヘルプ",
+          content_partial: "my/profiles/help_content_edit" %>
 
     <p class="mb-8 text-center text-gray-400">
       <span class="font-semibold text-white">

--- a/app/views/my/profiles/new.html.erb
+++ b/app/views/my/profiles/new.html.erb
@@ -1,8 +1,21 @@
 <div class="w-full max-w-4xl">
-  <div class="rounded-2xl border border-slate-700/40 bg-white/[0.03] p-8 shadow-[0_4px_20px_rgba(0,0,0,0.3)]">
-    <h1 class="mb-4 text-2xl font-bold text-center text-white">
-      プロフィール作成
-    </h1>
+  <%# モーダルコントローラはカード全体を囲む %>
+  <div class="rounded-2xl border border-slate-700/40 bg-white/[0.03] p-8 shadow-[0_4px_20px_rgba(0,0,0,0.3)]"
+       data-controller="modal">
+
+    <%# タイトル + ？ボタン（relative で中央を維持しつつ absolute でボタンを右端へ） %>
+    <div class="relative mb-4 flex items-center justify-center">
+      <h1 class="text-2xl font-bold text-white">プロフィール作成</h1>
+      <button type="button"
+              aria-label="プロフィール作成のヘルプを開く"
+              data-action="click->modal#open"
+              class="absolute right-0 flex h-7 w-7 items-center justify-center rounded-full border border-slate-500/50 bg-slate-800/60 text-sm font-bold text-slate-300 shadow-[0_0_8px_rgba(148,163,184,0.2)] transition hover:border-slate-400 hover:shadow-[0_0_12px_rgba(148,163,184,0.35)] focus:outline-none focus:ring-2 focus:ring-slate-400/50">?</button>
+    </div>
+
+    <%# ヘルプモーダル（初期状態は hidden） %>
+    <%= render "shared/help_modal",
+          title: "プロフィール作成のヘルプ",
+          content_partial: "my/profiles/help_content_new" %>
 
     <p class="mb-8 text-center text-gray-400">
       <span class="font-semibold text-white">

--- a/app/views/shared/_help_modal.html.erb
+++ b/app/views/shared/_help_modal.html.erb
@@ -1,0 +1,32 @@
+<%# ヘルプモーダル共通ラッパー（title: モーダルタイトル, content_partial: 本文パーシャルのパス） %>
+<div data-modal-target="panel"
+     data-testid="help-modal"
+     class="fixed inset-0 z-50 hidden flex items-center justify-center p-4">
+
+  <%# バックドロップ（クリックで閉じる） %>
+  <div class="absolute inset-0 bg-black/60"
+       data-testid="help-modal-backdrop"
+       data-action="click->modal#close"></div>
+
+  <%# モーダルパネル %>
+  <div class="relative z-10 w-full max-w-[480px] rounded-2xl border border-slate-700/60 bg-slate-900 p-6 shadow-2xl max-h-[80vh] overflow-y-auto">
+
+    <%# ヘッダー：タイトル + 閉じるボタン %>
+    <div class="mb-4 flex items-center justify-between">
+      <h2 class="text-lg font-bold text-white"><%= title %></h2>
+      <button type="button"
+              aria-label="ヘルプを閉じる"
+              data-action="click->modal#close"
+              data-testid="help-modal-close"
+              class="flex h-7 w-7 items-center justify-center rounded-full border border-slate-600/50 bg-slate-800/60 text-slate-400 transition hover:border-slate-500 hover:text-slate-200 focus:outline-none focus:ring-2 focus:ring-slate-400/50">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+
+    <%# 本文：画面ごとのヘルプコンテンツを挿入 %>
+    <div class="space-y-4 text-sm leading-relaxed text-slate-300">
+      <%= render content_partial %>
+    </div>
+
+  </div>
+</div>

--- a/spec/system/my/profile_help_modal_spec.rb
+++ b/spec/system/my/profile_help_modal_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe "プロフィールヘルプモーダル", type: :system, js: tru
       # モーダルを開く
       find("button[aria-label='プロフィール作成のヘルプを開く']").click
 
-      # バックドロップ（オーバーレイ）をクリック
-      find("[data-testid='help-modal-backdrop']").click
+      # バックドロップをJSで直接クリック（パネルが中心を覆うため execute_script で発火）
+      find("[data-testid='help-modal-backdrop']").execute_script("this.click()")
 
       # モーダルが非表示になること
       expect(page).to have_css("[data-testid='help-modal']", visible: false)

--- a/spec/system/my/profile_help_modal_spec.rb
+++ b/spec/system/my/profile_help_modal_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe "プロフィールヘルプモーダル", type: :system, js: true do
+  describe "プロフィール作成画面" do
+    # プロフィール未作成のユーザーを用意
+    let(:current_user) { create(:user) }
+
+    before do
+      # ログインしてプロフィール作成画面へ
+      login_as(current_user, scope: :user)
+      visit new_my_profile_path
+    end
+
+    it "？ボタンが表示されている" do
+      # aria-label でボタンを特定して存在確認
+      expect(page).to have_css("button[aria-label='プロフィール作成のヘルプを開く']")
+    end
+
+    it "？ボタンをクリックするとヘルプモーダルが開く" do
+      # ？ボタンをクリック
+      find("button[aria-label='プロフィール作成のヘルプを開く']").click
+
+      # hidden が外れてモーダルが visible になること、ヘルプタイトルが表示されること
+      expect(page).to have_css("[data-testid='help-modal']", visible: true)
+      expect(page).to have_text("プロフィール作成のヘルプ")
+    end
+
+    it "×ボタンをクリックするとモーダルが閉じる" do
+      # モーダルを開く
+      find("button[aria-label='プロフィール作成のヘルプを開く']").click
+
+      # ×ボタンをクリック
+      find("[data-testid='help-modal-close']").click
+
+      # hidden クラスが戻ってモーダルが非表示になること
+      expect(page).to have_css("[data-testid='help-modal']", visible: false)
+    end
+
+    it "バックドロップをクリックするとモーダルが閉じる" do
+      # モーダルを開く
+      find("button[aria-label='プロフィール作成のヘルプを開く']").click
+
+      # バックドロップ（オーバーレイ）をクリック
+      find("[data-testid='help-modal-backdrop']").click
+
+      # モーダルが非表示になること
+      expect(page).to have_css("[data-testid='help-modal']", visible: false)
+    end
+  end
+
+  describe "プロフィール編集画面" do
+    # プロフィール作成済みのユーザーを用意
+    let(:current_user) { create(:user) }
+    let!(:current_profile) { create(:profile, user: current_user) }
+
+    before do
+      # ログインしてプロフィール編集画面へ
+      login_as(current_user, scope: :user)
+      visit edit_my_profile_path
+    end
+
+    it "？ボタンが表示されている" do
+      # aria-label でボタンを特定して存在確認
+      expect(page).to have_css("button[aria-label='プロフィール編集のヘルプを開く']")
+    end
+
+    it "？ボタンをクリックするとヘルプモーダルが開く" do
+      # ？ボタンをクリック
+      find("button[aria-label='プロフィール編集のヘルプを開く']").click
+
+      # モーダルが visible になり、編集画面専用タイトルが表示されること
+      expect(page).to have_css("[data-testid='help-modal']", visible: true)
+      expect(page).to have_text("プロフィール編集のヘルプ")
+    end
+
+    it "×ボタンをクリックするとモーダルが閉じる" do
+      # モーダルを開く
+      find("button[aria-label='プロフィール編集のヘルプを開く']").click
+
+      # ×ボタンをクリック
+      find("[data-testid='help-modal-close']").click
+
+      # モーダルが非表示になること
+      expect(page).to have_css("[data-testid='help-modal']", visible: false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- プロフィール作成・編集画面のタイトル横に「？」ボタンを追加
- クリックで画面専用のヘルプモーダルを表示（Stimulus `modal_controller` で開閉制御）
- ×ボタンおよびモーダル背景クリックで閉じられる
- 共通モーダルラッパー `_help_modal.html.erb` と共通ヘルプコンテンツ `_help_content_shared.html.erb` を作成し将来の横展開に対応

## Test plan
- [x] `new` 画面の「？」ボタンが表示される
- [x] `edit` 画面の「？」ボタンが表示される
- [x] 各ボタンクリックでヘルプモーダルが開く
- [x] ×ボタンで閉じられる
- [x] モーダル背景クリックで閉じられる
- [x] `aria-label` が設定されている（？ボタン×2、×ボタン×1）
- [x] スマホ対応（`max-h-[80vh] overflow-y-auto`）
- [x] system spec 7例全通過
- [x] RuboCop 違反なし

## Related
- Issue: #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)