### PR TITLE
feat: 趣味タグに親タグ選択フローを実装 #237

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -25,4 +25,78 @@
     color: #6b7280; /* gray-500 */
     font-size: 0.875rem;
   }
+
+  .chip-badge {
+    font-size: 0.7rem;
+    background: rgba(96, 165, 250, 0.2);
+    padding: 0.1rem 0.4rem;
+    border-radius: 9999px;
+  }
+
+  .chip-remove-btn {
+    margin-left: 0.25rem;
+    color: #60a5fa;
+    background: none;
+    border: none;
+    cursor: pointer;
+    line-height: 1;
+  }
+
+  .autocomplete-item {
+    cursor: pointer;
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    color: #d1d5db;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .autocomplete-item:hover {
+    background: rgba(96, 165, 250, 0.15);
+  }
+
+  .autocomplete-badge {
+    font-size: 0.7rem;
+    background: rgba(96, 165, 250, 0.15);
+    color: #93c5fd;
+    padding: 0.1rem 0.5rem;
+    border-radius: 9999px;
+  }
+
+  .new-tag-section {
+    padding: 0.75rem 1rem;
+    font-size: 0.875rem;
+    color: #d1d5db;
+  }
+
+  .new-tag-select {
+    width: 100%;
+    background: #1e293b;
+    color: #f9fafb;
+    border: 1px solid #374151;
+    padding: 0.375rem 0.5rem;
+    border-radius: 0.375rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .new-tag-confirm-btn {
+    background: #2563eb;
+    color: white;
+    border: none;
+    padding: 0.375rem 0.75rem;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    font-size: 0.8rem;
+  }
+
+  .new-tag-skip-btn {
+    background: #374151;
+    color: #9ca3af;
+    border: none;
+    padding: 0.375rem 0.75rem;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    font-size: 0.8rem;
+  }
 }

--- a/app/controllers/hobbies_controller.rb
+++ b/app/controllers/hobbies_controller.rb
@@ -3,13 +3,18 @@ class HobbiesController < ApplicationController
 
   def autocomplete
     q = params[:q].to_s.strip
+    return render json: [] if q.length < 2
 
-    if q.length < 2
-      render json: []
-      return
-    end
+    hobbies = Hobby.where("normalized_name LIKE ?", "#{Hobby.normalize(q)}%")
+                   .includes(hobby_parent_tags: :parent_tag)
+                   .limit(10)
 
-    hobbies = Hobby.where("name LIKE ?", "#{q.downcase}%").limit(10).pluck(:name)
-    render json: hobbies
+    render json: hobbies.map { |hobby| serialize_hobby(hobby) }
+  end
+
+  private
+
+  def serialize_hobby(hobby)
+    { name: hobby.name }.merge(hobby.primary_parent_tag_info)
   end
 end

--- a/app/controllers/my/profiles_controller.rb
+++ b/app/controllers/my/profiles_controller.rb
@@ -2,6 +2,7 @@ class My::ProfilesController < ApplicationController
   before_action :authenticate_user!
   before_action :redirect_if_profile_exists, only: %i[new create]
   before_action :set_profile, only: %i[edit update destroy]
+  before_action :set_parent_tags, only: %i[new create edit update]
 
   def new
     @profile = current_user.build_profile
@@ -23,9 +24,10 @@ class My::ProfilesController < ApplicationController
   end
 
   def edit
-    @hobbies_text = @profile.profile_hobbies.includes(:hobby).map do |ph|
-      { name: ph.hobby.name, description: ph.description.to_s }
-    end.to_json
+    @hobbies_text = @profile.profile_hobbies
+                           .includes(hobby: { hobby_parent_tags: :parent_tag })
+                           .map { |profile_hobby| serialize_profile_hobby(profile_hobby) }
+                           .to_json
   end
 
   def update
@@ -60,5 +62,18 @@ class My::ProfilesController < ApplicationController
   def set_profile
     @profile = current_user.profile
     redirect_to new_my_profile_path, alert: "プロフィールを作成してください" unless @profile
+  end
+
+  def serialize_profile_hobby(profile_hobby)
+    { name: profile_hobby.hobby.name, description: profile_hobby.description.to_s }
+      .merge(profile_hobby.hobby.primary_parent_tag_info)
+  end
+
+  def set_parent_tags
+    @parent_tags_json = ParentTag.where.not(slug: "uncategorized")
+                                 .order(:room_type, :position)
+                                 .group_by(&:room_type)
+                                 .transform_values { |tags| tags.map { |t| { id: t.id, name: t.name } } }
+                                 .to_json
   end
 end

--- a/app/javascript/controllers/tag_autocomplete_controller.js
+++ b/app/javascript/controllers/tag_autocomplete_controller.js
@@ -1,23 +1,33 @@
 import { Controller } from "@hotwired/stimulus"
 
+const ROOM_TYPE_LABELS = {
+  chat: "雑談系",
+  study: "学習系",
+  game: "ゲーム系"
+}
+
 export default class extends Controller {
   static targets = ["input", "hiddenField", "chipList", "dropdown", "count"]
   static values = {
     url: String,
-    max: { type: Number, default: 10 }
+    max: { type: Number, default: 10 },
+    parentTags: { type: Object, default: {} }
   }
 
   #debounceTimer = null
-  // chips: [{ name: String, description: String }]
+  // chips: [{ name, normalized_name, description, parent_tag_id, parent_tag_name }]
   #chips = []
   #activeIndex = -1
+  #pendingNewTag = null
 
   connect() {
     const existing = this.hiddenFieldTarget.value
     if (existing) {
       try {
         const parsed = JSON.parse(existing)
-        parsed.forEach(tag => this.#addChip(tag.name, tag.description || ""))
+        parsed.forEach(tag => {
+          this.#addChip(tag.name, tag.description || "", null, tag.parent_tag_name || null)
+        })
       } catch {
         // JSON でない場合は無視
       }
@@ -31,6 +41,8 @@ export default class extends Controller {
       this.#closeDropdown()
       return
     }
+
+    this.#triggerNewTagFlow(q)
     this.#debounceTimer = setTimeout(() => this.#fetchSuggestions(q), 300)
   }
 
@@ -51,17 +63,11 @@ export default class extends Controller {
     } else if (event.key === "Enter") {
       event.preventDefault()
       if (isOpen && this.#activeIndex >= 0) {
-        const name = items[this.#activeIndex].dataset.name
-        this.#addChip(name, "")
-        this.inputTarget.value = ""
-        this.#closeDropdown()
+        const item = items[this.#activeIndex]
+        this.#selectExistingTag(item.dataset.name, item.dataset.parentTagName || null)
       } else {
         const q = this.inputTarget.value.trim()
-        if (q) {
-          this.#addChip(q, "")
-          this.inputTarget.value = ""
-          this.#closeDropdown()
-        }
+        if (q) this.#triggerNewTagFlow(q)
       }
     } else if (event.key === "Escape") {
       this.#closeDropdown()
@@ -69,15 +75,45 @@ export default class extends Controller {
   }
 
   selectSuggestion(event) {
-    const name = event.currentTarget.dataset.name
-    this.#addChip(name, "")
+    const { name, parentTagName } = event.currentTarget.dataset
+    this.#selectExistingTag(name, parentTagName || null)
+  }
+
+  confirmNewTag() {
+    if (!this.#pendingNewTag) return
+
+    const select = this.dropdownTarget.querySelector("[data-testid='new-tag-parent-select']")
+    const selectedOption = select?.options[select.selectedIndex]
+    const parentTagId = selectedOption?.value ? parseInt(selectedOption.value, 10) : null
+    const parentTagName = selectedOption?.value ? selectedOption.text : null
+
+    this.#addChip(this.#pendingNewTag, "", parentTagId, parentTagName)
     this.inputTarget.value = ""
+    this.#pendingNewTag = null
+    this.#closeDropdown()
+  }
+
+  skipParentTag() {
+    if (!this.#pendingNewTag) return
+
+    this.#addChip(this.#pendingNewTag, "", null, null)
+    this.inputTarget.value = ""
+    this.#pendingNewTag = null
     this.#closeDropdown()
   }
 
   removeChip(event) {
     const name = event.currentTarget.dataset.name
-    this.#chips = this.#chips.filter(c => c.name !== name)
+    this.#removeChipByName(name)
+  }
+
+  removeTag(event) {
+    const { name } = event.detail
+    this.#removeChipByName(name)
+  }
+
+  #removeChipByName(name) {
+    this.#chips = this.#chips.filter(chip => chip.name !== name)
     this.#renderChips()
     this.#syncHiddenField()
     this.#dispatchChipsChanged()
@@ -86,43 +122,57 @@ export default class extends Controller {
     }
   }
 
-  // tag-description コントローラから説明文更新を受け取る
   updateDescription(event) {
     const { name, description } = event.detail
-    const chip = this.#chips.find(c => c.name === name)
+    const chip = this.#chips.find(currentChip => currentChip.name === name)
+
     if (chip) {
       chip.description = description
       this.#syncHiddenField()
     }
   }
 
-  // private
+  #selectExistingTag(name, parentTagName) {
+    this.#addChip(name, "", null, parentTagName || null)
+    this.inputTarget.value = ""
+    this.#closeDropdown()
+  }
 
-  #addChip(name, description = "") {
-    const normalized = name.toLowerCase()
-    if (this.#chips.find(c => c.name === normalized)) return
+  #triggerNewTagFlow(query) {
+    if (this.#chips.find(chip => chip.normalized_name === this.#normalizeName(query))) return
+
+    this.#pendingNewTag = query
+    this.#renderNewTagUI(query)
+  }
+
+  #addChip(name, description = "", parentTagId = null, parentTagName = null) {
+    const displayName = name.trim()
+    const normalizedName = this.#normalizeName(displayName)
+
+    if (!displayName) return
+    if (this.#chips.find(chip => chip.normalized_name === normalizedName)) return
     if (this.#chips.length >= this.maxValue) return
-    this.#chips.push({ name: normalized, description })
+
+    this.#chips.push({
+      name: displayName,
+      normalized_name: normalizedName,
+      description,
+      parent_tag_id: parentTagId,
+      parent_tag_name: parentTagName
+    })
     this.#renderChips()
     this.#syncHiddenField()
     this.#dispatchChipsChanged()
+
     if (this.#chips.length >= this.maxValue) {
       this.inputTarget.disabled = true
     }
   }
 
   #renderChips() {
-    this.chipListTarget.innerHTML = this.#chips.map(chip => `
-      <span data-testid="chip"
-            style="display: inline-flex; align-items: center; gap: 0.25rem; border-radius: 9999px; background: rgba(96, 165, 250, 0.15); padding: 0.25rem 0.75rem; font-size: 0.875rem; color: #60a5fa;">
-        ${this.#escapeHtml(chip.name)}
-        <button type="button"
-                data-action="click->tag-autocomplete#removeChip"
-                data-name="${this.#escapeHtml(chip.name)}"
-                style="margin-left: 0.25rem; color: #60a5fa; background: none; border: none; cursor: pointer; line-height: 1;"
-                aria-label="${this.#escapeHtml(chip.name)}を削除">×</button>
-      </span>
-    `).join("")
+    if (this.hasChipListTarget) {
+      this.chipListTarget.innerHTML = ""
+    }
 
     if (this.hasCountTarget) {
       this.countTarget.textContent = `${this.#chips.length} / ${this.maxValue}件`
@@ -130,7 +180,9 @@ export default class extends Controller {
   }
 
   #syncHiddenField() {
-    this.hiddenFieldTarget.value = JSON.stringify(this.#chips)
+    this.hiddenFieldTarget.value = JSON.stringify(
+      this.#chips.map(({ name, description, parent_tag_id }) => ({ name, description, parent_tag_id }))
+    )
   }
 
   #dispatchChipsChanged() {
@@ -140,34 +192,82 @@ export default class extends Controller {
     }))
   }
 
-  async #fetchSuggestions(q) {
-    const url = `${this.urlValue}?q=${encodeURIComponent(q)}`
+  async #fetchSuggestions(query) {
+    if (this.#chips.find(chip => chip.normalized_name === this.#normalizeName(query))) {
+      this.#closeDropdown()
+      return
+    }
+
+    const url = `${this.urlValue}?q=${encodeURIComponent(query)}`
+
     try {
-      const res = await fetch(url, {
-        headers: { "Accept": "application/json", "X-Requested-With": "XMLHttpRequest" }
+      const response = await fetch(url, {
+        headers: { Accept: "application/json", "X-Requested-With": "XMLHttpRequest" }
       })
-      const names = await res.json()
-      this.#renderDropdown(names)
+      const hobbies = await response.json()
+
+      if (hobbies.length > 0) {
+        this.#renderDropdown(hobbies)
+      } else {
+        this.#triggerNewTagFlow(query)
+      }
     } catch {
       this.#closeDropdown()
     }
   }
 
-  #renderDropdown(names) {
-    if (names.length === 0) {
-      this.#closeDropdown()
-      return
-    }
-    this.dropdownTarget.innerHTML = names.map(name => `
+  #renderDropdown(hobbies) {
+    this.dropdownTarget.innerHTML = hobbies.map(hobby => `
       <li data-testid="autocomplete-item"
-          data-name="${this.#escapeHtml(name)}"
-          data-action="click->tag-autocomplete#selectSuggestion"
-          style="cursor: pointer; padding: 0.5rem 1rem; font-size: 0.875rem; color: #d1d5db; transition: background 0.15s;"
-          onmouseenter="this.style.background='rgba(96, 165, 250, 0.15)'"
-          onmouseleave="this.style.background='transparent'">
-        ${this.#escapeHtml(name)}
+          class="autocomplete-item"
+          data-name="${this.#escapeHtml(hobby.name)}"
+          data-parent-tag-name="${this.#escapeHtml(hobby.parent_tag_name || "")}"
+          data-action="click->tag-autocomplete#selectSuggestion">
+        <span>${this.#escapeHtml(hobby.name)}</span>
+        ${hobby.parent_tag_name
+          ? `<span data-testid="autocomplete-badge" class="autocomplete-badge">${this.#escapeHtml(hobby.parent_tag_name)}</span>`
+          : ""}
       </li>
     `).join("")
+    this.dropdownTarget.classList.remove("hidden")
+  }
+
+  #renderNewTagUI(query) {
+    const options = Object.entries(this.parentTagsValue).flatMap(([roomType, tags]) => {
+      const tagList = Array.isArray(tags) ? tags : []
+      if (tagList.length === 0) return []
+
+      return [
+        `<optgroup label="${ROOM_TYPE_LABELS[roomType] || roomType}">`,
+        ...tagList.map(parentTag => `<option value="${parentTag.id}">${this.#escapeHtml(parentTag.name)}</option>`),
+        "</optgroup>"
+      ]
+    }).join("")
+
+    this.dropdownTarget.innerHTML = `
+      <li data-testid="new-tag-section" class="new-tag-section">
+        <div style="margin-bottom:0.5rem;">「${this.#escapeHtml(query)}」を新しいタグとして追加する</div>
+        <div style="margin-bottom:0.5rem;color:#9ca3af;font-size:0.8rem;">近い分類を選ぶと、あとで見つけやすくなります</div>
+        <select data-testid="new-tag-parent-select"
+                id="new-tag-parent-select"
+                class="new-tag-select">
+          ${options}
+        </select>
+        <div style="display:flex;gap:0.5rem;">
+          <button type="button"
+                  class="new-tag-confirm-btn"
+                  data-action="click->tag-autocomplete#confirmNewTag">
+            追加する
+          </button>
+          <button type="button"
+                  class="new-tag-skip-btn"
+                  data-testid="skip-parent-tag"
+                  data-action="click->tag-autocomplete#skipParentTag">
+            わからない
+          </button>
+        </div>
+      </li>
+    `
     this.dropdownTarget.classList.remove("hidden")
   }
 
@@ -175,24 +275,25 @@ export default class extends Controller {
     this.dropdownTarget.innerHTML = ""
     this.dropdownTarget.classList.add("hidden")
     this.#activeIndex = -1
+    this.#pendingNewTag = null
   }
 
   #updateActiveItem(items) {
-    items.forEach((item, i) => {
-      if (i === this.#activeIndex) {
-        item.style.background = "rgba(96, 165, 250, 0.15)"
-      } else {
-        item.style.background = "transparent"
-      }
+    items.forEach((item, index) => {
+      item.style.background = index === this.#activeIndex ? "rgba(96,165,250,0.15)" : "transparent"
     })
   }
 
-  #escapeHtml(str) {
-    return str
+  #escapeHtml(value) {
+    return String(value)
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;")
       .replace(/'/g, "&#39;")
+  }
+
+  #normalizeName(value) {
+    return String(value).normalize("NFKC").trim().toLowerCase()
   }
 }

--- a/app/javascript/controllers/tag_description_controller.js
+++ b/app/javascript/controllers/tag_description_controller.js
@@ -10,7 +10,9 @@ export default class extends Controller {
 
   onToggle(event) {
     const button = event.currentTarget
-    const content = button.nextElementSibling
+    const content = button.closest("[data-testid='tag-card']")
+                          ?.querySelector("[data-description-content]")
+    if (!content) return
     content.classList.toggle("hidden")
   }
 
@@ -32,6 +34,15 @@ export default class extends Controller {
     }))
   }
 
+  onRemove(event) {
+    const name = event.currentTarget.dataset.name
+
+    this.element.dispatchEvent(new CustomEvent("tag-remove-request", {
+      bubbles: true,
+      detail: { name }
+    }))
+  }
+
   // private
 
   #renderDescriptionInputs(chips) {
@@ -41,20 +52,37 @@ export default class extends Controller {
       return
     }
     this.containerTarget.innerHTML = chips.map(chip => `
-      <div class="rounded-2xl border border-slate-700/60 bg-slate-900/65 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-        <button type="button"
-                data-action="click->tag-description#onToggle"
-                data-testid="description-toggle"
-                class="flex w-full items-center justify-between gap-3 rounded-2xl px-4 py-3 text-left transition hover:bg-white/5">
-          <span class="flex min-w-0 items-center gap-3">
-            <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-blue-500/15 text-base text-blue-300">✏️</span>
-            <span class="min-w-0">
-              <span class="block truncate text-sm font-semibold text-slate-100">${this.#escapeHtml(chip.name)}</span>
-              <span class="mt-0.5 block text-xs text-slate-400">その趣味との関わり方や最近ハマっていることを書けます</span>
-            </span>
-          </span>
-          <span class="shrink-0 text-xs font-medium text-blue-300">説明を追加</span>
-        </button>
+      <div data-testid="tag-card"
+           class="rounded-2xl border border-slate-700/60 bg-slate-900/65 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+        <div class="rounded-2xl px-4 py-2.5 transition hover:bg-white/5">
+          <div style="display:flex;align-items:center;justify-content:space-between;gap:0.75rem;">
+            <div style="display:flex;align-items:center;gap:0.6rem;min-width:0;flex:1;">
+              <span class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-500/15">
+                <img src="/icon.png?v=2" alt="" class="h-5 w-5 rounded-md object-cover">
+              </span>
+              <div style="display:flex;align-items:center;gap:0.35rem;min-width:0;flex:1;flex-wrap:wrap;">
+                <span data-testid="tag-parent-label"
+                      class="inline-flex items-center rounded-full px-2.5 text-[11px] font-semibold"
+                      style="${this.#parentLabelStyle(chip.parent_tag_name)}">${this.#escapeHtml(chip.parent_tag_name || "未分類")}</span>
+                <span data-testid="tag-child-chip"
+                      class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium"
+                      style="background:rgba(59,130,246,0.14);color:#bfdbfe;border:1px solid rgba(96,165,250,0.24);">${this.#escapeHtml(chip.name)}</span>
+                <button type="button"
+                        data-testid="tag-remove-button"
+                        data-name="${this.#escapeHtml(chip.name)}"
+                        data-action="click->tag-description#onRemove"
+                        class="inline-flex h-5 w-5 items-center justify-center rounded-full text-[10px] leading-none transition"
+                        style="display:inline-flex;align-items:center;justify-content:center;width:1.25rem;height:1.25rem;border:1px solid rgba(148,163,184,0.5);background:#0f172a;color:#cbd5e1;border-radius:9999px;"
+                        aria-label="${this.#escapeHtml(chip.name)}を削除">×</button>
+              </div>
+            </div>
+            <button type="button"
+                    data-action="click->tag-description#onToggle"
+                    data-testid="description-toggle"
+                    class="shrink-0 border-none cursor-pointer"
+                    style="display:inline-flex;align-items:center;justify-content:center;white-space:nowrap;line-height:1.2;padding:0.35rem 0.7rem;border-radius:9999px;background:rgba(59,130,246,0.14);color:#bfdbfe;border:1px solid rgba(96,165,250,0.22);font-size:0.75rem;font-weight:600;">説明を追加</button>
+          </div>
+        </div>
         <div data-description-content class="hidden border-t border-slate-700/60 px-4 pb-4 pt-4">
           <textarea data-testid="description-input"
                     data-name="${this.#escapeHtml(chip.name)}"
@@ -77,5 +105,13 @@ export default class extends Controller {
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;")
       .replace(/'/g, "&#39;")
+  }
+
+  #parentLabelStyle(parentTagName) {
+    if (parentTagName) {
+      return "background:linear-gradient(135deg, rgba(244,63,94,0.24), rgba(236,72,153,0.18));color:#fecdd3;border:1px solid rgba(251,113,133,0.38);padding-top:0.18rem;padding-bottom:0.18rem;"
+    }
+
+    return "background:rgba(71,85,105,0.22);color:#cbd5e1;border:1px solid rgba(148,163,184,0.28);padding-top:0.18rem;padding-bottom:0.18rem;"
   }
 }

--- a/app/models/hobby.rb
+++ b/app/models/hobby.rb
@@ -8,6 +8,11 @@ class Hobby < ApplicationRecord
     hobby_parent_tags.min_by { |hpt| HobbyParentTag.room_types[hpt.room_type] }&.room_type || "unclassified"
   end
 
+  def primary_parent_tag_info
+    primary = hobby_parent_tags.min_by { |hpt| HobbyParentTag.room_types[hpt.room_type] }
+    { parent_tag_name: primary&.parent_tag&.name, room_type: primary&.room_type }
+  end
+
   has_many :profile_hobbies, dependent: :restrict_with_error
   has_many :profiles, through: :profile_hobbies
 

--- a/app/services/profile_hobbies_updater.rb
+++ b/app/services/profile_hobbies_updater.rb
@@ -1,8 +1,14 @@
 class ProfileHobbiesUpdater
-  # tag_data: [{ name: String, description: String }, ...]
+  # tag_data: [{ name: String, description: String, parent_tag_id: Integer | nil }, ...]
   def self.call(profile, tag_data)
     normalized = tag_data
-      .map { |t| { name: Hobby.normalize(t[:name]), description: t[:description].to_s } }
+      .map do |tag|
+        {
+          name: Hobby.normalize(tag[:name]),
+          description: tag[:description].to_s,
+          parent_tag_id: tag[:parent_tag_id]
+        }
+      end
       .reject { |t| t[:name].blank? }
       .uniq { |t| t[:name] }
 
@@ -31,16 +37,27 @@ class ProfileHobbiesUpdater
                             .includes(:hobby)
                             .index_by { |ph| ph.hobby.normalized_name || Hobby.normalize(ph.hobby.name) }
 
+      parent_tag_ids = normalized.filter_map { |t| t[:parent_tag_id] }.uniq
+      preloaded_parent_tags = ParentTag.where(id: parent_tag_ids).index_by(&:id)
+
       normalized.each do |tag|
         hobby = existing_hobbies[tag[:name]] ||
                 Hobby.find_or_create_by!(normalized_name: tag[:name]) do |h|
                   h.name = tag[:name]
                 end
+        classify_if_newly_created(hobby, preloaded_parent_tags[tag[:parent_tag_id]])
 
         ph = existing_phs[tag[:name]] || ProfileHobby.new(profile:, hobby:)
         ph.description = tag[:description]
         ph.save!
       end
     end
+  end
+
+  def self.classify_if_newly_created(hobby, parent_tag)
+    return unless hobby.previously_new_record?
+    return if parent_tag.nil?
+
+    hobby.hobby_parent_tags.create!(parent_tag:)
   end
 end

--- a/app/views/my/profiles/_form.html.erb
+++ b/app/views/my/profiles/_form.html.erb
@@ -59,7 +59,8 @@
          data-controller="tag-description tag-autocomplete"
          data-tag-autocomplete-url-value="<%= autocomplete_hobbies_path %>"
          data-tag-autocomplete-max-value="10"
-         data-action="chips-changed->tag-description#onChipsChanged tag-description-update->tag-autocomplete#updateDescription">
+         data-tag-autocomplete-parent-tags-value="<%= @parent_tags_json %>"
+         data-action="chips-changed->tag-description#onChipsChanged tag-description-update->tag-autocomplete#updateDescription tag-remove-request->tag-autocomplete#removeTag">
 
       <div class="mb-5 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
         <div>
@@ -79,8 +80,9 @@
              value="<%= @hobbies_text %>"
              data-tag-autocomplete-target="hiddenField">
 
-      <%# チップ表示エリア %>
-      <div class="mb-4 flex min-h-9 flex-wrap gap-2"
+      <%# 表示上はカードを唯一の表現にし、hidden field と件数だけ tag-autocomplete が管理する %>
+      <div class="hidden"
+           aria-hidden="true"
            data-tag-autocomplete-target="chipList"></div>
 
       <%# テキスト入力 %>

--- a/app/views/mypage/dashboards/show.html.erb
+++ b/app/views/mypage/dashboards/show.html.erb
@@ -48,8 +48,8 @@
     </div>
   </div>
 
-  <%# メニュー %>
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+  <%# メニュー（1行目：2カラム） %>
+  <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem;">
     <%# 趣味プロフィール %>
     <% if current_user.profile %>
       <%= link_to edit_my_profile_path,
@@ -69,6 +69,18 @@
       <% end %>
     <% end %>
 
+    <%# プロフィール一覧 %>
+    <%= link_to profiles_path,
+                style: "display: flex; flex-direction: column; align-items: center; gap: 0.75rem; padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); text-decoration: none; transition: all 0.3s;" do %>
+      <svg xmlns="http://www.w3.org/2000/svg" style="height: 2rem; width: 2rem; color: #60a5fa;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+      </svg>
+      <span style="font-size: 0.875rem; font-weight: 500; color: #d1d5db;">プロフィール一覧</span>
+    <% end %>
+  </div>
+
+  <%# メニュー（2行目：3カラム） %>
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1rem;">
     <%# 部屋管理 %>
     <% rooms_count = current_user.profile&.issued_rooms&.count || 0 %>
     <%= link_to mypage_rooms_path,
@@ -88,15 +100,6 @@
       </svg>
       <span style="font-size: 0.875rem; font-weight: 500; color: #d1d5db;">公開部屋一覧</span>
       <span style="font-size: 0.75rem; color: #6b7280;">参加できる部屋を見る</span>
-    <% end %>
-
-    <%# プロフィール一覧 %>
-    <%= link_to profiles_path,
-                style: "display: flex; flex-direction: column; align-items: center; gap: 0.75rem; padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); text-decoration: none; transition: all 0.3s;" do %>
-      <svg xmlns="http://www.w3.org/2000/svg" style="height: 2rem; width: 2rem; color: #60a5fa;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
-      </svg>
-      <span style="font-size: 0.875rem; font-weight: 500; color: #d1d5db;">プロフィール一覧</span>
     <% end %>
 
     <%# 設定 %>

--- a/spec/requests/hobbies_spec.rb
+++ b/spec/requests/hobbies_spec.rb
@@ -31,13 +31,35 @@ RSpec.describe "Hobbies", type: :request do
         create(:hobby, name: "アウトドア")
         create(:hobby, name: "野球")
         get autocomplete_hobbies_path, params: { q: "アニ" }
-        expect(JSON.parse(response.body)).to eq([ "アニメ" ])
+        expect(JSON.parse(response.body)).to eq([
+          { "name" => "アニメ", "parent_tag_name" => nil, "room_type" => nil }
+        ])
       end
 
       it "最大10件まで返す" do
         11.times { |i| create(:hobby, name: "アニメ#{i.to_s.rjust(2, '0')}") }
         get autocomplete_hobbies_path, params: { q: "アニメ" }
         expect(JSON.parse(response.body).size).to eq(10)
+      end
+
+      it "親タグが紐づいている hobby は parent_tag_name と room_type を返す" do
+        programming = create(:parent_tag, name: "プログラミング", slug: "programming", room_type: :study)
+        rails_hobby = create(:hobby, name: "Rails")
+        create(:hobby_parent_tag, hobby: rails_hobby, parent_tag: programming)
+
+        get autocomplete_hobbies_path, params: { q: "Rai" }
+
+        expect(JSON.parse(response.body)).to eq([
+          { "name" => "Rails", "parent_tag_name" => "プログラミング", "room_type" => "study" }
+        ])
+      end
+
+      it "大文字で入力しても normalized_name で前方一致する" do
+        create(:hobby, name: "Rails")
+
+        get autocomplete_hobbies_path, params: { q: "RAIL" }
+
+        expect(JSON.parse(response.body).map { |hobby| hobby["name"] }).to include("Rails")
       end
 
       it "一致しないqは空配列を返す" do

--- a/spec/requests/my/profile_spec.rb
+++ b/spec/requests/my/profile_spec.rb
@@ -16,10 +16,27 @@ RSpec.describe "My::Profile", type: :request do
 
       expect(response.body).to include("プロフィールを作成してください")
     end
+
+    context "プロフィール作成済み" do
+      let!(:profile) { create(:profile, user:) }
+      let(:programming) { create(:parent_tag, name: "プログラミング", slug: "programming", room_type: :study) }
+
+      it "hobbies_text に parent_tag_name と room_type が含まれる" do
+        rails_hobby = create(:hobby, name: "Rails")
+        create(:hobby_parent_tag, hobby: rails_hobby, parent_tag: programming)
+        create(:profile_hobby, profile:, hobby: rails_hobby)
+
+        get edit_my_profile_path
+
+        expect(response.body).to include("プログラミング")
+        expect(response.body).to include("study")
+      end
+    end
   end
 
   describe "PATCH /my/profile" do
     let!(:profile) { create(:profile, user:) }
+    let(:fps) { create(:parent_tag, name: "FPS", slug: "fps", room_type: :game) }
 
     it "11個のタグで更新するとバリデーションエラーになる" do
       hobbies_text = (1..11).map { |i| { name: "タグ#{i}", description: "" } }.to_json
@@ -51,6 +68,15 @@ RSpec.describe "My::Profile", type: :request do
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("趣味タグを1つ以上追加してください")
+    end
+
+    it "parent_tag_id 付きで新規タグを保存すると HobbyParentTag が作成される" do
+      hobbies_text = [ { name: "brandnewtag", description: "", parent_tag_id: fps.id } ].to_json
+
+      patch my_profile_path, params: { profile: { bio: "自己紹介", hobbies_text: } }
+
+      hobby = Hobby.find_by(normalized_name: "brandnewtag")
+      expect(hobby.hobby_parent_tags.find_by(room_type: :game)&.parent_tag).to eq(fps)
     end
   end
 

--- a/spec/requests/mypage/dashboards_spec.rb
+++ b/spec/requests/mypage/dashboards_spec.rb
@@ -3,6 +3,11 @@ require "nokogiri"
 
 # /mypage へのアクセス条件とレスポンスの結果を確認すること
 RSpec.describe "Mypage::Dashboards", type: :request do
+  def dashboard_menu_links(response_body)
+    document = Nokogiri::HTML.parse(response_body)
+    document.css("div[style*='grid-template-columns'] > a")
+  end
+
   describe "GET /mypage" do
     context "ログインしている場合" do
       it "ダッシュボードが表示される" do
@@ -39,7 +44,7 @@ RSpec.describe "Mypage::Dashboards", type: :request do
 
         get mypage_root_path
 
-        menu_links = Nokogiri::HTML.parse(response.body).css("div.grid.grid-cols-1.md\\:grid-cols-2.lg\\:grid-cols-5.gap-4 > a")
+        menu_links = dashboard_menu_links(response.body)
 
         expect(menu_links.map(&:text).map(&:strip)).to include("プロフィールを作成する")
         expect(response.body).to include(new_my_profile_path)
@@ -52,7 +57,7 @@ RSpec.describe "Mypage::Dashboards", type: :request do
 
         get mypage_root_path
 
-        menu_links = Nokogiri::HTML.parse(response.body).css("div.grid.grid-cols-1.md\\:grid-cols-2.lg\\:grid-cols-5.gap-4 > a")
+        menu_links = dashboard_menu_links(response.body)
         menu_texts = menu_links.map(&:text).map { |text| text.gsub(/\s+/, " ").strip }
 
         # 5ブロック（プロフィール作成・部屋管理・公開部屋一覧・プロフィール一覧・設定）が表示されている
@@ -85,7 +90,7 @@ RSpec.describe "Mypage::Dashboards", type: :request do
         get mypage_root_path
 
         # メニューグリッド内のリンク一覧を取得
-        menu_links = Nokogiri::HTML.parse(response.body).css("div.grid.grid-cols-1.md\\:grid-cols-2.lg\\:grid-cols-5.gap-4 > a")
+        menu_links = dashboard_menu_links(response.body)
 
         # プロフィール一覧パスへのリンクがメニュー内に含まれている
         expect(menu_links.map { |a| a["href"] }).to include(profiles_path)

--- a/spec/services/profile_hobbies_updater_spec.rb
+++ b/spec/services/profile_hobbies_updater_spec.rb
@@ -117,6 +117,56 @@ RSpec.describe ProfileHobbiesUpdater do
       end
     end
 
+    context "parent_tag_id の処理" do
+      let(:programming) do
+        create(:parent_tag, name: "プログラミング", slug: "programming", room_type: :study)
+      end
+
+      it "新規タグ + 有効な parent_tag_id では HobbyParentTag が作成される" do
+        described_class.call(profile, [ { name: "newlang", description: "", parent_tag_id: programming.id } ])
+
+        hobby = Hobby.find_by(normalized_name: "newlang")
+        expect(hobby.hobby_parent_tags.find_by(room_type: :study)&.parent_tag).to eq(programming)
+      end
+
+      it "既存の未分類タグに parent_tag_id を渡しても HobbyParentTag は作成されない" do
+        create(:hobby, name: "existingtag")
+
+        described_class.call(profile, [ { name: "existingtag", description: "", parent_tag_id: programming.id } ])
+
+        hobby = Hobby.find_by(normalized_name: "existingtag")
+        expect(hobby.hobby_parent_tags).to be_empty
+      end
+
+      it "既存の分類済みタグに別の parent_tag_id を渡しても分類は変更されない" do
+        game_tag = create(:parent_tag, name: "FPS", slug: "fps", room_type: :game)
+        hobby = create(:hobby, name: "apex")
+        create(:hobby_parent_tag, hobby:, parent_tag: game_tag)
+
+        described_class.call(profile, [ { name: "apex", description: "", parent_tag_id: programming.id } ])
+
+        expect(hobby.reload.hobby_parent_tags.find_by(room_type: :game)&.parent_tag).to eq(game_tag)
+        expect(hobby.hobby_parent_tags.find_by(room_type: :study)).to be_nil
+      end
+
+      it "不正な parent_tag_id でも保存は成功する" do
+        expect {
+          described_class.call(profile, [ { name: "sometag", description: "", parent_tag_id: 99_999 } ])
+        }.not_to raise_error
+
+        hobby = Hobby.find_by(normalized_name: "sometag")
+        expect(hobby).not_to be_nil
+        expect(hobby.hobby_parent_tags).to be_empty
+      end
+
+      it "parent_tag_id が nil のときは HobbyParentTag を作成しない" do
+        described_class.call(profile, [ { name: "unknowntag", description: "", parent_tag_id: nil } ])
+
+        hobby = Hobby.find_by(normalized_name: "unknowntag")
+        expect(hobby.hobby_parent_tags).to be_empty
+      end
+    end
+
     context "削除対象の判定" do
       it "normalized_name で削除対象を判定する" do
         hobby_rails = create(:hobby, name: "rails")

--- a/spec/system/my/profile_tag_autocomplete_spec.rb
+++ b/spec/system/my/profile_tag_autocomplete_spec.rb
@@ -12,43 +12,51 @@ RSpec.describe "タグ入力チップUI", type: :system, js: true do
   end
 
   describe "タグの追加" do
-    it "Enterキーで新規タグをチップとして追加できる" do
+    it "新規タグを追加セクションから説明カードとして追加できる" do
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
+      find("[data-testid='skip-parent-tag']").click
 
-      expect(page).to have_css("[data-testid='chip']", text: "ゲーム")
+      expect(page).to have_text("ゲーム")
+      expect(page).to have_css("[data-testid='description-toggle']", count: 1)
     end
 
     it "同一タグは重複追加できない" do
-      2.times do
-        fill_in "tag-input", with: "ゲーム"
-        find("[data-testid='tag-input']").send_keys(:return)
-      end
+      fill_in "tag-input", with: "ゲーム"
+      find("[data-testid='skip-parent-tag']").click
 
-      expect(page).to have_css("[data-testid='chip']", text: "ゲーム", count: 1)
+      fill_in "tag-input", with: "ゲーム"
+      expect(page).to have_text("ゲーム")
+      expect(page).to have_css("[data-testid='description-toggle']", count: 1)
+    end
+
+    it "入力した表示名の大文字小文字を保ったままカードに追加できる" do
+      fill_in "tag-input", with: "Ruby Rails"
+      find("[data-testid='skip-parent-tag']").click
+
+      expect(page).to have_css("[data-testid='tag-child-chip']", text: "Ruby Rails")
     end
 
     it "10個追加するとinputが無効化される" do
       10.times do |i|
         fill_in "tag-input", with: "タグ#{i}"
-        find("[data-testid='tag-input']").send_keys(:return)
+        find("[data-testid='skip-parent-tag']").click
       end
 
-      expect(page).to have_css("[data-testid='chip']", count: 10)
+      expect(page).to have_css("[data-testid='description-toggle']", count: 10)
       expect(find("[data-testid='tag-input']")[:disabled]).to eq("true")
     end
   end
 
   describe "タグの削除" do
-    it "×ボタンでチップを削除できる" do
+    it "カードの×ボタンでタグを削除できる" do
       # タグを追加してから削除する
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
-      expect(page).to have_css("[data-testid='chip']", text: "ゲーム")
+      find("[data-testid='skip-parent-tag']").click
+      expect(page).to have_text("ゲーム")
 
-      find("[data-testid='chip']", text: "ゲーム").find("button").click
+      find("button[aria-label='ゲームを削除']", visible: :all).click
 
-      expect(page).not_to have_css("[data-testid='chip']", text: "ゲーム")
+      expect(page).not_to have_text("ゲーム")
     end
   end
 
@@ -61,11 +69,11 @@ RSpec.describe "タグ入力チップUI", type: :system, js: true do
       expect(page).to have_css("[data-testid='autocomplete-item']", text: "ゲーム")
     end
 
-    it "候補を選択するとチップになり入力欄がクリアされる" do
+    it "候補を選択するとカードになり入力欄がクリアされる" do
       fill_in "tag-input", with: "ゲー"
       find("[data-testid='autocomplete-item']", text: "ゲーム").click
 
-      expect(page).to have_css("[data-testid='chip']", text: "ゲーム")
+      expect(page).to have_text("ゲーム")
       expect(find("[data-testid='tag-input']").value).to eq("")
     end
 
@@ -77,20 +85,21 @@ RSpec.describe "タグ入力チップUI", type: :system, js: true do
   end
 
   describe "フォーム送信" do
-    it "チップのタグが保存される" do
+    it "カードのタグが保存される" do
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
+      find("[data-testid='skip-parent-tag']").click
       click_button "更新する"
 
+      expect(page).to have_current_path(profile_path(current_profile))
       expect(page).to have_content("ゲーム")
       expect(current_profile.reload.hobbies.pluck(:name)).to include("ゲーム")
     end
   end
 
-  describe "Turbo再表示時のチップ復元" do
-    it "バリデーションエラー後もチップが復元される" do
+  describe "Turbo再表示時のカード復元" do
+    it "バリデーションエラー後もカードが復元される" do
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
+      find("[data-testid='skip-parent-tag']").click
 
       # hidden fieldを11個分のタグ（上限超過）に書き換えてバリデーションエラーを発生させる
       over_limit = ([ { name: "ゲーム", description: "" } ] + (1..10).map { |i| { name: "tag#{i}", description: "" } }).to_json
@@ -99,7 +108,8 @@ RSpec.describe "タグ入力チップUI", type: :system, js: true do
 
       # バリデーションエラー後はタブがリセットされるため、タグタブを再度クリックする
       click_on "タグ"
-      expect(page).to have_css("[data-testid='chip']")
+      expect(page).to have_css("[data-testid='description-toggle']")
+      expect(page).to have_text("ゲーム")
     end
   end
 
@@ -110,15 +120,15 @@ RSpec.describe "タグ入力チップUI", type: :system, js: true do
 
     it "タグ追加時にカウンターが更新される" do
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
+      find("[data-testid='skip-parent-tag']").click
 
       expect(page).to have_css("[data-testid='tag-count']", text: "1 / 10件")
     end
 
     it "タグ削除時にカウンターが更新される" do
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
-      find("[data-testid='chip']", text: "ゲーム").find("button").click
+      find("[data-testid='skip-parent-tag']").click
+      find("button[aria-label='ゲームを削除']", visible: :all).click
 
       expect(page).to have_css("[data-testid='tag-count']", text: "0 / 10件")
     end

--- a/spec/system/my/profile_tag_classification_spec.rb
+++ b/spec/system/my/profile_tag_classification_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe "タグ作成時の親タグ選択", type: :system, js: true do
+  let(:current_user) { create(:user) }
+  let!(:current_profile) { create(:profile, user: current_user) }
+  let!(:fps) { create(:parent_tag, name: "FPS", slug: "fps", room_type: :game, position: 0) }
+
+  before do
+    login_as(current_user, scope: :user)
+    visit edit_my_profile_path
+    click_on "タグ"
+  end
+
+  describe "新規タグの親タグ選択" do
+    it "候補にないタグを追加すると新規追加セクションが表示される" do
+      fill_in "tag-input", with: "新作ゲームタグ"
+
+      expect(page).to have_button("わからない")
+      expect(page).to have_button("追加する")
+    end
+
+    it "親タグを選んで追加するとカードにバッジが表示される" do
+      fill_in "tag-input", with: "新作ゲームタグ"
+      expect(page).to have_button("わからない")
+      find("select").find("option", text: "FPS").select_option
+      click_button "追加する"
+
+      expect(page).to have_css("[data-testid='tag-parent-label']", text: "FPS")
+      expect(page).to have_css("[data-testid='tag-child-chip']", text: "新作ゲームタグ")
+    end
+
+    it "わからないを選んで追加するとバッジなしのカードが表示される" do
+      fill_in "tag-input", with: "未分類タグ"
+      expect(page).to have_button("わからない")
+      click_button "わからない"
+
+      expect(page).to have_css("[data-testid='tag-parent-label']", text: "未分類")
+      expect(page).to have_css("[data-testid='tag-child-chip']", text: "未分類タグ")
+    end
+
+    it "保存すると親タグ選択が DB に反映される" do
+      fill_in "tag-input", with: "新規タグ123"
+      expect(page).to have_button("わからない")
+      find("select").find("option", text: "FPS").select_option
+      click_button "追加する"
+      click_button "更新する"
+
+      expect(page).to have_current_path(profile_path(current_profile))
+
+      hobby = Hobby.find_by(normalized_name: "新規タグ123")
+      expect(hobby.hobby_parent_tags.find_by(room_type: :game)&.parent_tag).to eq(fps)
+    end
+  end
+
+  describe "既存タグのバッジ表示" do
+    let!(:rails_hobby) { create(:hobby, name: "Rails") }
+    let!(:programming) { create(:parent_tag, name: "プログラミング", slug: "programming", room_type: :study, position: 0) }
+    let!(:hobby_parent_tag) { create(:hobby_parent_tag, hobby: rails_hobby, parent_tag: programming) }
+
+    it "autocomplete の候補に親タグ名バッジが表示される" do
+      fill_in "tag-input", with: "Rai"
+
+      expect(page).to have_css("[data-testid='autocomplete-item']", text: "Rails")
+      expect(page).to have_css("[data-testid='autocomplete-badge']", text: "プログラミング")
+    end
+
+    it "既存タグを選択するとカードに親タグ名バッジが表示される" do
+      fill_in "tag-input", with: "Rai"
+      find("[data-testid='autocomplete-item']", text: "Rails").click
+
+      expect(page).to have_css("[data-testid='tag-parent-label']", text: "プログラミング")
+      expect(page).to have_css("[data-testid='tag-child-chip']", text: "Rails")
+    end
+  end
+end

--- a/spec/system/my/profile_tag_description_spec.rb
+++ b/spec/system/my/profile_tag_description_spec.rb
@@ -12,18 +12,19 @@ RSpec.describe "タグ説明文入力UI", type: :system, js: true do
   describe "説明文入力欄の表示" do
     before { click_on "タグ" }
 
-    it "チップ追加後に✏️ボタンが表示される" do
-      # タグを追加すると説明編集ボタンが出現する
+    it "タグ追加後に説明カードが表示される" do
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
+      find("[data-testid='skip-parent-tag']").click
 
       expect(page).to have_css("[data-testid='description-toggle']")
+      expect(page).to have_css("[data-testid='tag-parent-label']", text: "未分類")
+      expect(page).to have_css("[data-testid='tag-child-chip']", text: "ゲーム")
     end
 
     it "デフォルトでは説明文入力欄は非表示" do
       # ✏️クリック前は説明文入力欄が見えない
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
+      find("[data-testid='skip-parent-tag']").click
 
       expect(page).not_to have_css("[data-testid='description-input']")
     end
@@ -31,19 +32,19 @@ RSpec.describe "タグ説明文入力UI", type: :system, js: true do
     it "✏️ボタンをクリックすると説明文入力欄が表示される" do
       # ✏️クリック後に説明文入力欄が展開される
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
+      find("[data-testid='skip-parent-tag']").click
       find("[data-testid='description-toggle']").click
 
       expect(page).to have_css("[data-testid='description-input']")
     end
 
-    it "チップを削除すると✏️ボタンも消える" do
-      # チップ削除と同時に説明編集ボタンも消える
+    it "カードを削除すると説明編集ボタンも消える" do
+      # タグ削除と同時に説明編集ボタンも消える
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
+      find("[data-testid='skip-parent-tag']").click
       expect(page).to have_css("[data-testid='description-toggle']")
 
-      find("[data-testid='chip']", text: "ゲーム").find("button").click
+      find("button[aria-label='ゲームを削除']", visible: :all).click
 
       expect(page).not_to have_css("[data-testid='description-toggle']")
     end
@@ -55,7 +56,7 @@ RSpec.describe "タグ説明文入力UI", type: :system, js: true do
     it "説明文を入力して保存すると反映される" do
       # タグ追加 → ✏️クリック → 説明入力 → 保存
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
+      find("[data-testid='skip-parent-tag']").click
       find("[data-testid='description-toggle']").click
       find("[data-testid='description-input']").fill_in with: "毎日やってます"
       click_button "更新する"
@@ -70,7 +71,7 @@ RSpec.describe "タグ説明文入力UI", type: :system, js: true do
     it "説明文なしでも保存できる" do
       # ✏️を開かずに保存しても空文字で保存される
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
+      find("[data-testid='skip-parent-tag']").click
       click_button "更新する"
 
       expect(page).to have_current_path(profile_path(current_profile))
@@ -85,14 +86,14 @@ RSpec.describe "タグ説明文入力UI", type: :system, js: true do
   describe "Turbo再表示後の復元" do
     before { click_on "タグ" }
 
-    it "バリデーションエラー後もチップと説明文が復元される" do
+    it "バリデーションエラー後もカードと説明文が復元される" do
       # 入力内容がエラー後もそのまま残る
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
+      find("[data-testid='skip-parent-tag']").click
       find("[data-testid='description-toggle']").click
       find("[data-testid='description-input']").fill_in with: "毎日やってます"
 
-      expect(page).to have_css("[data-testid='chip']", text: "ゲーム")
+      expect(page).to have_text("ゲーム")
       expect(find("[data-testid='description-input']").value).to eq("毎日やってます")
     end
   end
@@ -114,7 +115,7 @@ RSpec.describe "タグ説明文入力UI", type: :system, js: true do
       fill_in "profile[bio]", with: "テスト自己紹介です"
       click_on "タグ"
       fill_in "tag-input", with: "ゲーム"
-      find("[data-testid='tag-input']").send_keys(:return)
+      find("[data-testid='skip-parent-tag']").click
       click_button "更新する"
 
       expect(page).to have_current_path(profile_path(current_profile))

--- a/spec/system/profile_hobbies_flow_spec.rb
+++ b/spec/system/profile_hobbies_flow_spec.rb
@@ -9,18 +9,17 @@ RSpec.describe "趣味(タグ)登録の一連の流れ", type: :system, js: true
     visit edit_my_profile_path
     click_on "タグ"
 
-    # chip が DOM に追加されるまで待ってから次のタグを入力する（JS タイミング対策）
-    fill_in "tag-input", with: "rails"
-    find("[data-testid='tag-input']").send_keys(:return)
-    expect(page).to have_css("[data-testid='chip']", text: "rails")
+    fill_in "tag-input", with: "Ruby Rails"
+    find("[data-testid='skip-parent-tag']").click
+    expect(page).to have_text("Ruby Rails")
 
-    fill_in "tag-input", with: "ruby"
-    find("[data-testid='tag-input']").send_keys(:return)
-    expect(page).to have_css("[data-testid='chip']", text: "ruby")
+    fill_in "tag-input", with: "Ruby"
+    find("[data-testid='skip-parent-tag']").click
+    expect(page).to have_text("Ruby")
 
     click_button "更新する"
 
-    expect(page).to have_content("rails")
-    expect(page).to have_content("ruby")
+    expect(page).to have_content("Ruby Rails")
+    expect(page).to have_content("Ruby")
   end
 end


### PR DESCRIPTION
## Summary

- `HobbiesController#autocomplete` に `normalized_name LIKE` 検索と親タグ名のJSON付与を追加
- `My::ProfilesController` に `set_parent_tags`・`serialize_profile_hobby` を追加し、フォームに親タグJSONを埋め込む
- `ProfileHobbiesUpdater` で新規Hobby限定の `HobbyParentTag` 作成を実装
  - `parent_tag_id` を事前一括ロードしN+1を解消
  - `Admin::HobbyClassificationService` 依存を除去しネストトランザクションを解消
- `Hobby#primary_parent_tag_info` をモデルに追加しコントローラ間の重複ロジックを集約
- `tag_autocomplete_controller.js` に新規タグ時の親タグ選択UI・チップバッジ表示を実装
- `application.tailwind.css` に autocomplete・chip・new-tag 用コンポーネントクラスを追加
- マイページダッシュボードのメニューを 2+3 レイアウトに変更

## Test plan

- [x] RSpec 43件 GREEN（request spec / service spec / system spec）
- [x] RuboCop 違反なし
- [x] 新規タグ入力 → 親タグ選択UI表示 → 追加 → チップにバッジが表示される
- [x] 「わからない」選択 → バッジなしチップが表示される
- [x] 既存タグ入力 → autocomplete候補に親タグバッジが表示される
- [x] フォーム送信 → DB に HobbyParentTag が正しく保存される
- [x] マイページメニューが 2+3 レイアウトで表示される

## Related

- Issue: #237