### PR TITLE
improve: 未分類タグ管理画面を分類主役・削除条件限定に改修 #248

### DIFF
--- a/app/controllers/admin/unclassified_hobbies_controller.rb
+++ b/app/controllers/admin/unclassified_hobbies_controller.rb
@@ -8,7 +8,6 @@ class Admin::UnclassifiedHobbiesController < Admin::BaseController
     @hobbies = scope
     @parent_tags = ParentTag.order(:room_type, :position)
     @grouped_parent_tag_options = build_grouped_parent_tag_options
-    @all_hobbies_grouped = build_all_hobbies_grouped
   end
 
   def update
@@ -20,15 +19,13 @@ class Admin::UnclassifiedHobbiesController < Admin::BaseController
     redirect_to admin_unclassified_hobbies_path, alert: "分類に失敗しました"
   end
 
-  def merge
-    source = Hobby.unclassified.find(params[:id])
-    target = Hobby.find(params[:target_hobby_id])
-    result = Admin::HobbyMergeService.call(source:, target:)
-    if result.success?
-      redirect_to admin_unclassified_hobbies_path, notice: "統合しました"
-    else
-      redirect_to admin_unclassified_hobbies_path, alert: result.error
-    end
+  def destroy
+    @hobby = Hobby.unclassified.find(params[:id])
+    # UI側でも usage_count == 0 のときのみボタン表示しているが、直接リクエストへの二重防御として rescue を残している
+    @hobby.destroy!
+    redirect_to admin_unclassified_hobbies_path, notice: "削除しました"
+  rescue ActiveRecord::RecordNotDestroyed
+    redirect_to admin_unclassified_hobbies_path, alert: "削除できませんでした（使用中のタグは削除できません）"
   end
 
   private
@@ -40,18 +37,5 @@ class Admin::UnclassifiedHobbiesController < Admin::BaseController
         @parent_tags.select { |pt| pt.room_type == room_type }.map { |pt| [ pt.name, pt.id ] }
       ]
     end
-  end
-
-  def build_all_hobbies_grouped
-    grouped_hobbies = Hobby.includes(:hobby_parent_tags)
-                           .order(:name)
-                           .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |hobby, hash|
-      hash[hobby.primary_room_type] << [ hobby.name, hobby.id ]
-    end
-
-    ParentTag.room_types.keys
-             .append("unclassified")
-             .index_with { |room_type| grouped_hobbies[room_type] }
-             .reject { |_, hobbies| hobbies.empty? }
   end
 end

--- a/app/models/hobby.rb
+++ b/app/models/hobby.rb
@@ -13,6 +13,10 @@ class Hobby < ApplicationRecord
     { parent_tag_name: primary&.parent_tag&.name, room_type: primary&.room_type }
   end
 
+  def unused?
+    usage_count.to_i == 0
+  end
+
   has_many :profile_hobbies, dependent: :restrict_with_error
   has_many :profiles, through: :profile_hobbies
 

--- a/app/views/admin/unclassified_hobbies/index.html.erb
+++ b/app/views/admin/unclassified_hobbies/index.html.erb
@@ -15,7 +15,7 @@
         <th style="padding: 0.5rem 1rem;">使用回数</th>
         <th style="padding: 0.5rem 1rem;">ユーザー数</th>
         <th style="padding: 0.5rem 1rem;">分類</th>
-        <th style="padding: 0.5rem 1rem;">統合</th>
+        <th style="padding: 0.5rem 1rem;">削除</th>
       </tr>
     </thead>
     <tbody>
@@ -31,20 +31,18 @@
                     prompt: "選択してください",
                     style: "background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.25rem;" %>
               <%= f.submit "分類",
-                    style: "margin-left: 0.25rem; background: #2563eb; color: white; border: none; padding: 0.25rem 0.75rem; border-radius: 0.25rem; cursor: pointer;" %>
+                    style: "margin-left: 0.5rem; background: #2563eb; color: white; border: none; padding: 0.375rem 1rem; border-radius: 0.25rem; cursor: pointer; font-weight: bold;" %>
             <% end %>
           </td>
           <td style="padding: 0.5rem 1rem;">
-            <%= form_with url: merge_admin_unclassified_hobby_path(hobby), method: :post, local: true do |f| %>
-              <% target_hobby_groups = @all_hobbies_grouped.transform_values do |grouped_hobbies|
-                   grouped_hobbies.reject { |(_, id)| id == hobby.id }
-                 end.reject { |_, grouped_hobbies| grouped_hobbies.empty? } %>
-              <%= select_tag :target_hobby_id,
-                    grouped_options_for_select(target_hobby_groups),
-                    prompt: "選択してください",
-                    style: "background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.25rem;" %>
-              <%= submit_tag "統合",
-                    style: "margin-left: 0.25rem; background: #dc2626; color: white; border: none; padding: 0.25rem 0.75rem; border-radius: 0.25rem; cursor: pointer;" %>
+            <% if hobby.unused? %>
+              <%= button_to "削除",
+                    admin_unclassified_hobby_path(hobby),
+                    method: :delete,
+                    data: { turbo_confirm: "「#{hobby.name}」を削除しますか？この操作は取り消せません。" },
+                    style: "background: #dc2626; color: white; border: none; padding: 0.375rem 0.75rem; border-radius: 0.25rem; cursor: pointer;" %>
+            <% else %>
+              <span style="color: #6b7280; font-size: 0.875rem;">使用中</span>
             <% end %>
           </td>
         </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,10 +66,6 @@ Rails.application.routes.draw do
     root "dashboards#show"
     resources :parent_tags, only: %i[index new create edit update destroy]
     resources :hobbies, only: %i[new create edit update destroy]
-    resources :unclassified_hobbies, only: [ :index, :update ] do
-      member do
-        post :merge
-      end
-    end
+    resources :unclassified_hobbies, only: [ :index, :update, :destroy ]
   end
 end

--- a/docs/designs/2026-04-22-unclassified-hobbies-improvement.md
+++ b/docs/designs/2026-04-22-unclassified-hobbies-improvement.md
@@ -1,0 +1,188 @@
+# 未分類タグ管理画面の改善（分類主役・削除条件限定） 設計書
+
+**日付:** 2026-04-22
+**Issue:** #248
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+
+- `Admin::UnclassifiedHobbiesController` に `destroy` アクションを追加
+- 同コントローラから `merge` アクション・`build_all_hobbies_grouped` を削除
+- ルーティングに `destroy` を追加、`merge` を削除
+- ビューを改修（統合列削除・分類を主役化・条件付き削除ボタン追加）
+- request spec / system spec を更新（統合テスト削除・削除テスト追加）
+
+後続 Issue: 統合専用画面（別 Issue で対応）
+
+## 2. 目的
+
+1. 管理者の操作フローを「まず分類、不要なら削除」に整理する
+2. 誰も使っていないゴミタグを安全に除去できる手段を提供する
+3. 誤操作リスクの高い統合を未分類タグ管理画面から分離する
+
+## 3. スコープ
+
+### 含むもの
+- `destroy` アクション追加（`Hobby.unclassified` スコープ経由のみ）
+- `merge` アクション・ルート・`build_all_hobbies_grouped` の削除
+- 分類フォームの主役化（ボタン拡大・色強調）
+- `usage_count = 0` のときのみ削除ボタン表示（`data-confirm` 付き）
+- spec 更新（統合テスト削除・削除テスト追加）
+
+### 含まないもの
+- `HobbyMergeService` の削除（将来の統合専用画面で再利用するため残す）
+- マイグレーション（スキーマ変更なし）
+- 分類済みタグの削除
+
+## 4. 設計方針
+
+削除の安全策を「UI制御のみ」か「モデル制約のみ」か「両方」かという論点がある。
+
+| 方式 | 安全性 | コスト |
+|---|---|---|
+| A: UI で非表示のみ | 低（直接リクエストで削除可能） | 低 |
+| B: モデルの `restrict_with_error` のみ | 中（エラー発生するが UX が雑） | 低 |
+| C: UI 非表示 ＋ `restrict_with_error` を rescue | 高（二重防御） | 低 |
+
+**採用理由:** 案C。UI で `usage_count = 0` のときのみ削除ボタンを表示しつつ、直接リクエストが来ても `restrict_with_error` が弾き、コントローラで rescue して alert にリダイレクトする。実装コストは低く、安全性が高い。
+
+## 5. データ設計
+
+**変更なし。** スキーマ・マイグレーションは不要。
+
+`profile_hobbies` の `restrict_with_error` 制約がすでにDBレベルの守りとして機能する。
+
+### ER 図
+
+```mermaid
+erDiagram
+  hobbies {
+    bigint id PK
+    string name "NOT NULL, UNIQUE"
+    string normalized_name
+  }
+  hobby_parent_tags {
+    bigint id PK
+    bigint hobby_id FK "NOT NULL"
+    bigint parent_tag_id FK "NOT NULL"
+    integer room_type "NOT NULL"
+  }
+  profile_hobbies {
+    bigint id PK
+    bigint profile_id FK "NOT NULL"
+    bigint hobby_id FK "NOT NULL"
+  }
+  hobbies ||--o{ hobby_parent_tags : "has many"
+  hobbies ||--o{ profile_hobbies : "restrict_with_error"
+```
+
+## 6. 画面・アクセス制御の流れ
+
+### シーケンス図（削除フロー）
+
+```mermaid
+sequenceDiagram
+  participant U as Admin
+  participant B as Browser
+  participant C as UnclassifiedHobbiesController
+  participant M as Hobby
+
+  U->>B: 削除ボタン押下（usage_count=0 のみ表示）
+  B->>U: data-confirm ダイアログ
+  U->>B: OK
+  B->>C: DELETE /admin/unclassified_hobbies/:id
+  C->>M: Hobby.unclassified.find(id)
+  alt 未分類タグが存在
+    M-->>C: hobby
+    C->>M: hobby.destroy!
+    alt usage_count = 0
+      M-->>C: 成功
+      C->>B: redirect + notice 削除しました
+    else usage_count > 0
+      M-->>C: RecordNotDestroyed
+      C->>B: redirect + alert 削除できませんでした
+    end
+  else 存在しない or 分類済み
+    M-->>C: RecordNotFound
+    C->>B: 404
+  end
+```
+
+## 7. アプリケーション設計
+
+**Controller（`destroy` 追加・`merge` 削除）**
+
+```ruby
+def destroy
+  @hobby = Hobby.unclassified.find(params[:id])
+  @hobby.destroy!
+  redirect_to admin_unclassified_hobbies_path, notice: "削除しました"
+rescue ActiveRecord::RecordNotDestroyed
+  redirect_to admin_unclassified_hobbies_path, alert: "削除できませんでした（使用中のタグは削除できません）"
+end
+```
+
+`index` アクションから `@all_hobbies_grouped` と `build_all_hobbies_grouped` も削除する。
+
+**設計意図:** Service 分離不要。単一モデルへの操作のみで、トランザクションも不要。
+
+## 8. ルーティング設計
+
+```ruby
+# 変更前
+resources :unclassified_hobbies, only: [:index, :update] do
+  member { post :merge }
+end
+
+# 変更後
+resources :unclassified_hobbies, only: [:index, :update, :destroy]
+```
+
+**設計意図:** `merge` を除去し `destroy` を追加する最小変更。
+
+## 9. レイアウト / UI 設計
+
+現在の「分類」列と「統合」列を並べたレイアウトから変更する。
+
+- **統合列を削除**
+- **分類列を主役化:** select はそのまま、ボタンを青・やや大きめに
+- **削除列を追加:** `usage_count == 0` のときのみ赤い削除ボタンを表示、`usage_count > 0` のときはグレーの「使用中」表示
+
+## 10. クエリ・性能面
+
+既存の `index` クエリは `COUNT(DISTINCT profile_hobbies.id) AS usage_count` を SQL 集計で取得済みのため、`hobby.usage_count` をビューで参照しても追加クエリは発生しない。N+1 なし。
+
+`@all_hobbies_grouped`（統合用の全タグ一覧）を削除するため、index アクションのクエリ数が1つ減る（パフォーマンス改善）。
+
+## 11. トランザクション / Service 分離
+
+**トランザクション:** 不要（単一モデルへの `destroy` のみ）
+**Service 分離:** 不要（複数モデル跨ぎなし、条件分岐も少ない）
+
+## 12. 実装対象一覧
+
+| # | 対象 | 内容 |
+|---|---|---|
+| 1 | Route | `destroy` 追加、`merge` メンバールート削除 |
+| 2 | Controller | `destroy` 追加、`merge` / `build_all_hobbies_grouped` / `@all_hobbies_grouped` 削除 |
+| 3 | View | 統合列削除・分類ボタン主役化・条件付き削除ボタン追加 |
+| 4 | Request spec | 統合テスト削除、`DELETE` テスト追加 |
+| 5 | System spec | 統合テスト削除、削除テスト追加 |
+
+## 13. 受入条件
+
+- [ ] 統合列・統合フォームが画面から消えている
+- [ ] 分類ボタンが視覚的に主役として目立つ
+- [ ] `usage_count = 0` のタグに削除ボタンが表示される
+- [ ] `usage_count > 0` のタグに削除ボタンが表示されない（「使用中」表示）
+- [ ] 削除ボタン押下時に確認ダイアログが出る
+- [ ] 削除後に一覧から消え、`Hobby` レコードが削除されている
+- [ ] 分類済みタグや存在しないタグへの `DELETE` は 404 を返す
+- [ ] 使用中タグへの直接 `DELETE` リクエストは alert リダイレクトになる
+- [ ] RSpec / RuboCop 全通過
+
+## 14. この設計の結論
+
+スキーマ変更なし・Service 不要・ルート1本追加のシンプルな実装。既存の `restrict_with_error` を活かした二重防御で安全性を確保しつつ、UI を「分類主役・削除条件限定」に整理する。将来の統合専用画面は `HobbyMergeService` をそのまま再利用できる。

--- a/docs/designs/codex-prompt-248.md
+++ b/docs/designs/codex-prompt-248.md
@@ -1,0 +1,347 @@
+# Codex 実装プロンプト — Issue #248 未分類タグ管理画面の改善（分類主役・削除条件限定）
+
+**ブランチ:** `feature/248-unclassified-hobbies-improvement`
+**設計書:** `docs/designs/2026-04-22-unclassified-hobbies-improvement.md`
+
+---
+
+## 概要
+
+管理者向け未分類タグ管理画面（`/admin/unclassified_hobbies`）を改修する。
+
+- 統合機能（merge）を画面から除去する
+- 分類フォームを視覚的に主役化する
+- `usage_count = 0` のタグにのみ削除ボタンを表示する（`data-confirm` 付き）
+- 使用中タグへの直接 DELETE リクエストは `restrict_with_error` で弾き、alert にリダイレクトする
+
+---
+
+## 変更対象ファイル
+
+| ファイル | 変更種別 |
+|---|---|
+| `config/routes.rb` | 修正 |
+| `app/controllers/admin/unclassified_hobbies_controller.rb` | 修正 |
+| `app/views/admin/unclassified_hobbies/index.html.erb` | 修正 |
+| `spec/requests/admin/unclassified_hobbies_spec.rb` | 修正 |
+| `spec/system/admin/unclassified_hobbies_spec.rb` | 修正 |
+
+---
+
+## Task 1：request spec — merge テスト削除 + DELETE テスト追加
+
+**対象ファイル:** `spec/requests/admin/unclassified_hobbies_spec.rb`
+
+### Step 1: merge テストブロックを削除する
+
+`describe "POST /admin/unclassified_hobbies/:id/merge"` ブロック全体を削除する。
+
+### Step 2: DELETE テストブロックを末尾（最後の `end` の直前）に追加する
+
+```ruby
+describe "DELETE /admin/unclassified_hobbies/:id" do
+  context "管理者の場合" do
+    before { sign_in admin_user }
+
+    context "usage_count が 0 の場合" do
+      # hobby を使用しているプロフィールがない状態
+      it "削除されて一覧にリダイレクトされる" do
+        delete admin_unclassified_hobby_path(unclassified_hobby)
+        aggregate_failures do
+          expect(Hobby.find_by(id: unclassified_hobby.id)).to be_nil
+          expect(response).to redirect_to(admin_unclassified_hobbies_path)
+        end
+      end
+    end
+
+    context "usage_count が 1 以上の場合" do
+      # hobby を使用しているプロフィールがある状態
+      let!(:owner_profile) { create(:profile) }
+
+      before { create(:profile_hobby, profile: owner_profile, hobby: unclassified_hobby) }
+
+      it "削除されずに alert でリダイレクトされる" do
+        delete admin_unclassified_hobby_path(unclassified_hobby)
+        aggregate_failures do
+          expect(Hobby.find_by(id: unclassified_hobby.id)).not_to be_nil
+          expect(response).to redirect_to(admin_unclassified_hobbies_path)
+        end
+      end
+    end
+
+    context "分類済み hobby の場合" do
+      # unclassified スコープ外なので 404
+      it "404 を返す" do
+        delete admin_unclassified_hobby_path(classified_hobby)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  context "一般ユーザーの場合" do
+    let!(:normal_user) { create(:user) }
+
+    before { sign_in normal_user }
+
+    it "root_path にリダイレクトされる" do
+      delete admin_unclassified_hobby_path(unclassified_hobby)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end
+```
+
+### Step 3: テスト実行 → DELETE テストが RED であることを確認
+
+```bash
+docker compose exec web bundle exec rspec spec/requests/admin/unclassified_hobbies_spec.rb
+```
+
+期待出力: `No route matches [DELETE]` のエラー（ルート未定義）
+
+---
+
+## Task 2：routes + controller 修正（GREEN）
+
+### Step 1: `config/routes.rb` の unclassified_hobbies を書き換える
+
+```ruby
+# 変更前
+resources :unclassified_hobbies, only: [ :index, :update ] do
+  member do
+    post :merge
+  end
+end
+
+# 変更後
+resources :unclassified_hobbies, only: [ :index, :update, :destroy ]
+```
+
+### Step 2: `app/controllers/admin/unclassified_hobbies_controller.rb` の index アクションを修正する
+
+`@all_hobbies_grouped = build_all_hobbies_grouped` の行を削除する。
+
+```ruby
+def index
+  scope = Hobby.unclassified
+               .left_joins(:profile_hobbies)
+               .select("hobbies.*, COUNT(DISTINCT profile_hobbies.id) AS usage_count, COUNT(DISTINCT profile_hobbies.profile_id) AS user_count")
+               .group("hobbies.id")
+  scope = scope.where("hobbies.name LIKE ?", "%#{ActiveRecord::Base.sanitize_sql_like(params[:q])}%") if params[:q].present?
+  @hobbies = scope
+  @parent_tags = ParentTag.order(:room_type, :position)
+  @grouped_parent_tag_options = build_grouped_parent_tag_options
+end
+```
+
+### Step 3: `merge` アクションを削除し、`destroy` アクションを `update` の後に追加する
+
+```ruby
+def destroy
+  @hobby = Hobby.unclassified.find(params[:id])
+  @hobby.destroy!
+  redirect_to admin_unclassified_hobbies_path, notice: "削除しました"
+rescue ActiveRecord::RecordNotDestroyed
+  redirect_to admin_unclassified_hobbies_path, alert: "削除できませんでした（使用中のタグは削除できません）"
+end
+```
+
+### Step 4: private の `build_all_hobbies_grouped` メソッドを削除する
+
+削除対象:
+
+```ruby
+def build_all_hobbies_grouped
+  grouped_hobbies = Hobby.includes(:hobby_parent_tags)
+                         .order(:name)
+                         .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |hobby, hash|
+    hash[hobby.primary_room_type] << [ hobby.name, hobby.id ]
+  end
+
+  ParentTag.room_types.keys
+           .append("unclassified")
+           .index_with { |room_type| grouped_hobbies[room_type] }
+           .reject { |_, hobbies| hobbies.empty? }
+end
+```
+
+### Step 5: request spec を実行 → GREEN を確認
+
+```bash
+docker compose exec web bundle exec rspec spec/requests/admin/unclassified_hobbies_spec.rb
+```
+
+期待出力: `X examples, 0 failures`
+
+---
+
+## Task 3：system spec — merge テスト削除 + delete テスト追加
+
+**対象ファイル:** `spec/system/admin/unclassified_hobbies_spec.rb`
+
+### Step 1: 統合テストブロックを削除する
+
+`describe "統合"` ブロック全体を削除する。
+
+### Step 2: 削除テストブロックを「アクセス制御」describe の直前に追加する
+
+```ruby
+describe "削除" do
+  let!(:unused_hobby) { create(:hobby, name: "unused-tag") }
+  let!(:used_hobby) { create(:hobby, name: "used-tag") }
+  let!(:owner_profile) { create(:profile) }
+
+  before do
+    # used_hobby は1件のプロフィールで使用中
+    create(:profile_hobby, profile: owner_profile, hobby: used_hobby)
+    visit admin_unclassified_hobbies_path
+  end
+
+  it "usage_count が 0 のタグに削除ボタンが表示される" do
+    within "[data-hobby-id='#{unused_hobby.id}']" do
+      expect(page).to have_button "削除"
+    end
+  end
+
+  it "usage_count が 1 以上のタグに削除ボタンが表示されず「使用中」と表示される" do
+    within "[data-hobby-id='#{used_hobby.id}']" do
+      expect(page).not_to have_button "削除"
+      expect(page).to have_content "使用中"
+    end
+  end
+
+  it "削除後にタグが一覧から消えてフラッシュが表示される" do
+    within "[data-hobby-id='#{unused_hobby.id}']" do
+      accept_confirm { click_button "削除" }
+    end
+    expect(page).not_to have_css("[data-hobby-id='#{unused_hobby.id}']")
+    expect(page).to have_content "削除しました"
+  end
+end
+```
+
+### Step 3: system spec を実行 → 削除テストが RED であることを確認
+
+```bash
+docker compose exec web bundle exec rspec spec/system/admin/unclassified_hobbies_spec.rb
+```
+
+期待出力: 削除テスト3件が `FAILED`（ビューに削除ボタンがないため）
+
+---
+
+## Task 4：ビュー改修（GREEN）
+
+**対象ファイル:** `app/views/admin/unclassified_hobbies/index.html.erb`
+
+### Step 1: thead の「統合」列ヘッダーを「削除」に変更する
+
+```erb
+<%# 変更前 %>
+<th style="padding: 0.5rem 1rem;">分類</th>
+<th style="padding: 0.5rem 1rem;">統合</th>
+
+<%# 変更後 %>
+<th style="padding: 0.5rem 1rem;">分類</th>
+<th style="padding: 0.5rem 1rem;">削除</th>
+```
+
+### Step 2: 分類フォームの submit ボタンを主役化する
+
+```erb
+<%# 変更前 %>
+<%= f.submit "分類",
+      style: "margin-left: 0.25rem; background: #2563eb; color: white; border: none; padding: 0.25rem 0.75rem; border-radius: 0.25rem; cursor: pointer;" %>
+
+<%# 変更後 %>
+<%= f.submit "分類",
+      style: "margin-left: 0.5rem; background: #2563eb; color: white; border: none; padding: 0.375rem 1rem; border-radius: 0.25rem; cursor: pointer; font-weight: bold;" %>
+```
+
+### Step 3: tbody の統合フォーム列を削除し、条件付き削除ボタン列に置き換える
+
+削除対象（統合フォーム `<td>` 全体）:
+
+```erb
+<td style="padding: 0.5rem 1rem;">
+  <%= form_with url: merge_admin_unclassified_hobby_path(hobby), method: :post, local: true do |f| %>
+    ...
+  <% end %>
+</td>
+```
+
+追加する削除列:
+
+```erb
+<td style="padding: 0.5rem 1rem;">
+  <% if hobby.usage_count == 0 %>
+    <%= button_to "削除",
+          admin_unclassified_hobby_path(hobby),
+          method: :delete,
+          data: { confirm: "「#{hobby.name}」を削除しますか？この操作は取り消せません。" },
+          style: "background: #dc2626; color: white; border: none; padding: 0.375rem 0.75rem; border-radius: 0.25rem; cursor: pointer;" %>
+  <% else %>
+    <span style="color: #6b7280; font-size: 0.875rem;">使用中</span>
+  <% end %>
+</td>
+```
+
+### Step 4: system spec を実行 → GREEN を確認
+
+```bash
+docker compose exec web bundle exec rspec spec/system/admin/unclassified_hobbies_spec.rb
+```
+
+期待出力: `X examples, 0 failures`
+
+---
+
+## Task 5：全 spec 確認 + RuboCop + コミット
+
+### Step 1: 関連 spec を全件実行
+
+```bash
+docker compose exec web bundle exec rspec spec/requests/admin/unclassified_hobbies_spec.rb spec/system/admin/unclassified_hobbies_spec.rb
+```
+
+期待出力: `X examples, 0 failures`
+
+### Step 2: RuboCop を実行
+
+```bash
+docker compose exec web bundle exec rubocop app/controllers/admin/unclassified_hobbies_controller.rb app/views/admin/unclassified_hobbies/index.html.erb config/routes.rb
+```
+
+期待出力: `no offenses detected`
+
+### Step 3: 違反があれば自動修正して再確認
+
+```bash
+docker compose exec web bundle exec rubocop -a app/controllers/admin/unclassified_hobbies_controller.rb
+docker compose exec web bundle exec rubocop app/controllers/admin/unclassified_hobbies_controller.rb
+```
+
+### Step 4: コミット
+
+```bash
+git add config/routes.rb \
+  app/controllers/admin/unclassified_hobbies_controller.rb \
+  app/views/admin/unclassified_hobbies/index.html.erb \
+  spec/requests/admin/unclassified_hobbies_spec.rb \
+  spec/system/admin/unclassified_hobbies_spec.rb
+git commit -m "improve: 未分類タグ管理画面を分類主役・削除条件限定に改修 #248"
+```
+
+---
+
+## 受入条件チェックリスト
+
+- [ ] 統合列・統合フォームが画面から消えている
+- [ ] 分類ボタンが視覚的に主役として目立つ
+- [ ] `usage_count = 0` のタグに削除ボタンが表示される
+- [ ] `usage_count > 0` のタグに削除ボタンが表示されない（「使用中」表示）
+- [ ] 削除ボタン押下時に確認ダイアログが出る
+- [ ] 削除後に一覧から消え、`Hobby` レコードが削除されている
+- [ ] 分類済みタグや存在しないタグへの `DELETE` は 404 を返す
+- [ ] 使用中タグへの直接 `DELETE` リクエストは alert リダイレクトになる
+- [ ] RSpec / RuboCop 全通過

--- a/spec/requests/admin/unclassified_hobbies_spec.rb
+++ b/spec/requests/admin/unclassified_hobbies_spec.rb
@@ -117,37 +117,39 @@ RSpec.describe "Admin::UnclassifiedHobbiesController", type: :request do
     end
   end
 
-  describe "POST /admin/unclassified_hobbies/:id/merge" do
-    let!(:source_hobby) { create(:hobby, name: "rails-merge-source") }
-    let!(:target_hobby) { create(:hobby, name: "rails-merge-target") }
-    let!(:source_hobby_owner_profile) { create(:profile) }
-
-    before do
-      create(:profile_hobby, profile: source_hobby_owner_profile, hobby: source_hobby)
-    end
-
+  describe "DELETE /admin/unclassified_hobbies/:id" do
     context "管理者の場合" do
       before { sign_in admin_user }
 
-      it "profile_hobbies が付け替えられ source が削除されて一覧にリダイレクトされる" do
-        post merge_admin_unclassified_hobby_path(source_hobby),
-             params: { target_hobby_id: target_hobby.id }
-
-        aggregate_failures do
-          expect(
-            ProfileHobby.where(hobby_id: target_hobby.id, profile_id: source_hobby_owner_profile.id)
-          ).to exist
-          expect(Hobby.find_by(id: source_hobby.id)).to be_nil
-          expect(response).to redirect_to(admin_unclassified_hobbies_path)
+      context "usage_count が 0 の場合" do
+        it "削除されて一覧にリダイレクトされる" do
+          delete admin_unclassified_hobby_path(unclassified_hobby)
+          aggregate_failures do
+            expect(Hobby.find_by(id: unclassified_hobby.id)).to be_nil
+            expect(response).to redirect_to(admin_unclassified_hobbies_path)
+          end
         end
       end
 
-      it "source と target が同じ場合は alert とともにリダイレクトされる" do
-        post merge_admin_unclassified_hobby_path(source_hobby),
-             params: { target_hobby_id: source_hobby.id }
-        expect(response).to redirect_to(admin_unclassified_hobbies_path)
-        follow_redirect!
-        expect(response.body).to include("統合元と統合先が同じです")
+      context "usage_count が 1 以上の場合" do
+        let!(:owner_profile) { create(:profile) }
+
+        before { create(:profile_hobby, profile: owner_profile, hobby: unclassified_hobby) }
+
+        it "削除されずに alert でリダイレクトされる" do
+          delete admin_unclassified_hobby_path(unclassified_hobby)
+          aggregate_failures do
+            expect(Hobby.find_by(id: unclassified_hobby.id)).not_to be_nil
+            expect(response).to redirect_to(admin_unclassified_hobbies_path)
+          end
+        end
+      end
+
+      context "分類済み hobby の場合" do
+        it "404 を返す" do
+          delete admin_unclassified_hobby_path(classified_hobby)
+          expect(response).to have_http_status(:not_found)
+        end
       end
     end
 
@@ -157,8 +159,7 @@ RSpec.describe "Admin::UnclassifiedHobbiesController", type: :request do
       before { sign_in normal_user }
 
       it "root_path にリダイレクトされる" do
-        post merge_admin_unclassified_hobby_path(source_hobby),
-             params: { target_hobby_id: target_hobby.id }
+        delete admin_unclassified_hobby_path(unclassified_hobby)
         expect(response).to redirect_to(root_path)
       end
     end

--- a/spec/system/admin/unclassified_hobbies_spec.rb
+++ b/spec/system/admin/unclassified_hobbies_spec.rb
@@ -90,38 +90,35 @@ RSpec.describe "Admin 未分類タグ管理", type: :system do
     end
   end
 
-  describe "統合" do
-    let!(:source_rails_hobby) { create(:hobby, name: "rails") }
-    let!(:target_rails_hobby) { create(:hobby, name: "Rails") }
-    let!(:source_hobby_owner_profile) { create(:profile) }
+  describe "削除", js: true do
+    let!(:unused_hobby) { create(:hobby, name: "unused-tag") }
+    let!(:used_hobby) { create(:hobby, name: "used-tag") }
+    let!(:owner_profile) { create(:profile) }
 
     before do
-      create(:profile_hobby, profile: source_hobby_owner_profile, hobby: source_rails_hobby)
+      create(:profile_hobby, profile: owner_profile, hobby: used_hobby)
       visit admin_unclassified_hobbies_path
     end
 
-    it "統合するとフラッシュが表示される" do
-      within "[data-hobby-id='#{source_rails_hobby.id}']" do
-        select "Rails", from: "target_hobby_id"
-        click_button "統合"
+    it "usage_count が 0 のタグに削除ボタンが表示される" do
+      within "[data-hobby-id='#{unused_hobby.id}']" do
+        expect(page).to have_button "削除"
       end
-      expect(page).to have_content "統合しました"
     end
 
-    it "統合後にprofile_hobbiesがtargetに付け替えられる" do
-      within "[data-hobby-id='#{source_rails_hobby.id}']" do
-        select "Rails", from: "target_hobby_id"
-        click_button "統合"
+    it "usage_count が 1 以上のタグに削除ボタンが表示されず「使用中」と表示される" do
+      within "[data-hobby-id='#{used_hobby.id}']" do
+        expect(page).not_to have_button "削除"
+        expect(page).to have_content "使用中"
       end
-      expect(ProfileHobby.where(hobby_id: target_rails_hobby.id, profile_id: source_hobby_owner_profile.id)).to exist
     end
 
-    it "統合後にsource hobbyが削除される" do
-      within "[data-hobby-id='#{source_rails_hobby.id}']" do
-        select "Rails", from: "target_hobby_id"
-        click_button "統合"
+    it "削除後にタグが一覧から消えてフラッシュが表示される" do
+      within "[data-hobby-id='#{unused_hobby.id}']" do
+        accept_confirm { click_button "削除" }
       end
-      expect(Hobby.find_by(id: source_rails_hobby.id)).to be_nil
+      expect(page).not_to have_css("[data-hobby-id='#{unused_hobby.id}']")
+      expect(page).to have_content "削除しました"
     end
   end
 


### PR DESCRIPTION
## Summary
- 統合機能（merge アクション・ルート）を未分類タグ管理画面から除去
- 分類ボタンを視覚的に主役化（padding 拡大・font-weight: bold）
- `usage_count = 0` のタグにのみ削除ボタンを表示（`data-turbo-confirm` 付き）
- `Hobby#unused?` をモデルに追加してビューのドメイン判定を一元管理
- 使用中タグへの直接 DELETE リクエストは `restrict_with_error` + rescue で二重防御

## Test plan
- [x] RSpec: 26 examples, 0 failures
- [x] 未分類タグ一覧に統合列・統合フォームが表示されない
- [x] 分類ボタンが太字・大きめで表示される
- [x] `usage_count = 0` のタグに赤い削除ボタンが表示される
- [x] `usage_count > 0` のタグに「使用中」と表示され削除ボタンが出ない
- [x] 削除ボタン押下で確認ダイアログが表示される
- [x] 削除後にタグが一覧から消える
- [x] 分類済みタグへの DELETE は 404 を返す

## Related
- Issue: #248
- 後続: #251 趣味タグ統合専用画面（別 Issue）