### PR TITLE
feat: 趣味タグ統合専用画面を追加（Admin） #251

### DIFF
--- a/app/controllers/admin/hobby_merges_controller.rb
+++ b/app/controllers/admin/hobby_merges_controller.rb
@@ -1,0 +1,35 @@
+class Admin::HobbyMergesController < Admin::BaseController
+  def new
+    @grouped_hobby_options = build_grouped_hobby_options
+  end
+
+  def create
+    source = Hobby.find(params[:source_hobby_id])
+    target = Hobby.find(params[:target_hobby_id])
+    result = Admin::HobbyMergeService.call(source:, target:)
+
+    if result.success?
+      redirect_to new_admin_hobby_merge_path,
+                  notice: "「#{source.name}」を「#{target.name}」に統合しました"
+    else
+      @grouped_hobby_options = build_grouped_hobby_options
+      flash.now[:alert] = result.error
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def build_grouped_hobby_options
+    hobbies = Hobby.includes(hobby_parent_tags: :parent_tag).order(:name)
+    grouped = hobbies.group_by { |hobby| hobby.primary_parent_tag_info[:parent_tag_name] || "未分類" }
+
+    ordered_labels = grouped.keys.reject { |label| label == "未分類" }.sort
+    ordered_labels << "未分類" if grouped.key?("未分類")
+
+    ordered_labels.map do |label|
+      options = grouped[label].sort_by(&:name).map { |hobby| [ hobby.name, hobby.id ] }
+      [ label, options ]
+    end
+  end
+end

--- a/app/views/admin/hobby_merges/new.html.erb
+++ b/app/views/admin/hobby_merges/new.html.erb
@@ -1,0 +1,29 @@
+<div style="max-width: 48rem; margin: 0 auto;">
+  <h1 style="font-size: 1.5rem; font-weight: bold; color: #f9fafb; margin-bottom: 1.5rem;">趣味タグ統合</h1>
+
+  <%= form_with url: admin_hobby_merges_path,
+                data: { turbo_confirm: "選択したタグを統合しますか？この操作は取り消せません。" } do |f| %>
+    <div style="margin-bottom: 1.5rem;">
+      <label for="source_hobby_id" style="color: #d1d5db; display: block; margin-bottom: 0.5rem;">
+        統合元タグ（削除されます）
+      </label>
+      <%= select_tag :source_hobby_id,
+                     grouped_options_for_select(@grouped_hobby_options),
+                     prompt: "選択してください",
+                     style: "background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.375rem 0.75rem; border-radius: 0.25rem; width: 100%;" %>
+    </div>
+
+    <div style="margin-bottom: 1.5rem;">
+      <label for="target_hobby_id" style="color: #d1d5db; display: block; margin-bottom: 0.5rem;">
+        統合先タグ（残ります）
+      </label>
+      <%= select_tag :target_hobby_id,
+                     grouped_options_for_select(@grouped_hobby_options),
+                     prompt: "選択してください",
+                     style: "background: #1f2937; color: #f9fafb; border: 1px solid #374151; padding: 0.375rem 0.75rem; border-radius: 0.25rem; width: 100%;" %>
+    </div>
+
+    <%= f.submit "統合する",
+                 style: "background: #dc2626; color: white; border: none; padding: 0.5rem 1.5rem; border-radius: 0.25rem; cursor: pointer; font-weight: bold;" %>
+  <% end %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -14,6 +14,7 @@
       <%= link_to "ダッシュボード", admin_root_path, style: "color: #9ca3af; text-decoration: none; font-size: 0.875rem;" %>
       <%= link_to "親タグ管理", admin_parent_tags_path, style: "color: #9ca3af; text-decoration: none; font-size: 0.875rem;" %>
       <%= link_to "未分類タグ管理", admin_unclassified_hobbies_path, style: "color: #9ca3af; text-decoration: none; font-size: 0.875rem;" %>
+      <%= link_to "タグ統合", new_admin_hobby_merge_path, style: "color: #9ca3af; text-decoration: none; font-size: 0.875rem;" %>
       <span style="margin-left: auto;">
         <%= link_to "サイトに戻る", root_path, style: "color: #9ca3af; text-decoration: none; font-size: 0.875rem;" %>
       </span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,5 +67,6 @@ Rails.application.routes.draw do
     resources :parent_tags, only: %i[index new create edit update destroy]
     resources :hobbies, only: %i[new create edit update destroy]
     resources :unclassified_hobbies, only: [ :index, :update, :destroy ]
+    resources :hobby_merges, only: %i[new create]
   end
 end

--- a/docs/designs/2026-04-22-admin-hobby-merges.md
+++ b/docs/designs/2026-04-22-admin-hobby-merges.md
@@ -1,0 +1,190 @@
+# 趣味タグ統合専用画面（Admin） 設計書
+
+**日付:** 2026-04-22
+**Issue:** #251
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+
+- `Admin::HobbyMergesController`（new / create）
+- `app/views/admin/hobby_merges/new.html.erb`（統合フォーム）
+- ルーティング追加: `resources :hobby_merges, only: [:new, :create]`
+- request spec / system spec
+
+## 2. 目的
+
+- 表記ゆれのある趣味タグを管理者が安全に統合できる専用画面を提供する
+- `Admin::HobbyMergeService`（既存）を再利用し、責務を明確に分離する
+
+## 3. スコープ
+
+### 含むもの
+
+- `/admin/hobby_merges/new`：統合フォーム表示
+- `POST /admin/hobby_merges`：統合実行 → リダイレクト
+- 同じタグ選択時のエラー表示（flash alert）
+- 管理者認証（`Admin::BaseController` 継承で自動適用）
+- request spec・system spec
+
+### 含まないもの
+
+- バルク統合（将来 Issue で対応）
+- `Admin::HobbyMergeService` の変更（そのまま再利用）
+- 統合履歴の記録（スコープ外）
+
+## 4. 設計方針
+
+**ルーティング方式の比較:**
+
+| 方式 | 実装コスト | URL の明確さ | 現状との相性 |
+|---|---|---|---|
+| A: 独立した `resources :hobby_merges` | 低 | `/admin/hobby_merges` で機能が明確 | ○ Issue 記載通り |
+| B: `hobbies` にネスト | 中 | `/admin/hobbies/:id/merges` 等、直感的でない | × 統合は特定hobby起点でない |
+
+**採用: 案A。** 統合操作はどちらか一方の hobby に紐づくものではなく、2タグ間の操作のため独立リソースが適切。
+
+## 5. データ設計
+
+**変更なし。** 新規テーブル・カラム・マイグレーションは不要。既存の `hobbies`・`profile_hobbies` テーブルをそのまま使う。
+
+### DB 制約
+
+追加なし。`Admin::HobbyMergeService` 内のトランザクションで整合性を保証済み。
+
+### ER 図
+
+```mermaid
+erDiagram
+  hobbies {
+    bigint id PK ""
+    string name "NOT NULL, UNIQUE"
+    string normalized_name ""
+  }
+  profile_hobbies {
+    bigint id PK ""
+    bigint profile_id FK "NOT NULL"
+    bigint hobby_id FK "NOT NULL"
+  }
+  profiles {
+    bigint id PK ""
+    bigint user_id FK "NOT NULL, UNIQUE"
+  }
+
+  profiles ||--o{ profile_hobbies : "has many"
+  hobbies ||--o{ profile_hobbies : "has many"
+```
+
+## 6. 画面・アクセス制御の流れ
+
+`Admin::BaseController` の `before_action :authenticate_user!` と `require_admin!` により、管理者以外は `/` にリダイレクト。
+
+### シーケンス図
+
+```mermaid
+sequenceDiagram
+    participant A as Admin
+    participant C as HobbyMergesController
+    participant S as HobbyMergeService
+    participant DB as Database
+
+    A->>C: GET /admin/hobby_merges/new
+    C->>DB: Hobby.order(:name)
+    DB-->>C: @hobbies
+    C-->>A: フォーム表示（source/target select）
+
+    A->>C: POST /admin/hobby_merges (source_id, target_id)
+    C->>DB: Hobby.find(source_id), Hobby.find(target_id)
+    DB-->>C: source, target
+    C->>S: HobbyMergeService.call(source:, target:)
+    S->>DB: トランザクション開始
+    S->>DB: profile_hobbies 付け替え
+    S->>DB: source.destroy!
+    DB-->>S: 完了
+    S-->>C: Result(success?: true)
+    C-->>A: redirect new + notice
+
+    Note over C,S: source == target の場合
+    S-->>C: Result(success?: false, error: "統合元と統合先が同じです")
+    C-->>A: render :new + flash.now[:alert]
+```
+
+## 7. アプリケーション設計
+
+```ruby
+class Admin::HobbyMergesController < Admin::BaseController
+  def new
+    @hobbies = Hobby.order(:name)
+  end
+
+  def create
+    source = Hobby.find(params[:source_hobby_id])
+    target = Hobby.find(params[:target_hobby_id])
+    result = Admin::HobbyMergeService.call(source:, target:)
+    if result.success?
+      redirect_to new_admin_hobby_merge_path,
+                  notice: "「#{source.name}」を「#{target.name}」に統合しました"
+    else
+      @hobbies = Hobby.order(:name)
+      flash.now[:alert] = result.error
+      render :new, status: :unprocessable_entity
+    end
+  end
+end
+```
+
+**設計意図:** `create` 失敗時は `render :new` で再描画し、flash.now で即時表示。サービスが `Result` オブジェクトを返すため、例外ではなく戻り値で分岐する。
+
+## 8. ルーティング設計
+
+```ruby
+namespace :admin do
+  resources :hobby_merges, only: %i[new create]   # 追加
+end
+```
+
+URL: `GET /admin/hobby_merges/new` / `POST /admin/hobby_merges`
+
+## 9. レイアウト / UI 設計
+
+既存 Admin 画面（`unclassified_hobbies`）と統一したダークテーマのインラインスタイルを使用。
+
+- 統合元 select（全タグ、`name` 昇順）
+- 統合先 select（同上）
+- 統合ボタンに `data: { turbo_confirm: "「〇〇」を「△△」に統合しますか？この操作は取り消せません。" }`
+  → Turbo の標準 confirm ダイアログで確認
+
+## 10. クエリ・性能面
+
+- `Hobby.order(:name)` を1回発行するのみ（N+1 なし）
+- 追加インデックス不要（`hobbies.name` / `profile_hobbies(hobby_id)` は既存）
+
+## 11. トランザクション / Service 分離
+
+**トランザクション:** `Admin::HobbyMergeService` 内で `ActiveRecord::Base.transaction` 済み。Controller 側では不要。
+**Service 分離:** 既存 `Admin::HobbyMergeService` をそのまま再利用。変更なし。
+
+## 12. 実装対象一覧
+
+| # | 対象 | 内容 |
+|---|---|---|
+| 1 | Routes | `resources :hobby_merges, only: [:new, :create]` を admin に追加 |
+| 2 | Controller | `Admin::HobbyMergesController` 新規作成（new / create） |
+| 3 | View | `app/views/admin/hobby_merges/new.html.erb` 新規作成 |
+| 4 | Request spec | `spec/requests/admin/hobby_merges_spec.rb` 新規作成 |
+| 5 | System spec | `spec/system/admin/hobby_merges_spec.rb` 新規作成 |
+
+## 13. 受入条件
+
+- [ ] `/admin/hobby_merges/new` にアクセスできる
+- [ ] 全タグから統合元・統合先を select で選択できる
+- [ ] 統合後に `profile_hobbies` が統合先に付け替えられる
+- [ ] 統合後に統合元タグが削除される
+- [ ] 統合元と統合先が同じ場合は flash alert が表示される
+- [ ] 管理者以外はアクセスできない（root にリダイレクト）
+- [ ] RSpec / RuboCop 全通過
+
+## 14. この設計の結論
+
+既存の `Admin::HobbyMergeService` を完全再利用し、Controller + View + ルートの3点追加のみで完結する。最小コストで責務分離を実現できる設計。将来のバルク統合は Service を拡張するだけで対応可能。

--- a/spec/requests/admin/hobby_merges_spec.rb
+++ b/spec/requests/admin/hobby_merges_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+RSpec.describe "Admin::HobbyMergesController", type: :request do
+  let!(:admin_user) { create(:user, :admin) }
+  let!(:programming_parent_tag) { create(:parent_tag, name: "プログラミング", slug: "programming", room_type: :study) }
+  let!(:game_parent_tag) { create(:parent_tag, name: "ゲーム", slug: "game", room_type: :game) }
+  let!(:source_hobby) { create(:hobby, name: "Apex") }
+  let!(:target_hobby) { create(:hobby, name: "React") }
+  let!(:unclassified_hobby) { create(:hobby, name: "未分類タグ") }
+
+  before do
+    create(:hobby_parent_tag, hobby: source_hobby, parent_tag: game_parent_tag)
+    create(:hobby_parent_tag, hobby: target_hobby, parent_tag: programming_parent_tag)
+  end
+
+  describe "GET /admin/hobby_merges/new" do
+    context "管理者の場合" do
+      before { sign_in admin_user }
+
+      it "200 OK を返す" do
+        get new_admin_hobby_merge_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "親タグごとと未分類で optgroup が表示される" do
+        get new_admin_hobby_merge_path
+
+        doc = Nokogiri::HTML(response.body)
+        labels = doc.css("select#source_hobby_id optgroup").map { |node| node["label"] }
+
+        expect(labels).to include("ゲーム", "プログラミング", "未分類")
+      end
+
+      it "各 optgroup に対応するタグが表示される" do
+        get new_admin_hobby_merge_path
+
+        doc = Nokogiri::HTML(response.body)
+        source_groups = doc.css("select#source_hobby_id optgroup").to_h do |group|
+          [ group["label"], group.css("option").map(&:text) ]
+        end
+
+        aggregate_failures do
+          expect(source_groups["ゲーム"]).to include("Apex")
+          expect(source_groups["プログラミング"]).to include("React")
+          expect(source_groups["未分類"]).to include("未分類タグ")
+        end
+      end
+    end
+
+    context "一般ユーザーの場合" do
+      before { sign_in create(:user) }
+
+      it "root_path にリダイレクトされる" do
+        get new_admin_hobby_merge_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "ログインページにリダイレクトされる" do
+        get new_admin_hobby_merge_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "POST /admin/hobby_merges" do
+    context "管理者の場合" do
+      before { sign_in admin_user }
+
+      context "異なるタグを指定した場合" do
+        it "統合元タグが削除される" do
+          expect do
+            post admin_hobby_merges_path,
+                 params: { source_hobby_id: source_hobby.id, target_hobby_id: target_hobby.id }
+          end.to change(Hobby, :count).by(-1)
+        end
+
+        it "new にリダイレクトされる" do
+          post admin_hobby_merges_path,
+               params: { source_hobby_id: source_hobby.id, target_hobby_id: target_hobby.id }
+
+          expect(response).to redirect_to(new_admin_hobby_merge_path)
+        end
+
+        it "profile_hobbies が統合先に付け替えられる" do
+          profile = create(:profile)
+          create(:profile_hobby, profile:, hobby: source_hobby)
+
+          post admin_hobby_merges_path,
+               params: { source_hobby_id: source_hobby.id, target_hobby_id: target_hobby.id }
+
+          expect(profile.profile_hobbies.reload.map(&:hobby_id)).to include(target_hobby.id)
+        end
+      end
+
+      context "同じタグを指定した場合" do
+        it "422 を返す" do
+          post admin_hobby_merges_path,
+               params: { source_hobby_id: source_hobby.id, target_hobby_id: source_hobby.id }
+
+          expect(response).to have_http_status(422)
+        end
+
+        it "エラーメッセージがレスポンスに含まれる" do
+          post admin_hobby_merges_path,
+               params: { source_hobby_id: source_hobby.id, target_hobby_id: source_hobby.id }
+
+          expect(response.body).to include("統合元と統合先が同じです")
+        end
+      end
+    end
+
+    context "一般ユーザーの場合" do
+      before { sign_in create(:user) }
+
+      it "root_path にリダイレクトされる" do
+        post admin_hobby_merges_path,
+             params: { source_hobby_id: source_hobby.id, target_hobby_id: target_hobby.id }
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/system/admin/hobby_merges_spec.rb
+++ b/spec/system/admin/hobby_merges_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe "Admin 趣味タグ統合", type: :system do
+  let!(:admin_user) { create(:user, :admin) }
+  let!(:programming_parent_tag) { create(:parent_tag, name: "プログラミング", slug: "programming", room_type: :study) }
+  let!(:game_parent_tag) { create(:parent_tag, name: "ゲーム", slug: "game", room_type: :game) }
+  let!(:source_hobby) { create(:hobby, name: "Apex") }
+  let!(:target_hobby) { create(:hobby, name: "React") }
+  let!(:unclassified_hobby) { create(:hobby, name: "未分類タグ") }
+
+  before do
+    create(:hobby_parent_tag, hobby: source_hobby, parent_tag: game_parent_tag)
+    create(:hobby_parent_tag, hobby: target_hobby, parent_tag: programming_parent_tag)
+    login_as(admin_user, scope: :user)
+  end
+
+  describe "フォーム表示" do
+    before { visit new_admin_hobby_merge_path }
+
+    it "ページタイトルが表示される" do
+      expect(page).to have_content "趣味タグ統合"
+    end
+
+    it "統合元セレクトが親タグごとと未分類に分かれている" do
+      aggregate_failures do
+        expect(page).to have_css("select#source_hobby_id optgroup[label='ゲーム'] option", text: "Apex")
+        expect(page).to have_css("select#source_hobby_id optgroup[label='プログラミング'] option", text: "React")
+        expect(page).to have_css("select#source_hobby_id optgroup[label='未分類'] option", text: "未分類タグ")
+      end
+    end
+
+    it "統合先セレクトも同じセクション構成で表示される" do
+      aggregate_failures do
+        expect(page).to have_css("select#target_hobby_id optgroup[label='ゲーム'] option", text: "Apex")
+        expect(page).to have_css("select#target_hobby_id optgroup[label='プログラミング'] option", text: "React")
+        expect(page).to have_css("select#target_hobby_id optgroup[label='未分類'] option", text: "未分類タグ")
+      end
+    end
+  end
+
+  describe "統合実行", js: true do
+    before { visit new_admin_hobby_merge_path }
+
+    it "異なるタグを選択して統合するとflashが表示される" do
+      select "Apex", from: "source_hobby_id"
+      select "React", from: "target_hobby_id"
+
+      accept_confirm { click_button "統合する" }
+
+      expect(page).to have_content "「Apex」を「React」に統合しました"
+    end
+
+    it "統合後に統合元タグがフォームから消える" do
+      select "Apex", from: "source_hobby_id"
+      select "React", from: "target_hobby_id"
+
+      accept_confirm { click_button "統合する" }
+
+      expect(page).to have_no_css("select#source_hobby_id option", text: "Apex")
+    end
+
+    it "同じタグを選択するとエラーが表示される" do
+      select "Apex", from: "source_hobby_id"
+      select "Apex", from: "target_hobby_id"
+
+      accept_confirm { click_button "統合する" }
+
+      expect(page).to have_content "統合元と統合先が同じです"
+    end
+  end
+
+  describe "アクセス制御" do
+    it "一般ユーザーは root にリダイレクトされる" do
+      login_as(create(:user), scope: :user)
+
+      visit new_admin_hobby_merge_path
+
+      expect(page).to have_current_path root_path
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- 管理者が表記ゆれのある趣味タグを統合できる専用画面 `/admin/hobby_merges/new` を新規追加
- 既存の `Admin::HobbyMergeService` を再利用し、Controller + View + Routes のみで完結
- 親タグ別 `grouped_options_for_select` でタグ選択UIを提供（未分類を末尾に表示）
- `includes(hobby_parent_tags: :parent_tag)` でN+1クエリを解消

## Test plan
- [x] RSpec 18 examples, 0 failures（request spec + system spec）
- [x] 全体 523 examples, 0 failures（既存機能に影響なし）
- [x] RuboCop offenses なし
- [x] 正常系: 統合元・統合先を選択して統合できる
- [x] 異常系: 同じタグを選択すると alert が表示される
- [x] 異常系: 一般ユーザーはアクセスできない（root にリダイレクト）

## Related
- Issue: #251
- 前提: #248（未分類タグ管理画面の改善）で統合機能が除去されたため本画面を新設

🤖 Generated with [Claude Code](https://claude.com/claude-code)