### PR TITLE
fix: 公開部屋モーダルの位置崩れを修正

### DIFF
--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -55,7 +55,7 @@
 
         <div data-modal-target="panel"
              data-testid="room-modal-<%= room.id %>"
-             class="hidden"
+             class="hidden flex"
              style="position: fixed; inset: 0; z-index: 50; align-items: center; justify-content: center; padding: 1rem;">
           <div data-action="click->modal#close"
                style="position: absolute; inset: 0; background: rgba(0,0,0,0.6);"></div>

--- a/spec/system/rooms_spec.rb
+++ b/spec/system/rooms_spec.rb
@@ -80,6 +80,10 @@ RSpec.describe "公開部屋一覧", type: :system, js: true do
     end
 
     expect(page).to have_css("[data-testid='room-modal-#{unjoined_room.id}']", visible: true)
+    modal_display = page.evaluate_script(<<~JS)
+      window.getComputedStyle(document.querySelector("[data-testid='room-modal-#{unjoined_room.id}']")).display
+    JS
+    expect(modal_display).to eq("flex")
     expect(page).to have_text("未参加の部屋")
   end
 


### PR DESCRIPTION
## 概要
公開部屋一覧で「参加する」を押したときに表示される確認モーダルが、画面中央ではなく左上寄りに崩れて表示される不具合を修正しました。

## 原因
モーダル外枠要素が `hidden` 解除後に `block` 表示になっており、中央寄せに必要な `flex` レイアウトが効いていませんでした。

## 対応内容
- 公開部屋モーダルの外枠を `hidden flex` に変更
- モーダル表示時に `display: flex` になることを確認する system spec を追加

## 確認内容
- 公開部屋一覧で「参加する」を押すとモーダルが中央表示されること
- モーダルから共有ページへ遷移できること
- モーダルを閉じられること

## 実行したテスト
- `docker compose exec web bundle exec rspec spec/system/rooms_spec.rb`
- `docker compose exec web bundle exec rubocop spec/system/rooms_spec.rb`

## 結果
- `7 examples, 0 failures`
- `1 file inspected, no offenses detected`
