### PR TITLE
fix: プロフィール編集レイアウト安定化・タブ動作修正・ログイン後リダイレクト修正 #257 #258

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,8 @@ class ApplicationController < ActionController::Base
     request.get? &&
       is_navigational_format? &&
       !devise_controller? &&
-      !request.xhr?
+      !request.xhr? &&
+      request.path != root_path
   end
 
   def store_user_location!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     return new_my_profile_path if resource.profile.nil?
 
-    stored_location_for(resource) || profiles_path
+    stored_location_for(resource) || mypage_root_path
   end
 
   def configure_permitted_parameters

--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -2,7 +2,10 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["tab", "panel"]
-  static values = { defaultOpen: { type: Boolean, default: true } }
+  static values = {
+    defaultOpen: { type: Boolean, default: true },
+    toggleable: { type: Boolean, default: true }
+  }
 
   connect() {
     this.activeIndex = null
@@ -20,7 +23,7 @@ export default class extends Controller {
     if (index === -1) return
 
     if (this.activeIndex === index) {
-      this.deactivate()
+      if (this.toggleableValue) this.deactivate()
       return
     }
 

--- a/app/javascript/controllers/tag_autocomplete_controller.js
+++ b/app/javascript/controllers/tag_autocomplete_controller.js
@@ -254,6 +254,7 @@ export default class extends Controller {
           ${options}
         </select>
         <div style="margin-top:0.35rem;margin-bottom:0.5rem;color:#9ca3af;font-size:0.8rem;">近い分類を選ぶと、あとで見つけやすくなります</div>
+        <div style="margin-top:0.25rem;margin-bottom:0.5rem;color:#f87171;font-size:0.75rem;">※ プロフィールを更新すると、親タグはご自身では変更できなくなります。変更が必要な場合は管理者にお問い合わせください。</div>
         <div style="display:flex;gap:0.5rem;">
           <button type="button"
                   class="new-tag-confirm-btn"

--- a/app/views/my/profiles/_form.html.erb
+++ b/app/views/my/profiles/_form.html.erb
@@ -16,7 +16,7 @@
   <% end %>
 
   <%# タブ切り替え %>
-  <div data-controller="tabs" class="space-y-6">
+  <div data-controller="tabs" data-tabs-toggleable-value="false" class="space-y-6">
 
     <%# タブボタン %>
     <div class="inline-flex rounded-2xl border border-slate-700/60 bg-slate-900/70 p-1">

--- a/app/views/my/profiles/edit.html.erb
+++ b/app/views/my/profiles/edit.html.erb
@@ -1,4 +1,5 @@
-<div class="w-full max-w-4xl space-y-6">
+<% content_for :no_center, true %>
+<div class="w-full max-w-4xl space-y-6 mx-auto">
   <%# モーダルコントローラはカード全体を囲む %>
   <div class="rounded-2xl border border-slate-700/40 bg-white/[0.03] p-8 shadow-[0_4px_20px_rgba(0,0,0,0.3)]"
        data-controller="modal">

--- a/app/views/my/profiles/new.html.erb
+++ b/app/views/my/profiles/new.html.erb
@@ -1,4 +1,5 @@
-<div class="w-full max-w-4xl">
+<% content_for :no_center, true %>
+<div class="w-full max-w-4xl mx-auto">
   <%# モーダルコントローラはカード全体を囲む %>
   <div class="rounded-2xl border border-slate-700/40 bg-white/[0.03] p-8 shadow-[0_4px_20px_rgba(0,0,0,0.3)]"
        data-controller="modal">

--- a/docs/designs/2026-04-23-profile-edit-layout-stability.md
+++ b/docs/designs/2026-04-23-profile-edit-layout-stability.md
@@ -1,0 +1,190 @@
+# プロフィール編集レイアウト安定化 設計書
+
+**日付:** 2026-04-23
+**Issue:** #257（関連: #258）
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+
+- プロフィール編集・作成ページの「カードが上にずれる」レイアウト崩れ修正（#257）
+- タブを2回クリックするとパネルが消える不具合修正（#258）
+
+> #258 も同じファイル群に起因するため、このIssueで合わせて対処する。
+
+## 2. 目的
+
+- カードが動的に高さ変化しても、画面上の位置が上にずれないようにする（下方向にのみ伸びる）
+- 自己紹介・タグタブを2回クリックしても、パネルが消えないようにする
+
+## 3. スコープ
+
+### 含むもの
+
+- `tabs_controller.js` に `toggleable` value を追加
+- プロフィール編集フォームの `data-tabs-toggleable-value="false"` 設定
+- `edit.html.erb` / `new.html.erb` への `content_for(:no_center)` と `mx-auto` 追加
+
+### 含まないもの
+
+- `profiles/show.html.erb` の tabs（閲覧用でパネルが消えても大きな支障なし。別Issueで検討）
+- `rooms/members/show.html.erb` の tabs（折りたたみ動作は意図的なため変更しない）
+- その他ページのレイアウト調整
+
+## 4. 設計方針
+
+### #257（レイアウトずれ）
+
+| 方式 | 実装コスト | 副作用 |
+|---|---|---|
+| `content_for(:no_center)` を追加 | 低（2ファイルで1行ずつ） | なし（既存パターン） |
+| グローバルに `items-center` → `items-start` | 低 | 全ページに影響 |
+| パネルに `min-height` を設定 | 中 | 空状態で余白が生じる |
+
+**採用理由:** `content_for(:no_center)` は既にコードベース内 8 ページで使われている確立パターン。最も影響範囲が小さい。
+
+### #258（二重クリックでパネル消失）
+
+| 方式 | 実装コスト | 副作用 |
+|---|---|---|
+| `toggleable` value を追加（default: true） | 低 | なし（後方互換） |
+| `deactivate()` 呼び出しを削除 | 低 | `rooms/members/show.html.erb` の折りたたみ機能が壊れる |
+
+**採用理由:** `rooms/members/show.html.erb` が意図的に折りたたみ動作（`default-open-value="false"`）を使用しているため、グローバル変更は不可。`toggleable` value でオプトアウトする。
+
+## 5. データ設計
+
+なし（DB変更なし）
+
+### ER 図
+
+```mermaid
+erDiagram
+  profiles {
+    bigint id PK
+    bigint user_id FK "unique"
+    text bio
+  }
+  profile_hobbies {
+    bigint id PK
+    bigint profile_id FK
+    bigint hobby_id FK
+    string description
+  }
+  hobbies {
+    bigint id PK
+    string name "unique"
+    bigint parent_tag_id FK
+  }
+  profiles ||--o{ profile_hobbies : "has many"
+  hobbies ||--o{ profile_hobbies : "tagged in"
+```
+
+## 6. 画面・アクセス制御の流れ
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant T as tabs_controller
+    participant DOM as DOM
+
+    note over U,DOM: 修正前（#258）
+    U->>T: 自己紹介タブをクリック（2回目）
+    T->>DOM: deactivate() → 全パネル hidden
+    DOM-->>U: フォームが消える（UIが崩れた状態）
+
+    note over U,DOM: 修正後（#258）
+    U->>T: 自己紹介タブをクリック（2回目）
+    T->>T: toggleableValue === false → return
+    DOM-->>U: 変化なし（フォームは表示維持）
+```
+
+## 7. アプリケーション設計
+
+### tabs_controller.js の変更
+
+```js
+static values = {
+  defaultOpen: { type: Boolean, default: true },
+  toggleable: { type: Boolean, default: true }  // 追加
+}
+
+switch(event) {
+  const index = this.tabTargets.indexOf(event.currentTarget)
+  if (index === -1) return
+  if (this.activeIndex === index) {
+    if (this.toggleableValue) this.deactivate()  // toggleable な場合のみ閉じる
+    return
+  }
+  this.activate(index)
+}
+```
+
+### _form.html.erb の変更
+
+```html
+<div data-controller="tabs"
+     data-tabs-toggleable-value="false"
+     class="space-y-6">
+```
+
+### edit.html.erb の変更
+
+```html
+<%# flexの垂直中央寄せを無効にする（カードが上にずれる問題の修正） %>
+<% content_for :no_center, true %>
+
+<div class="w-full max-w-4xl space-y-6 mx-auto">
+```
+
+### new.html.erb の変更
+
+```html
+<% content_for :no_center, true %>
+
+<div class="w-full max-w-4xl mx-auto">
+```
+
+## 8. ルーティング設計
+
+なし
+
+## 9. レイアウト / UI 設計
+
+`content_for(:no_center)` 適用後のmain class:
+- **変更前:** `container mx-auto py-8 px-5 flex items-center justify-center`
+- **変更後:** `container mx-auto py-8 px-5`
+
+flexが外れることで水平中央寄せも解除されるため、カードwrapperに `mx-auto` を追加して水平中央寄せを維持する。
+
+## 10. クエリ・性能面
+
+なし（JSとCSSの修正のみ）
+
+## 11. トランザクション / Service 分離
+
+**トランザクション:** 不要
+**Service 分離:** 不要
+
+## 12. 実装対象一覧
+
+| # | 対象ファイル | 内容 |
+|---|---|---|
+| 1 | `app/javascript/controllers/tabs_controller.js` | `toggleable` value 追加、`switch()` を条件分岐 |
+| 2 | `app/views/my/profiles/_form.html.erb` | `data-tabs-toggleable-value="false"` 追加 |
+| 3 | `app/views/my/profiles/edit.html.erb` | `content_for(:no_center)` + `mx-auto` 追加 |
+| 4 | `app/views/my/profiles/new.html.erb` | 同上 |
+
+## 13. 受入条件
+
+- [ ] プロフィール編集画面でタグを追加・削除してもカードが上方向に動かない（下に伸びる）
+- [ ] タブを切り替えてもカードが上方向に動かない
+- [ ] 自己紹介タブを2回クリックしてもパネルが消えない
+- [ ] タグタブを2回クリックしてもパネルが消えない
+- [ ] プロフィール作成画面（new）でも同様に動作する
+- [ ] `rooms/members/show.html.erb` の折りたたみタブ動作が壊れていない
+
+## 14. この設計の結論
+
+`content_for(:no_center)` で垂直中央寄せを無効化し、`tabs_controller` に `toggleable` value を追加する2点の修正で、最小限の影響範囲に収める。どちらも既存パターンの活用であり、後方互換性を保つ。

--- a/spec/system/auth/login_spec.rb
+++ b/spec/system/auth/login_spec.rb
@@ -1,6 +1,35 @@
 require "rails_helper"
 
 RSpec.describe "ログイン画面", type: :system do
+  describe "ログイン後のリダイレクト" do
+    let(:password) { "password123" }
+
+    it "プロフィールあり：ログイン後にマイページへ遷移する" do
+      # プロフィール登録済みユーザーでログイン
+      current_user = create(:user, password: password)
+      create(:profile, user: current_user)
+
+      fill_in "user_email", with: current_user.email
+      fill_in "user_password", with: password
+      click_button "ログイン"
+
+      # マイページへ遷移することを確認
+      expect(page).to have_current_path(mypage_root_path)
+    end
+
+    it "プロフィールなし：ログイン後にプロフィール作成画面へ遷移する" do
+      # プロフィール未登録ユーザーでログイン
+      current_user = create(:user, password: password)
+
+      fill_in "user_email", with: current_user.email
+      fill_in "user_password", with: password
+      click_button "ログイン"
+
+      # プロフィール作成画面へ遷移することを確認
+      expect(page).to have_current_path(new_my_profile_path)
+    end
+  end
+
   before { visit new_user_session_path }
 
   it "「パスワードをお忘れですか？」リンクが表示される" do

--- a/spec/system/my/profile_tabs_spec.rb
+++ b/spec/system/my/profile_tabs_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe "プロフィール編集タブ", type: :system, js: true do
+  # プロフィール作成済みのユーザーを用意
+  let(:current_user) { create(:user) }
+  let!(:current_profile) { create(:profile, user: current_user) }
+
+  before do
+    # ログインしてプロフィール編集画面へ
+    login_as(current_user, scope: :user)
+    visit edit_my_profile_path
+  end
+
+  describe "自己紹介タブ" do
+    it "初期表示では自己紹介パネルが表示されている" do
+      # デフォルトで自己紹介タブがアクティブなので bio が見える
+      expect(page).to have_css("textarea[id='profile_bio']", visible: true)
+    end
+
+    it "アクティブな自己紹介タブを再クリックしてもbioパネルが消えない" do
+      # 自己紹介タブボタンを取得（最初のタブ）
+      bio_tab = find("[data-tabs-target='tab']", match: :first)
+
+      # すでにアクティブな自己紹介タブを再クリック
+      bio_tab.click
+
+      # bio textarea が visible のまま
+      expect(page).to have_css("textarea[id='profile_bio']", visible: true)
+    end
+  end
+
+  describe "タグタブ" do
+    it "タグタブを2回クリックしてもタグパネルが消えない" do
+      # タグタブ（2番目のタブ）をクリックしてアクティブにする
+      tag_tab = all("[data-tabs-target='tab']")[1]
+      tag_tab.click
+
+      # タグ入力欄が表示されることを確認
+      expect(page).to have_css("[data-testid='tag-input']", visible: true)
+
+      # もう一度タグタブをクリック
+      tag_tab.click
+
+      # タグ入力欄が消えない
+      expect(page).to have_css("[data-testid='tag-input']", visible: true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- #257 プロフィール編集ページのカードが上にずれる問題を修正（`content_for(:no_center)` で flex items-center を無効化）
- #258 タブを二重クリックするとパネルが消える問題を修正（`tabs_controller.js` に `toggleable` value を追加し、フォームは `toggleable=false` に設定）
- 新規タグ登録時に親タグ変更不可の赤文字メッセージを追加
- Googleログイン後にTOPページへ戻ってしまうバグを修正（TOPページを `stored_location` に保存しないよう `storable_location?` を修正）

## Test plan
- [x] RSpec 534件（+システムスペック追加分）全通過済み
- [x] RuboCop 違反なし
- [x] プロフィール編集ページで「説明を追加」ボタン押下時にカードがずれないことを目視確認
- [x] タブを二重クリックしてもフォームが消えないことを確認
- [x] TOPページからGoogleログインしてマイページへ遷移することを確認

## Related
- Closes #257
- Closes #258