### PR TITLE
feat: mypage/rooms をテーブル形式に変更し管理中・参加中を統合 #272

### DIFF
--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -6,7 +6,7 @@ module RoomsHelper
   }.freeze
 
   LOCK_STATUS_BADGES = {
-    true  => { label: "ロック中", color: "rgba(239, 68, 68, 0.15)",  border: "rgba(239, 68, 68, 0.3)",  text: "#fca5a5" },
+    true  => { label: "非公開",   color: "rgba(239, 68, 68, 0.15)",  border: "rgba(239, 68, 68, 0.3)",  text: "#fca5a5" },
     false => { label: "公開中",   color: "rgba(34, 197, 94, 0.15)",  border: "rgba(34, 197, 94, 0.3)",  text: "#86efac" }
   }.freeze
 

--- a/app/views/mypage/rooms/_form.html.erb
+++ b/app/views/mypage/rooms/_form.html.erb
@@ -1,56 +1,54 @@
-<%= turbo_frame_tag dom_id(room) do %>
-  <% link = room.share_link %>
+<% link = room.share_link %>
 
-  <div style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
-    <%= form_with model: room, url: mypage_room_path(room), method: :patch do |f| %>
+<div style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+  <%= form_with model: room, url: mypage_room_path(room), method: :patch, data: { turbo: false } do |f| %>
 
-      <%# 部屋名（編集） %>
-      <div style="margin-bottom: 0.75rem;">
-        <%= f.label :label, "部屋名", class: "sr-only" %>
-        <%= f.text_field :label,
-              placeholder: "名無しの部屋",
-              style: "width: 100%; max-width: 16rem; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
-      </div>
+    <%# 部屋名（編集） %>
+    <div style="margin-bottom: 0.75rem;">
+      <%= f.label :label, "部屋名", class: "sr-only" %>
+      <%= f.text_field :label,
+            placeholder: "名無しの部屋",
+            style: "width: 100%; max-width: 16rem; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+    </div>
 
-      <% if link.present? %>
-        <p style="font-size: 0.875rem; color: #6b7280; word-break: break-all; margin-bottom: 0.5rem;">
-          共有URL:<br>
-          <%= link_to share_url(link.token),
-                      share_path(link.token),
-                      target: "_blank",
-                      style: "color: #60a5fa; text-decoration: none;" %>
-        </p>
-
-        <p style="font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.5rem;">
-          有効期限:
-          <%= link.expires_at.in_time_zone.strftime("%Y/%m/%d %H:%M") if link.expires_at.present? %>
-
-          <% if link.expired? %>
-            <span style="margin-left: 0.5rem; display: inline-block; background: rgba(239, 68, 68, 0.15); color: #fca5a5; font-size: 0.75rem; padding: 0.125rem 0.5rem; border-radius: 9999px;">
-              期限切れ
-            </span>
-          <% elsif link.expires_at.present? %>
-            <span style="margin-left: 0.5rem; display: inline-block; background: rgba(34, 197, 94, 0.15); color: #86efac; font-size: 0.75rem; padding: 0.125rem 0.5rem; border-radius: 9999px;">
-              有効
-            </span>
-          <% end %>
-        </p>
-      <% end %>
-
-      <p style="font-size: 0.875rem; color: #6b7280; margin-bottom: 1rem;">
-        参加人数: <%= room.room_memberships.size %> 人
+    <% if link.present? %>
+      <p style="font-size: 0.875rem; color: #6b7280; word-break: break-all; margin-bottom: 0.5rem;">
+        共有URL:<br>
+        <%= link_to share_url(link.token),
+                    share_path(link.token),
+                    target: "_blank",
+                    style: "color: #60a5fa; text-decoration: none;" %>
       </p>
 
-      <div style="display: flex; justify-content: space-between; font-size: 0.875rem;">
-        <span></span>
-        <div style="display: flex; gap: 1rem;">
-          <%= f.submit "更新", style: "color: #60a5fa; background: none; border: none; cursor: pointer; font-size: 0.875rem;" %>
-          <%= link_to "キャンセル",
-                      mypage_rooms_path,
-                      style: "color: #6b7280; text-decoration: none;" %>
-        </div>
-      </div>
+      <p style="font-size: 0.875rem; color: #d1d5db; margin-bottom: 0.5rem;">
+        有効期限:
+        <%= link.expires_at.in_time_zone.strftime("%Y/%m/%d %H:%M") if link.expires_at.present? %>
 
+        <% if link.expired? %>
+          <span style="margin-left: 0.5rem; display: inline-block; background: rgba(239, 68, 68, 0.15); color: #fca5a5; font-size: 0.75rem; padding: 0.125rem 0.5rem; border-radius: 9999px;">
+            期限切れ
+          </span>
+        <% elsif link.expires_at.present? %>
+          <span style="margin-left: 0.5rem; display: inline-block; background: rgba(34, 197, 94, 0.15); color: #86efac; font-size: 0.75rem; padding: 0.125rem 0.5rem; border-radius: 9999px;">
+            有効
+          </span>
+        <% end %>
+      </p>
     <% end %>
-  </div>
-<% end %>
+
+    <p style="font-size: 0.875rem; color: #6b7280; margin-bottom: 1rem;">
+      参加人数: <%= room.room_memberships.size %> 人
+    </p>
+
+    <div style="display: flex; justify-content: space-between; font-size: 0.875rem;">
+      <span></span>
+      <div style="display: flex; gap: 1rem;">
+        <%= f.submit "更新", style: "color: #60a5fa; background: none; border: none; cursor: pointer; font-size: 0.875rem;" %>
+        <%= link_to "キャンセル",
+                    mypage_rooms_path,
+                    style: "color: #6b7280; text-decoration: none;" %>
+      </div>
+    </div>
+
+  <% end %>
+</div>

--- a/app/views/mypage/rooms/_joined_room.html.erb
+++ b/app/views/mypage/rooms/_joined_room.html.erb
@@ -1,47 +1,56 @@
 <% room = membership.room %>
-<% issuer = room.issuer_profile&.user %>
 <% link = room.share_link %>
 <% badge = room_type_badge(room.room_type) %>
 
-<div id="<%= dom_id(membership) %>" style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); display: flex; flex-direction: column;">
-  <%# 部屋タイプバッジ %>
-  <% if badge %>
-    <span style="display: inline-block; align-self: flex-start; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; margin-bottom: 0.5rem; background: <%= badge[:color] %>; border: 1px solid <%= badge[:border] %>; color: <%= badge[:text] %>;">
-      <%= badge[:label] %>
-    </span>
-  <% end %>
+<tr id="<%= dom_id(membership) %>" style="border-bottom: 1px solid rgba(55, 65, 81, 0.3);">
 
   <%# 部屋名 %>
-  <h3 style="font-size: 1.125rem; font-weight: 600; color: #ffffff; margin-bottom: 0.75rem;">
+  <td style="padding: 0.875rem 1rem; color: #ffffff; font-weight: 600; white-space: nowrap;">
     <%= room.label.presence || "名無しの部屋" %>
-  </h3>
+  </td>
 
-  <%# 作成者 %>
-  <% if issuer %>
-    <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem;">
-      <%= avatar_image_tag(issuer, size: :small) %>
-      <span style="font-size: 0.875rem; color: #d1d5db;"><%= issuer.nickname %></span>
-    </div>
-  <% end %>
+  <%# タイプバッジ %>
+  <td style="padding: 0.875rem 1rem; white-space: nowrap;">
+    <% if badge %>
+      <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: <%= badge[:color] %>; border: 1px solid <%= badge[:border] %>; color: <%= badge[:text] %>;">
+        <%= badge[:label] %>
+      </span>
+    <% end %>
+  </td>
+
+  <%# 役割バッジ：参加者 %>
+  <td style="padding: 0.875rem 1rem; white-space: nowrap;">
+    <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: rgba(75, 85, 99, 0.3); border: 1px solid rgba(107, 114, 128, 0.4); color: #9ca3af;">
+      参加中
+    </span>
+  </td>
+
+  <%# ロック（参加者は表示なし） %>
+  <td style="padding: 0.875rem 1rem; color: #6b7280;">―</td>
+
+  <%# リンク（参加者は表示なし） %>
+  <td style="padding: 0.875rem 1rem; color: #6b7280;">―</td>
 
   <%# 参加人数 %>
-  <p style="font-size: 0.875rem; color: #6b7280; margin-bottom: 1rem;">
-    参加人数: <%= room.room_memberships.size %> 人
-  </p>
+  <td style="padding: 0.875rem 1rem; color: #9ca3af; white-space: nowrap;">
+    <%= room.room_memberships.length %> 人
+  </td>
 
   <%# 操作 %>
-  <div style="display: flex; justify-content: flex-end; align-items: center; gap: 1rem; font-size: 0.875rem; width: 100%; margin-top: auto;">
-    <% if link.present? %>
-      <%= link_to "部屋を見る",
-                  share_path(link.token),
-                  target: "_blank",
-                  style: "color: #a78bfa; text-decoration: none;" %>
-    <% end %>
+  <td style="padding: 0.875rem 1rem; white-space: nowrap;">
+    <div style="display: flex; align-items: center; gap: 0.5rem;">
+      <% if link.present? %>
+        <%= link_to "部屋を見る",
+                    share_path(link.token),
+                    target: "_blank",
+                    style: "display: inline-flex; align-items: center; padding: 0.25rem 0.75rem; border-radius: 0.375rem; border: 1px solid rgba(167,139,250,0.4); color: #c4b5fd; font-size: 0.875rem; text-decoration: none;" %>
+      <% end %>
 
-    <%= button_to "退出",
-                  mypage_room_membership_path(membership),
-                  method: :delete,
-                  data: { turbo_confirm: "本当に退出しますか？" },
-                  style: "padding: 0.25rem 0.75rem; border-radius: 0.375rem; background: rgba(239, 68, 68, 0.15); border: 1px solid rgba(239, 68, 68, 0.3); color: #fca5a5; font-size: 0.875rem; cursor: pointer;" %>
-  </div>
-</div>
+      <%= button_to "退出",
+                    mypage_room_membership_path(membership),
+                    method: :delete,
+                    data: { turbo_confirm: "本当に退出しますか？" },
+                    style: "padding: 0.375rem 0.75rem; border-radius: 0.375rem; background: rgba(239, 68, 68, 0.15); border: 1px solid rgba(239, 68, 68, 0.3); color: #fca5a5; font-size: 0.8125rem; cursor: pointer;" %>
+    </div>
+  </td>
+</tr>

--- a/app/views/mypage/rooms/_room.html.erb
+++ b/app/views/mypage/rooms/_room.html.erb
@@ -1,48 +1,87 @@
 <% badge = room_type_badge(room.room_type) %>
 <% lock_badge = lock_status_badge(room) %>
 
-<%= turbo_frame_tag dom_id(room) do %>
-  <div style="padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); display: flex; flex-direction: column; gap: 1rem; min-height: 100%;">
+<tr id="<%= dom_id(room) %>" style="border-bottom: 1px solid rgba(55, 65, 81, 0.3);">
 
-    <%# ヘッダー：部屋名 + バッジ + ︙メニュー %>
-    <div style="display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem;">
-      <div style="min-width: 0; flex: 1;">
-        <h3 style="font-size: 1.125rem; font-weight: 600; color: #ffffff; margin: 0 0 0.5rem 0;">
-          <%= room.label.presence || "名無しの部屋" %>
-        </h3>
+  <%# 部屋名 %>
+  <td style="padding: 0.875rem 1rem; color: #ffffff; font-weight: 600; white-space: nowrap;">
+    <%= room.label.presence || "名無しの部屋" %>
+  </td>
 
-        <%# バッジ横並び %>
-        <div style="display: flex; flex-wrap: wrap; gap: 0.5rem;">
-          <% if badge %>
-            <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: <%= badge[:color] %>; border: 1px solid <%= badge[:border] %>; color: <%= badge[:text] %>;">
-              <%= badge[:label] %>
-            </span>
-          <% end %>
+  <%# タイプバッジ %>
+  <td style="padding: 0.875rem 1rem; white-space: nowrap;">
+    <% if badge %>
+      <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: <%= badge[:color] %>; border: 1px solid <%= badge[:border] %>; color: <%= badge[:text] %>;">
+        <%= badge[:label] %>
+      </span>
+    <% end %>
+  </td>
 
-          <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: <%= lock_badge[:color] %>; border: 1px solid <%= lock_badge[:border] %>; color: <%= lock_badge[:text] %>;">
-            <%= lock_badge[:label] %>
+  <%# 役割バッジ：管理者 %>
+  <td style="padding: 0.875rem 1rem; white-space: nowrap;">
+    <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: rgba(37, 99, 235, 0.2); border: 1px solid rgba(96, 165, 250, 0.4); color: #93c5fd;">
+      管理中
+    </span>
+  </td>
+
+  <%# ロック状態 %>
+  <td style="padding: 0.875rem 1rem; white-space: nowrap;">
+    <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: <%= lock_badge[:color] %>; border: 1px solid <%= lock_badge[:border] %>; color: <%= lock_badge[:text] %>;">
+      <%= lock_badge[:label] %>
+    </span>
+  </td>
+
+  <%# リンク状態 + Copyボタン %>
+  <td style="padding: 0.875rem 1rem; white-space: nowrap;">
+    <% if link.present? %>
+      <% if link.expired? %>
+        <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: rgba(239, 68, 68, 0.15); border: 1px solid rgba(239, 68, 68, 0.3); color: #fca5a5;">
+          期限切れ
+        </span>
+      <% else %>
+        <div style="display: flex; align-items: center; gap: 0.5rem;" data-controller="clipboard" data-clipboard-text-value="<%= share_url(link.token) %>">
+          <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: rgba(34, 197, 94, 0.15); border: 1px solid rgba(34, 197, 94, 0.3); color: #86efac;">
+            有効
           </span>
-
-          <% if link.present? %>
-            <% if link.expired? %>
-              <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: rgba(239, 68, 68, 0.15); border: 1px solid rgba(239, 68, 68, 0.3); color: #fca5a5;">
-                期限切れ
-              </span>
-            <% else %>
-              <span style="display: inline-flex; align-items: center; padding: 0.125rem 0.625rem; border-radius: 9999px; font-size: 0.75rem; font-weight: 500; background: rgba(34, 197, 94, 0.15); border: 1px solid rgba(34, 197, 94, 0.3); color: #86efac;">
-                有効
-              </span>
-            <% end %>
-          <% end %>
+          <button type="button"
+                  data-clipboard-target="button"
+                  data-action="click->clipboard#copy"
+                  style="display: inline-flex; align-items: center; padding: 0.25rem 0.5rem; font-size: 0.75rem; color: #60a5fa; background: rgba(96, 165, 250, 0.1); border: 1px solid rgba(96, 165, 250, 0.3); border-radius: 0.375rem; cursor: pointer;">
+            Copy
+          </button>
         </div>
-      </div>
+      <% end %>
+    <% else %>
+      <span style="color: #6b7280;">―</span>
+    <% end %>
+  </td>
 
-      <%# ︙メニュー %>
-      <div data-controller="dropdown" style="position: relative; flex-shrink: 0;">
+  <%# 参加人数 %>
+  <td style="padding: 0.875rem 1rem; color: #9ca3af; white-space: nowrap;">
+    <%= room.room_memberships.length %> 人
+  </td>
+
+  <%# 操作 %>
+  <td style="padding: 0.875rem 1rem; white-space: nowrap;">
+    <div style="display: flex; align-items: center; gap: 0.5rem;">
+      <% if link.present? %>
+        <%= link_to "部屋を見る",
+                    share_path(link.token),
+                    target: "_blank",
+                    style: "display: inline-flex; align-items: center; padding: 0.25rem 0.75rem; border-radius: 0.375rem; border: 1px solid rgba(167,139,250,0.4); color: #c4b5fd; font-size: 0.875rem; text-decoration: none;" %>
+      <% end %>
+
+      <%= link_to "編集",
+                  edit_mypage_room_path(room),
+                  data: { turbo_frame: "_top" },
+                  style: "display: inline-flex; align-items: center; padding: 0.375rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(55, 65, 81, 0.5); color: #d1d5db; text-decoration: none; font-size: 0.8125rem;" %>
+
+      <%# ドロップダウンメニュー %>
+      <div data-controller="dropdown" style="position: relative;">
         <button
           type="button"
           data-action="click->dropdown#toggle"
-          style="display: inline-flex; align-items: center; justify-content: center; width: 2.25rem; height: 2.25rem; border-radius: 0.5rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(55, 65, 81, 0.5); color: #d1d5db; cursor: pointer;"
+          style="display: inline-flex; align-items: center; justify-content: center; width: 2rem; height: 2rem; border-radius: 0.375rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(55, 65, 81, 0.5); color: #d1d5db; cursor: pointer;"
           aria-label="その他の操作"
         >
           &#8942;
@@ -51,80 +90,33 @@
         <div
           data-dropdown-target="menu"
           class="hidden"
-          style="position: absolute; top: calc(100% + 0.5rem); right: 0; z-index: 10; min-width: 11rem; padding: 0.5rem; border-radius: 0.75rem; background: #111827; border: 1px solid rgba(55, 65, 81, 0.6); box-shadow: 0 10px 24px rgba(0,0,0,0.35);"
+          style="position: absolute; top: calc(100% + 0.25rem); right: 0; z-index: 10; min-width: 10rem; padding: 0.5rem; border-radius: 0.75rem; background: #111827; border: 1px solid rgba(55, 65, 81, 0.6); box-shadow: 0 10px 24px rgba(0,0,0,0.35);"
         >
           <% if link.present? %>
             <%= link_to "再発行",
                         regenerate_share_link_mypage_room_path(room),
                         data: { turbo_method: :patch, turbo_confirm: "招待リンクを再発行しますか？古いURLは無効になります。" },
-                        style: "display: block; width: fit-content; padding: 0.5rem 0.75rem; border-radius: 0.5rem; color: #fbbf24; text-decoration: none; font-size: 0.875rem;" %>
+                        style: "display: block; padding: 0.5rem 0.75rem; border-radius: 0.5rem; color: #fbbf24; text-decoration: none; font-size: 0.875rem;" %>
           <% end %>
 
           <% if room.locked? %>
             <%= link_to "解除する",
                         unlock_mypage_room_path(room),
                         data: { turbo_method: :patch, turbo_confirm: "この部屋のロックを解除しますか？" },
-                        style: "display: block; width: fit-content; padding: 0.5rem 0.75rem; border-radius: 0.5rem; color: #86efac; text-decoration: none; font-size: 0.875rem;" %>
+                        style: "display: block; padding: 0.5rem 0.75rem; border-radius: 0.5rem; color: #86efac; text-decoration: none; font-size: 0.875rem;" %>
           <% else %>
             <%= link_to "ロックする",
                         lock_mypage_room_path(room),
                         data: { turbo_method: :patch, turbo_confirm: "この部屋をロックしますか？" },
-                        style: "display: block; width: fit-content; padding: 0.5rem 0.75rem; border-radius: 0.5rem; color: #fca5a5; text-decoration: none; font-size: 0.875rem;" %>
+                        style: "display: block; padding: 0.5rem 0.75rem; border-radius: 0.5rem; color: #fca5a5; text-decoration: none; font-size: 0.875rem;" %>
           <% end %>
 
           <%= link_to "削除",
                       mypage_room_path(room),
                       data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
-                      style: "display: block; width: fit-content; padding: 0.5rem 0.75rem; border-radius: 0.5rem; color: #ef4444; text-decoration: none; font-size: 0.875rem;" %>
+                      style: "display: block; padding: 0.5rem 0.75rem; border-radius: 0.5rem; color: #ef4444; text-decoration: none; font-size: 0.875rem;" %>
         </div>
       </div>
     </div>
-
-    <%# メタ情報：人数・有効期限 %>
-    <div style="display: flex; flex-wrap: wrap; gap: 1rem; font-size: 0.875rem; color: #9ca3af;">
-      <p style="margin: 0;">参加人数: <%= room.room_memberships.size %> 人</p>
-
-      <% if link.present? && link.expires_at.present? %>
-        <p style="margin: 0;">
-          有効期限: <%= link.expires_at.in_time_zone.strftime("%Y/%m/%d %H:%M") %>
-        </p>
-      <% end %>
-    </div>
-
-    <%# 主操作：部屋を見る / 編集 %>
-    <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem; margin-top: auto;">
-      <% if link.present? %>
-        <%= link_to "部屋を見る",
-                    share_path(link.token),
-                    target: "_blank",
-                    style: "display: inline-flex; align-items: center; justify-content: center; padding: 0.5rem 1rem; border-radius: 0.5rem; background: linear-gradient(135deg, #8b5cf6, #7c3aed); color: #ffffff; text-decoration: none; font-size: 0.875rem; font-weight: 600;" %>
-      <% end %>
-
-      <%= link_to "編集",
-                  edit_mypage_room_path(room),
-                  data: { turbo_frame: dom_id(room) },
-                  style: "display: inline-flex; align-items: center; justify-content: center; padding: 0.5rem 1rem; border-radius: 0.5rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(55, 65, 81, 0.5); color: #d1d5db; text-decoration: none; font-size: 0.875rem; font-weight: 500;" %>
-    </div>
-
-    <%# 共有リンク：下段・省略表示 %>
-    <% if link.present? %>
-      <div data-controller="clipboard" data-clipboard-text-value="<%= share_url(link.token) %>" style="padding-top: 0.75rem; border-top: 1px solid rgba(55, 65, 81, 0.35);">
-        <div style="display: flex; justify-content: space-between; align-items: center; gap: 0.75rem;">
-          <div style="min-width: 0;">
-            <p style="margin: 0 0 0.25rem 0; font-size: 0.75rem; color: #6b7280;">共有リンク</p>
-            <p style="margin: 0; font-size: 0.8125rem; color: #9ca3af; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 18rem;">
-              <%= share_url(link.token) %>
-            </p>
-          </div>
-
-          <button type="button"
-                  data-clipboard-target="button"
-                  data-action="click->clipboard#copy"
-                  style="display: inline-flex; align-items: center; padding: 0.375rem 0.75rem; font-size: 0.75rem; font-weight: 500; color: #60a5fa; background: rgba(96, 165, 250, 0.1); border: 1px solid rgba(96, 165, 250, 0.3); border-radius: 0.375rem; cursor: pointer; flex-shrink: 0;">
-            Copy
-          </button>
-        </div>
-      </div>
-    <% end %>
-  </div>
-<% end %>
+  </td>
+</tr>

--- a/app/views/mypage/rooms/create.turbo_stream.erb
+++ b/app/views/mypage/rooms/create.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.prepend "rooms_list" do %>
+<%= turbo_stream.prepend "rooms_tbody" do %>
   <%= render "mypage/rooms/room", room: @room, link: @room.share_link %>
 <% end %>
 

--- a/app/views/mypage/rooms/edit.html.erb
+++ b/app/views/mypage/rooms/edit.html.erb
@@ -1,1 +1,7 @@
-<%= render "form", room: @room %>
+<div style="max-width: 36rem; margin: 0 auto; padding: 2.5rem 1.5rem;">
+  <h1 style="font-size: 1.5rem; font-weight: 700; color: #ffffff; margin-bottom: 1.5rem;">部屋を編集</h1>
+  <%= render "form", room: @room %>
+  <div style="margin-top: 1rem;">
+    <%= link_to "部屋管理に戻る", mypage_rooms_path, style: "font-size: 0.875rem; color: #6b7280; text-decoration: none;" %>
+  </div>
+</div>

--- a/app/views/mypage/rooms/index.html.erb
+++ b/app/views/mypage/rooms/index.html.erb
@@ -17,7 +17,7 @@
     <div data-toggle-target="content" style="max-width: 28rem; padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); margin-top: 1rem;">
       <h2 style="font-size: 1.125rem; font-weight: 600; color: #ffffff; margin-bottom: 1rem;">新しい部屋を作成</h2>
 
-      <% room = @new_room || Room.new %>
+      <% room = @new_room %>
       <%= form_with model: room, url: mypage_rooms_path do |f| %>
         <% if room.errors.any? %>
           <div style="margin-bottom: 1rem; border-radius: 0.5rem; border: 1px solid rgba(239, 68, 68, 0.3); background: rgba(239, 68, 68, 0.1); padding: 0.75rem 1rem; color: #fca5a5; font-size: 0.875rem;">
@@ -63,38 +63,41 @@
     </div>
   </div>
 
-  <%# 作成済みの部屋 %>
-  <section style="margin-bottom: 3rem; min-height: 24rem;">
-    <h2 style="font-size: 1.25rem; font-weight: 600; color: #ffffff; margin-bottom: 0.25rem;">管理中の部屋</h2>
-    <p style="font-size: 0.8125rem; color: #6b7280; margin-bottom: 1rem;">自分が作成・管理する部屋です。編集や削除ができます。</p>
-    <%# rooms_list は常に DOM に存在させる（create.turbo_stream.erb の prepend 先） %>
-    <div id="rooms_list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-      <% if @rooms.empty? %>
-        <p style="color: #6b7280; font-size: 0.875rem; grid-column: 1 / -1;">
-          まだ部屋を作成していません。上のフォームから部屋を作成してみましょう。
-        </p>
-      <% else %>
-        <% @rooms.each do |room| %>
-          <%= render "mypage/rooms/room", room: room, link: room.share_link %>
-        <% end %>
-      <% end %>
-    </div>
-  </section>
+  <%# 部屋一覧テーブル %>
+  <section style="margin-bottom: 3rem;">
+    <h2 style="font-size: 1.25rem; font-weight: 600; color: #ffffff; margin-bottom: 0.25rem;">部屋一覧</h2>
+    <p style="font-size: 0.8125rem; color: #6b7280; margin-bottom: 1rem;">管理中・参加中の部屋をまとめて表示します。</p>
 
-  <%# 参加中の部屋 %>
-  <section style="min-height: 24rem;">
-    <h2 style="font-size: 1.25rem; font-weight: 600; color: #ffffff; margin-bottom: 0.25rem;">参加中の部屋</h2>
-    <p style="font-size: 0.8125rem; color: #6b7280; margin-bottom: 1rem;">他のユーザーが作成した部屋に参加しています。退出できます。</p>
-    <div id="memberships_list" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-      <% if @memberships.empty? %>
-        <p style="color: #6b7280; font-size: 0.875rem; grid-column: 1 / -1;">
-          参加中の部屋はありません。招待URLから部屋に参加できます。
-        </p>
-      <% else %>
-        <% @memberships.each do |membership| %>
-          <%= render "mypage/rooms/joined_room", membership: membership %>
-        <% end %>
-      <% end %>
+    <div style="overflow-x: auto;">
+      <table style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
+        <thead>
+          <tr style="border-bottom: 1px solid rgba(55, 65, 81, 0.5);">
+            <th style="padding: 0.75rem 1rem; text-align: left; color: #9ca3af; font-weight: 500; white-space: nowrap;">部屋名</th>
+            <th style="padding: 0.75rem 1rem; text-align: left; color: #9ca3af; font-weight: 500; white-space: nowrap;">タイプ</th>
+            <th style="padding: 0.75rem 1rem; text-align: left; color: #9ca3af; font-weight: 500; white-space: nowrap;">状態</th>
+            <th style="padding: 0.75rem 1rem; text-align: left; color: #9ca3af; font-weight: 500; white-space: nowrap;">公開設定</th>
+            <th style="padding: 0.75rem 1rem; text-align: left; color: #9ca3af; font-weight: 500; white-space: nowrap;">リンク</th>
+            <th style="padding: 0.75rem 1rem; text-align: left; color: #9ca3af; font-weight: 500; white-space: nowrap;">人数</th>
+            <th style="padding: 0.75rem 1rem; text-align: left; color: #9ca3af; font-weight: 500; white-space: nowrap;">操作</th>
+          </tr>
+        </thead>
+        <tbody id="rooms_tbody">
+          <% if @rooms.empty? && @memberships.empty? %>
+            <tr>
+              <td colspan="7" style="padding: 2rem 1rem; color: #6b7280; text-align: center;">
+                まだ部屋がありません。上のフォームから部屋を作成してみましょう。
+              </td>
+            </tr>
+          <% else %>
+            <% @rooms.each do |room| %>
+              <%= render "mypage/rooms/room", room: room, link: room.share_link %>
+            <% end %>
+            <% @memberships.each do |membership| %>
+              <%= render "mypage/rooms/joined_room", membership: membership %>
+            <% end %>
+          <% end %>
+        </tbody>
+      </table>
     </div>
   </section>
 

--- a/docs/designs/2026-04-23-rooms-table-layout.md
+++ b/docs/designs/2026-04-23-rooms-table-layout.md
@@ -1,0 +1,156 @@
+# mypage/rooms テーブルレイアウト統合 設計書
+
+**日付:** 2026-04-23
+**Issue:** #TBD
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+
+- `mypage/rooms` の「管理中の部屋」「参加中の部屋」を1本のテーブルに統合
+- カードグリッド → テーブル行（`<tr>`）へ切り替え
+- 既存の Turbo Stream を新しい行パーシャルに対応させる
+
+## 2. 目的
+
+一覧性の向上と、複数部屋を管理する際の視認性改善
+
+## 3. スコープ
+
+### 含むもの
+- `index.html.erb` のレイアウト変更（グリッド → テーブル）
+- `_room.html.erb`・`_joined_room.html.erb` のパーシャル変更（`<div>` → `<tr>`）
+- Turbo Stream 系テンプレートの対応修正
+- 編集をフルページナビゲーションに変更
+
+### 含まないもの
+- DB変更・マイグレーション（なし）
+- ソート・フィルタ機能（将来対応）
+- モバイル対応の別表示（今回はテーブルのまま、スクロール対応のみ）
+
+## 4. 設計方針
+
+**turbo_frame をテーブル行に使えない問題：**
+
+`<turbo-frame>` を `<tbody>` の直接の子要素にすると HTML が不正になります。
+
+| 方式 | 実装コスト | UX |
+|---|---|---|
+| A: turbo_frame を行に残す（不正HTML） | 低 | 動くが壊れやすい |
+| B: turbo_frame を外し Turbo Drive でフルページ遷移 | 低 | シンプル・安定 |
+| C: モーダルで編集 | 高 | リッチだが過剰 |
+
+**採用: B案** — 編集リンクに `data: { turbo_frame: "_top" }` を付与してフルページ遷移。ロック/アンロック/再発行は `turbo_stream.replace` で `<tr>` を差し替え。
+
+## 5. データ設計
+
+変更なし（DB・モデル変更不要）
+
+## 6. 画面・アクセス制御の流れ
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as Mypage::RoomsController
+    participant V as View
+
+    U->>C: GET /mypage/rooms
+    C->>C: @rooms = issued_rooms (includes share_link, memberships)
+    C->>C: @memberships = joined rooms (excludes self-issued)
+    C->>V: index.html.erb
+
+    note over V: 1本のテーブルに @rooms + @memberships を描画
+    V-->>U: 管理者行 + 参加者行 混在テーブル
+
+    U->>C: PATCH /mypage/rooms/:id/lock
+    C->>V: lock.turbo_stream.erb
+    V-->>U: turbo_stream.replace → <tr> 行を差し替え
+```
+
+## 7. アプリケーション設計
+
+**コントローラ変更なし** — `@rooms`・`@memberships` はそのまま。ビューで1テーブルに統合。
+
+**パーシャル変更：**
+
+`_room.html.erb`（管理者行）:
+```html
+<tr id="<%= dom_id(room) %>">
+  <td>部屋名</td>
+  <td>タイプバッジ</td>
+  <td>管理者バッジ</td>
+  <td>ロック状態</td>
+  <td>リンク状態 + Copyボタン</td>
+  <td>参加人数</td>
+  <td>部屋を見る | 編集 | ドロップダウン（再発行/ロック/削除）</td>
+</tr>
+```
+
+`_joined_room.html.erb`（参加者行）:
+```html
+<tr id="<%= dom_id(membership) %>">
+  <td>部屋名</td>
+  <td>タイプバッジ</td>
+  <td>参加者バッジ</td>
+  <td>―</td>
+  <td>―</td>
+  <td>参加人数</td>
+  <td>部屋を見る | 退出</td>
+</tr>
+```
+
+**テーブルヘッダー:** 部屋名 | タイプ | 役割 | ロック | リンク | 人数 | 操作
+
+## 8. ルーティング設計
+
+変更なし
+
+## 9. レイアウト / UI 設計
+
+- テーブル外側に `overflow-x: auto` でスマホスクロール対応
+- 行の背景は `hover` でわずかにハイライト（既存ダークテーマに合わせて `rgba(255,255,255,0.03)`）
+- 役割バッジ：管理者 = 青系、参加者 = グレー系
+- Copyボタンはリンク列セル内に小さく配置
+
+## 10. クエリ・性能面
+
+**N+1対策**（現状のまま継続）:
+- `@rooms`: `.includes(:share_link, :room_memberships)`
+- `@memberships`: `.includes(room: [{ issuer_profile: :user }, :room_memberships, :share_link])`
+
+変更なし。追加インデックス不要。
+
+## 11. トランザクション / Service 分離
+
+- トランザクション: 不要（UIのみの変更）
+- Service分離: 不要
+
+## 12. 実装対象一覧
+
+| # | 対象 | 内容 |
+|---|---|---|
+| 1 | `index.html.erb` | グリッド2段 → 統合テーブル1本 |
+| 2 | `_room.html.erb` | カード div → `<tr>` 行（turbo_frame削除） |
+| 3 | `_joined_room.html.erb` | カード div → `<tr>` 行 |
+| 4 | `create.turbo_stream.erb` | prepend先を `rooms_tbody` に変更 |
+| 5 | `destroy.turbo_stream.erb` | 変更なし（dom_id targeting 継続） |
+| 6 | `lock/unlock/regenerate_share_link.turbo_stream.erb` | `_room` の新 `<tr>` パーシャルを参照 |
+| 7 | `update.turbo_stream.erb` | 同上 |
+| 8 | `edit.html.erb` | ページラッパー追加（フルページ遷移対応） |
+| 9 | `room_memberships/destroy.turbo_stream.erb` | 変更なし |
+
+## 13. 受入条件
+
+- [ ] `mypage/rooms` にアクセスすると管理中・参加中の部屋が1本のテーブルで表示される
+- [ ] 「役割」列で管理者・参加者が区別できる
+- [ ] 管理者行：編集・ロック・削除・リンク再発行が動作する
+- [ ] 参加者行：退出が動作する
+- [ ] 部屋作成後、Turbo Stream で新行がテーブル先頭に追加される
+- [ ] ロック/アンロック/再発行後、該当行が Turbo Stream で差し替えられる
+- [ ] 部屋削除・退出後、該当行が Turbo Stream で削除される
+- [ ] RSpec 全通過・RuboCop 全通過
+
+## 14. この設計の結論
+
+DB変更なし・UIのみの変更。`<turbo-frame>` をテーブルから除去し、行単位の `turbo_stream.replace` で動的更新を維持する。編集はフルページナビゲーションに切り替えてシンプルに保つ。

--- a/spec/requests/mypage/rooms_spec.rb
+++ b/spec/requests/mypage/rooms_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Mypage::Rooms", type: :request do
         expect(response.body).to include("公開中")
       end
 
-      it "ロック中の部屋に「ロック中」バッジが表示される" do
+      it "ロック中の部屋に「非公開」バッジが表示される" do
         # ロック中の部屋を準備
         current_user = create(:user)
         current_profile = create(:profile, user: current_user)
@@ -50,8 +50,8 @@ RSpec.describe "Mypage::Rooms", type: :request do
 
         get mypage_rooms_path
 
-        # 「ロック中」バッジが表示されること
-        expect(response.body).to include("ロック中")
+        # 「非公開」バッジが表示されること
+        expect(response.body).to include("非公開")
       end
 
       it "他人の部屋は表示されない" do

--- a/spec/system/mypage/rooms_table_spec.rb
+++ b/spec/system/mypage/rooms_table_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "mypage/rooms テーブル表示", type: :system, js: true do
+  # セットアップ
+  let(:current_user) { create(:user) }
+  let!(:current_profile) { create(:profile, user: current_user) }
+  let!(:owner_profile) { create(:profile) }
+  let!(:own_room) { create(:room, issuer_profile: current_profile, label: "管理中の部屋", locked: false) }
+  let!(:other_room) { create(:room, issuer_profile: owner_profile, label: "参加中の部屋") }
+  let!(:own_membership) { create(:room_membership, room: own_room, profile: current_profile) }
+  let!(:joined_membership) { create(:room_membership, room: other_room, profile: current_profile) }
+
+  before do
+    create(:share_link, room: own_room)
+    login_as(current_user, scope: :user)
+    visit mypage_rooms_path
+  end
+
+  # アサーション：テーブルが存在する
+  it "テーブルが表示される" do
+    expect(page).to have_css("table")
+  end
+
+  # アサーション：管理中の部屋がテーブルのセルに表示される
+  it "管理中の部屋がテーブルに表示される" do
+    expect(page).to have_css("table td", text: "管理中の部屋")
+  end
+
+  # アサーション：参加中の部屋が同じテーブルのセルに表示される
+  it "参加中の部屋が同じテーブルに表示される" do
+    expect(page).to have_css("table td", text: "参加中の部屋")
+  end
+
+  # アサーション：管理中バッジが管理者行に表示される
+  it "管理中バッジが表示される" do
+    within("tr##{ActionView::RecordIdentifier.dom_id(own_room)}") do
+      expect(page).to have_text("管理中")
+    end
+  end
+
+  # アサーション：参加中バッジが参加者行に表示される
+  it "参加中バッジが表示される" do
+    within("tr##{ActionView::RecordIdentifier.dom_id(joined_membership)}") do
+      expect(page).to have_text("参加中")
+    end
+  end
+
+  # アサーション：管理者行に編集リンクがある
+  it "管理者行に編集リンクがある" do
+    within("tr##{ActionView::RecordIdentifier.dom_id(own_room)}") do
+      expect(page).to have_link("編集")
+    end
+  end
+
+  # アサーション：参加者行に退出ボタンがある
+  it "参加者行に退出ボタンがある" do
+    within("tr##{ActionView::RecordIdentifier.dom_id(joined_membership)}") do
+      expect(page).to have_button("退出")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- mypage/rooms のカードグリッドレイアウトをテーブル形式に変更
- 「管理中の部屋」と「参加中の部屋」を1つのテーブルに統合
- 列構成: 部屋名 / タイプ / 状態（管理中・参加中バッジ）/ 公開設定 / リンク / 人数 / 操作
- 編集フォームの turbo_frame を削除し `data: { turbo: false }` でフルページリダイレクトに変更
- `ロック中` ラベルを `非公開` に変更

## Test plan
- [x] テーブルが表示されること（`spec/system/mypage/rooms_table_spec.rb`）
- [x] 管理中の部屋が「管理中」バッジで表示されること
- [x] 参加中の部屋が「参加中」バッジで表示されること
- [x] 編集リンクがフルページ遷移で動作すること
- [x] 退出ボタンが動作すること
- [x] request spec: 「非公開」バッジのアサーション更新

## Related
- Issue: #272