### PR TITLE
feat: mypage/rooms 作成フォームをモーダルに変更 #273

### DIFF
--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -3,15 +3,32 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["panel"]
 
-  // モーダルを開き、背景スクロールを無効化する
+  connect() {
+    this.boundHandleKeydown = this.handleKeydown.bind(this)
+  }
+
+  disconnect() {
+    document.removeEventListener("keydown", this.boundHandleKeydown)
+    document.body.classList.remove("overflow-hidden")
+  }
+
   open() {
     this.panelTarget.classList.remove("hidden")
     document.body.classList.add("overflow-hidden")
+    document.addEventListener("keydown", this.boundHandleKeydown)
   }
 
-  // モーダルを閉じ、背景スクロールを復元する
   close() {
     this.panelTarget.classList.add("hidden")
     document.body.classList.remove("overflow-hidden")
+    document.removeEventListener("keydown", this.boundHandleKeydown)
+  }
+
+  closeOnSuccess(event) {
+    if (event.detail.success) this.close()
+  }
+
+  handleKeydown(event) {
+    if (event.key === "Escape") this.close()
   }
 }

--- a/app/views/mypage/rooms/index.html.erb
+++ b/app/views/mypage/rooms/index.html.erb
@@ -1,73 +1,100 @@
 <% content_for :no_center, true %>
 
 <div style="max-width: 72rem; margin: 0 auto; padding: 2.5rem 1.5rem;">
-  <h1 style="font-size: 1.875rem; font-weight: 700; color: #ffffff; margin-bottom: 2rem;">部屋管理</h1>
 
-  <%# 作成フォーム（折りたたみ） %>
-  <div data-controller="toggle" style="margin-bottom: 2.5rem;">
-    <button
-      type="button"
-      data-action="click->toggle#toggle"
-      style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.75rem 1rem; border-radius: 0.75rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.9375rem; font-weight: 600; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);"
-    >
-      <span data-toggle-target="openText">+ 部屋を新規作成</span>
-      <span data-toggle-target="closeText" class="hidden">− フォームを閉じる</span>
-    </button>
-
-    <div data-toggle-target="content" style="max-width: 28rem; padding: 1.5rem; border-radius: 0.75rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3); margin-top: 1rem;">
-      <h2 style="font-size: 1.125rem; font-weight: 600; color: #ffffff; margin-bottom: 1rem;">新しい部屋を作成</h2>
-
-      <% room = @new_room %>
-      <%= form_with model: room, url: mypage_rooms_path do |f| %>
-        <% if room.errors.any? %>
-          <div style="margin-bottom: 1rem; border-radius: 0.5rem; border: 1px solid rgba(239, 68, 68, 0.3); background: rgba(239, 68, 68, 0.1); padding: 0.75rem 1rem; color: #fca5a5; font-size: 0.875rem;">
-            <% room.errors.each do |error| %>
-              <% message = error.attribute == :label ? "部屋名#{error.message}" : error.full_message %>
-              <div><%= message %></div>
-            <% end %>
-          </div>
-        <% end %>
-
-        <div style="margin-bottom: 1rem;">
-          <%= f.label :label, "部屋名", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
-          <%= f.text_field :label,
-                style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
-        </div>
-
-        <div style="margin-bottom: 1rem;">
-          <%= f.label :room_type, "タイプ", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
-          <%= f.select :room_type,
-                [["雑談", "chat"], ["勉強", "study"], ["ゲーム", "game"]],
-                { selected: "chat" },
-                style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
-        </div>
-
-        <div style="margin-bottom: 1rem;">
-          <%= f.label :locked, "公開設定", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
-          <%= f.select :locked,
-                [["公開", false], ["ロック", true]],
-                { selected: false },
-                style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
-        </div>
-
-        <div style="margin-bottom: 1rem;">
-          <%= label_tag :expires_in, "招待リンクの有効期限", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
-          <%= select_tag :expires_in,
-                options_for_select([["1時間", "1h"], ["24時間", "24h"], ["3日", "3d"], ["7日", "7d"], ["期限なし", "none"]], "24h"),
-                style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
-        </div>
-
-        <%= f.submit "部屋を作成",
-              style: "padding: 0.5rem 1rem; border-radius: 0.5rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);" %>
-      <% end %>
+  <%# 作成ボタン＋モーダル（部屋一覧見出しと横並び） %>
+  <div data-controller="modal" data-action="turbo:submit-end->modal#closeOnSuccess" style="margin-bottom: 2.5rem;">
+    <%# 見出し行：部屋一覧 + 新規作成ボタン %>
+    <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 0.25rem;">
+      <h2 style="font-size: 1.875rem; font-weight: 700; color: #ffffff; margin: 0;">部屋一覧</h2>
+      <button
+        type="button"
+        data-action="click->modal#open"
+        style="padding: 0.375rem 0.875rem; border-radius: 0.5rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(167,139,250,0.4); color: #c4b5fd; font-size: 0.8125rem; font-weight: 500; cursor: pointer;"
+      >
+        + 新規作成
+      </button>
     </div>
-  </div>
+    <p style="font-size: 0.8125rem; color: #6b7280; margin-bottom: 1rem;">管理中・参加中の部屋をまとめて表示します。</p>
+
+    <%# モーダルオーバーレイ（hidden クラスで表示制御。inline に display を書かない） %>
+    <div data-modal-target="panel" data-testid="room-create-modal" class="hidden" style="position: fixed; inset: 0; z-index: 50;">
+      <%# 背景（クリックで閉じる） %>
+      <div
+        data-testid="room-create-modal-backdrop"
+        data-action="click->modal#close"
+        style="position: absolute; inset: 0; background: rgba(0, 0, 0, 0.6);"
+      ></div>
+
+      <%# センタリング用ラッパー %>
+      <div style="display: flex; align-items: center; justify-content: center; width: 100%; height: 100%; position: relative; z-index: 10;">
+
+      <%# モーダル本体 %>
+      <div style="width: 100%; max-width: 28rem; margin: 1rem; padding: 1.5rem; border-radius: 0.75rem; background: #1f2937; border: 1px solid rgba(55, 65, 81, 0.6); box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);">
+        <%# ヘッダー %>
+        <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 1.25rem;">
+          <h2 style="font-size: 1.125rem; font-weight: 600; color: #ffffff; margin: 0;">新しい部屋を作成</h2>
+          <button
+            type="button"
+            data-action="click->modal#close"
+            data-testid="room-create-modal-close"
+            style="background: none; border: none; color: #6b7280; cursor: pointer; font-size: 1.25rem; line-height: 1; padding: 0.25rem;"
+            aria-label="モーダルを閉じる"
+          >×</button>
+        </div>
+
+        <%# フォーム（turbo_frame でバリデーションエラーをインライン表示） %>
+        <%= turbo_frame_tag "new_room_form" do %>
+          <%= form_with model: @new_room, url: mypage_rooms_path do |f| %>
+            <% if @new_room&.errors&.any? %>
+              <div style="margin-bottom: 1rem; border-radius: 0.5rem; border: 1px solid rgba(239, 68, 68, 0.3); background: rgba(239, 68, 68, 0.1); padding: 0.75rem 1rem; color: #fca5a5; font-size: 0.875rem;">
+                <% @new_room.errors.each do |error| %>
+                  <% message = error.attribute == :label ? "部屋名#{error.message}" : error.full_message %>
+                  <div><%= message %></div>
+                <% end %>
+              </div>
+            <% end %>
+
+            <div style="margin-bottom: 1rem;">
+              <%= f.label :label, "部屋名", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
+              <%= f.text_field :label,
+                    style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+            </div>
+
+            <div style="margin-bottom: 1rem;">
+              <%= f.label :room_type, "タイプ", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
+              <%= f.select :room_type,
+                    [["雑談", "chat"], ["勉強", "study"], ["ゲーム", "game"]],
+                    { selected: "chat" },
+                    style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+            </div>
+
+            <div style="margin-bottom: 1rem;">
+              <%= f.label :locked, "公開設定", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
+              <%= f.select :locked,
+                    [["公開", false], ["非公開", true]],
+                    { selected: false },
+                    style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+            </div>
+
+            <div style="margin-bottom: 1.25rem;">
+              <%= label_tag :expires_in, "招待リンクの有効期限", style: "display: block; font-size: 0.875rem; font-weight: 500; color: #d1d5db; margin-bottom: 0.375rem;" %>
+              <%= select_tag :expires_in,
+                    options_for_select([["1時間", "1h"], ["24時間", "24h"], ["3日", "3d"], ["7日", "7d"], ["期限なし", "none"]], "24h"),
+                    style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.375rem; background: rgba(255,255,255,0.05); border: 1px solid rgba(55, 65, 81, 0.6); color: #ffffff; font-size: 0.875rem; outline: none; box-sizing: border-box;" %>
+            </div>
+
+            <%= f.submit "部屋を作成",
+                  style: "width: 100%; padding: 0.625rem 1rem; border-radius: 0.5rem; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-size: 0.875rem; font-weight: 500; border: none; cursor: pointer; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3), inset 0 1px 0 rgba(255,255,255,0.1);" %>
+          <% end %>
+        <% end %>
+      </div>
+      </div><%# /センタリング用ラッパー %>
+    </div><%# /モーダルオーバーレイ %>
+  </div><%# /data-controller="modal" %>
 
   <%# 部屋一覧テーブル %>
   <section style="margin-bottom: 3rem;">
-    <h2 style="font-size: 1.25rem; font-weight: 600; color: #ffffff; margin-bottom: 0.25rem;">部屋一覧</h2>
-    <p style="font-size: 0.8125rem; color: #6b7280; margin-bottom: 1rem;">管理中・参加中の部屋をまとめて表示します。</p>
-
     <div style="overflow-x: auto;">
       <table style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
         <thead>

--- a/docs/designs/2026-04-23-room-create-modal.md
+++ b/docs/designs/2026-04-23-room-create-modal.md
@@ -1,0 +1,142 @@
+# 部屋新規作成モーダル 設計書
+
+**日付:** 2026-04-23
+**Issue:** #TBD
+**ステータス:** 合意済み
+
+---
+
+## 1. この設計で作るもの
+
+- `modal_controller.js` に ESC キー対応・`closeOnSuccess` メソッドを追加
+- `index.html.erb` の折りたたみフォームをモーダルに置き換え
+- モーダル内フォームを `turbo_frame_tag "new_room_form"` で囲み、バリデーションエラーをモーダル内でインライン表示
+
+## 2. 目的
+
+- 作成フォームをモーダルで提示し、テーブル一覧との分離を明確にする
+- バリデーションエラー時もモーダルが閉じず、エラーがインライン表示される UX を実現する
+
+## 3. スコープ
+
+### 含むもの
+- `modal_controller.js` への ESC キー・`closeOnSuccess` 追加
+- `index.html.erb` のモーダル構造への置き換え
+
+### 含まないもの
+- コントローラ変更（不要）
+- DB・ルーティング変更（不要）
+- フォーカストラップ（将来対応）
+
+## 4. 設計方針
+
+**バリデーションエラーをモーダル内で表示する方法：**
+
+| 方式 | 実装コスト | UX | 既存コードとの相性 |
+|---|---|---|---|
+| A: turbo_frame でフォームを囲む | 低 | エラー時モーダルが開いたまま ✓ | コントローラ変更不要 |
+| B: エラー専用 turbo_stream を追加 | 中 | 同上 | コントローラ修正が必要 |
+| C: data-turbo=false（従来型） | 低 | ページ全体リロード → モーダル閉じる ✗ | 最も単純だが UX 最悪 |
+
+**採用: A案** — `<turbo-frame id="new_room_form">` で囲むことで、422 応答時に Turbo がフレームだけ差し替え、モーダルは開いたまま。成功時は `turbo:submit-end` イベントで `closeOnSuccess` を呼んで閉じる。コントローラ変更不要。
+
+## 5. データ設計
+
+変更なし（DB・モデル変更不要）
+
+## 6. 画面・アクセス制御の流れ
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant M as modal_controller
+    participant C as Mypage::RoomsController
+    participant V as View
+
+    U->>M: click "+ 部屋を新規作成"
+    M->>M: open() → panel.hidden を除去, ESC リスナー追加
+
+    U->>C: POST /mypage/rooms (turbo_frame 内フォーム)
+
+    alt バリデーション成功
+        C->>V: create.turbo_stream.erb
+        V-->>U: turbo_stream.prepend → tbody に新行追加
+        U->>M: turbo:submit-end (success: true)
+        M->>M: closeOnSuccess() → close()
+    else バリデーション失敗
+        C->>V: render :index, 422
+        V-->>U: turbo_frame "new_room_form" だけ差し替え（エラー表示）
+        note over M: モーダルは開いたまま
+    end
+
+    U->>M: ESC キー or オーバーレイクリック or × ボタン
+    M->>M: close() → panel.hidden 追加, ESC リスナー除去
+```
+
+## 7. アプリケーション設計
+
+**`modal_controller.js` 変更点:**
+
+```js
+connect() {
+  this.boundHandleKeydown = this.handleKeydown.bind(this)
+}
+
+open() {
+  this.panelTarget.classList.remove("hidden")
+  document.body.classList.add("overflow-hidden")
+  document.addEventListener("keydown", this.boundHandleKeydown)
+}
+
+close() {
+  this.panelTarget.classList.add("hidden")
+  document.body.classList.remove("overflow-hidden")
+  document.removeEventListener("keydown", this.boundHandleKeydown)
+}
+
+closeOnSuccess(event) {
+  if (event.detail.success) this.close()
+}
+
+handleKeydown(event) {
+  if (event.key === "Escape") this.close()
+}
+```
+
+## 8. ルーティング設計
+
+変更なし
+
+## 9. レイアウト / UI 設計
+
+- モーダル背景：`rgba(0,0,0,0.6)` オーバーレイ
+- モーダル本体：既存 rooms/_room.html.erb のモーダルと同一スタイル（`background: #1f2937`）
+- ボタンスタイル・フォームフィールドは既存のものを流用
+
+## 10. クエリ・性能面
+
+変更なし（コントローラ・クエリ変更なし）
+
+## 11. トランザクション / Service 分離
+
+- トランザクション: 不要
+- Service 分離: 不要
+
+## 12. 実装対象一覧
+
+| # | 対象 | 内容 |
+|---|---|---|
+| 1 | `app/javascript/controllers/modal_controller.js` | ESC キー・`closeOnSuccess`・`handleKeydown` 追加 |
+| 2 | `app/views/mypage/rooms/index.html.erb` | 折りたたみ → モーダル構造に置き換え |
+
+## 13. 受入条件
+
+- [ ] 「+ 部屋を新規作成」を押すとモーダルが開く
+- [ ] オーバーレイクリック・ESC キー・× ボタンでモーダルが閉じる
+- [ ] バリデーションエラー時はモーダルが開いたままエラーが表示される
+- [ ] 部屋作成成功後、モーダルが閉じてテーブルに新行が追加される
+- [ ] RSpec 全通過・RuboCop 全通過
+
+## 14. この設計の結論
+
+DB・コントローラ変更なし。`turbo_frame` + `turbo:submit-end` の組み合わせで、エラー時のインライン表示と成功時のモーダル自動クローズを最小コストで実現する。`modal_controller.js` に ESC キー対応を追加することで、他の画面のモーダルも恩恵を受ける。

--- a/spec/system/mypage/room_create_modal_spec.rb
+++ b/spec/system/mypage/room_create_modal_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe "mypage/rooms 作成モーダル", type: :system, js: true do
+  # セットアップ：プロフィール済みユーザーでログイン
+  let(:current_user) { create(:user) }
+  let!(:current_profile) { create(:profile, user: current_user) }
+
+  before do
+    # ログインして部屋管理ページへ
+    login_as(current_user, scope: :user)
+    visit mypage_rooms_path
+  end
+
+  it "「+ 新規作成」ボタンが表示されている" do
+    # モーダルトリガーボタンが存在すること
+    expect(page).to have_button("+ 新規作成")
+  end
+
+  it "ボタンをクリックするとモーダルが開く" do
+    # ボタンをクリック
+    click_button "+ 新規作成"
+
+    # モーダルパネルが visible になること
+    expect(page).to have_css("[data-testid='room-create-modal']", visible: true)
+  end
+
+  it "× ボタンをクリックするとモーダルが閉じる" do
+    # モーダルを開く
+    click_button "+ 新規作成"
+
+    # × ボタンをクリック
+    find("[data-testid='room-create-modal-close']").click
+
+    # モーダルが非表示になること
+    expect(page).to have_css("[data-testid='room-create-modal']", visible: false)
+  end
+
+  it "ESC キーでモーダルが閉じる" do
+    # モーダルを開く
+    click_button "+ 新規作成"
+
+    # ESC キーを押す
+    find("body").send_keys(:escape)
+
+    # モーダルが非表示になること
+    expect(page).to have_css("[data-testid='room-create-modal']", visible: false)
+  end
+
+  it "オーバーレイクリックでモーダルが閉じる" do
+    # モーダルを開く
+    click_button "+ 新規作成"
+
+    # オーバーレイをJSで直接クリック
+    find("[data-testid='room-create-modal-backdrop']").execute_script("this.click()")
+
+    # モーダルが非表示になること
+    expect(page).to have_css("[data-testid='room-create-modal']", visible: false)
+  end
+
+  it "バリデーションエラー時はモーダルが開いたままエラーが表示される" do
+    # モーダルを開く
+    click_button "+ 新規作成"
+
+    # 部屋名を空にして送信（バリデーションエラーを発生させる）
+    within("[data-testid='room-create-modal']") do
+      fill_in "room[label]", with: ""
+      click_button "部屋を作成"
+    end
+
+    # モーダルが開いたままエラーメッセージが表示されること
+    expect(page).to have_css("[data-testid='room-create-modal']", visible: true)
+    expect(page).to have_text("部屋名")
+  end
+
+  it "作成成功後にモーダルが閉じてテーブルに新行が追加される" do
+    # 初期状態でテーブルに行がないこと
+    expect(page).not_to have_css("table td", text: "テストルーム")
+
+    # モーダルを開いてフォームに入力
+    click_button "+ 新規作成"
+    within("[data-testid='room-create-modal']") do
+      fill_in "room[label]", with: "テストルーム"
+      click_button "部屋を作成"
+    end
+
+    # モーダルが閉じること
+    expect(page).to have_css("[data-testid='room-create-modal']", visible: false)
+
+    # テーブルに新しい部屋が追加されること
+    expect(page).to have_css("table td", text: "テストルーム")
+  end
+end


### PR DESCRIPTION
## Summary
- `modal_controller.js` に ESC キー対応・`closeOnSuccess`・`disconnect` を追加
- mypage/rooms の折りたたみフォームをモーダルに置き換え
- `turbo_frame_tag "new_room_form"` でバリデーションエラーをモーダル内インライン表示
- 作成成功時は `turbo:submit-end` イベントでモーダルを自動クローズ
- 「部屋管理」h1 を削除し「部屋一覧」見出しと新規作成ボタンを横並びに変更

## Test plan
- [x] `+ 新規作成` ボタンでモーダルが開く
- [x] × ボタン・ESC キー・オーバーレイクリックでモーダルが閉じる
- [x] バリデーションエラー時はモーダルが開いたままエラーが表示される
- [x] 作成成功後にモーダルが閉じてテーブルに新行が追加される
- [x] RSpec 548件通過・RuboCop 違反なし

## Related
- Issue: #273