### PR TITLE
feat: 各一覧ページにKaminariページネーションを追加 #232

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
+gem "kaminari"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,18 @@ GEM
     json (2.18.0)
     jwt (3.1.2)
       base64
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     launchy (3.1.1)
       addressable (~> 2.8)
@@ -493,6 +505,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
+  kaminari
   letter_opener_web
   minitest (~> 5.20)
   omniauth-discord
@@ -583,6 +596,10 @@ CHECKSUMS
   jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
   json (2.18.0) sha256=b10506aee4183f5cf49e0efc48073d7b75843ce3782c68dbeb763351c08fd505
   jwt (3.1.2) sha256=af6991f19a6bb4060d618d9add7a66f0eeb005ac0bc017cd01f63b42e122d535
+  kaminari (1.2.2) sha256=c4076ff9adccc6109408333f87b5c4abbda5e39dc464bd4c66d06d9f73442a3e
+  kaminari-actionview (1.2.2) sha256=1330f6fc8b59a4a4ef6a549ff8a224797289ebf7a3a503e8c1652535287cc909
+  kaminari-activerecord (1.2.2) sha256=0dd3a67bab356a356f36b3b7236bcb81cef313095365befe8e98057dd2472430
+  kaminari-core (1.2.2) sha256=3bd26fec7370645af40ca73b9426a448d09b8a8ba7afa9ba3c3e0d39cdbb83ff
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
   letter_opener (1.10.0) sha256=2ff33f2e3b5c3c26d1959be54b395c086ca6d44826e8bf41a14ff96fdf1bdbb2

--- a/app/controllers/admin/parent_tags_controller.rb
+++ b/app/controllers/admin/parent_tags_controller.rb
@@ -3,16 +3,17 @@ class Admin::ParentTagsController < Admin::BaseController
   before_action :set_parent_tag_options, only: %i[index new create edit update]
 
   def index
-    scope = ParentTag.classified.includes(:hobbies).order(:room_type, :position, :id)
-    scope = scope.where(room_type: params[:room_type]) if params[:room_type].present?
-    scope = scope.where(id: params[:parent_tag_id]) if params[:parent_tag_id].present?
+    base_scope = ParentTag.classified.includes(:hobbies).order(:position, :id)
+    base_scope = base_scope.where(room_type: params[:room_type]) if params[:room_type].present?
+    base_scope = base_scope.where(id: params[:parent_tag_id]) if params[:parent_tag_id].present?
 
-    @parent_tags = scope.to_a
-    hobby_ids = @parent_tags.flat_map { |parent_tag| parent_tag.hobbies.map(&:id) }
-
-    @usage_counts = ProfileHobby.where(hobby_id: hobby_ids).group(:hobby_id).count
-    @parent_tags_by_room_type = @parent_tags.group_by(&:room_type)
     @room_type_options = ParentTag.room_types.keys
+    @parent_tags_by_room_type = @room_type_options.each_with_object({}) do |rt, hash|
+      hash[rt] = base_scope.where(room_type: rt).page(params[:"#{rt}_page"]).per(10)
+    end
+
+    hobby_ids = @parent_tags_by_room_type.values.flat_map { |tags| tags.flat_map { |t| t.hobbies.map(&:id) } }
+    @usage_counts = ProfileHobby.where(hobby_id: hobby_ids).group(:hobby_id).count
   end
 
   def new

--- a/app/controllers/admin/unclassified_hobbies_controller.rb
+++ b/app/controllers/admin/unclassified_hobbies_controller.rb
@@ -5,7 +5,7 @@ class Admin::UnclassifiedHobbiesController < Admin::BaseController
                  .select("hobbies.*, COUNT(DISTINCT profile_hobbies.id) AS usage_count, COUNT(DISTINCT profile_hobbies.profile_id) AS user_count")
                  .group("hobbies.id")
     scope = scope.where("hobbies.name LIKE ?", "%#{ActiveRecord::Base.sanitize_sql_like(params[:q])}%") if params[:q].present?
-    @hobbies = scope
+    @hobbies = scope.page(params[:page]).per(10)
     @parent_tags = ParentTag.order(:room_type, :position)
     @grouped_parent_tag_options = build_grouped_parent_tag_options
   end

--- a/app/controllers/mypage/rooms_controller.rb
+++ b/app/controllers/mypage/rooms_controller.rb
@@ -6,22 +6,11 @@ class Mypage::RoomsController < ApplicationController
     @new_room = Room.new
     profile = current_user.profile
     unless profile
-      @rooms = Room.none
-      @memberships = RoomMembership.none
+      @combined = Kaminari.paginate_array([]).page(params[:page]).per(10)
       return
     end
 
-    # 自分が作成した部屋一覧
-    @rooms = profile.issued_rooms
-                    .includes(:share_link, :room_memberships)
-                    .order(created_at: :desc)
-
-    # 自分が参加中の部屋（自分が作成者の部屋は除く）
-    @memberships = profile.room_memberships
-                          .joins(:room)
-                          .where.not(rooms: { issuer_profile_id: profile.id })
-                          .includes(room: [ { issuer_profile: :user }, :room_memberships, :share_link ])
-                          .order("rooms.created_at DESC")
+    load_room_lists(profile)
   end
 
   def create
@@ -124,14 +113,22 @@ class Mypage::RoomsController < ApplicationController
   end
 
   def load_room_lists(profile)
-    @rooms = profile.issued_rooms
+    issued = profile.issued_rooms
                     .includes(:share_link, :room_memberships)
                     .order(created_at: :desc)
+                    .to_a
 
-    @memberships = profile.room_memberships
-                          .joins(:room)
-                          .where.not(rooms: { issuer_profile_id: profile.id })
-                          .includes(room: [ { issuer_profile: :user }, :room_memberships, :share_link ])
-                          .order("rooms.created_at DESC")
+    joined = profile.room_memberships
+                    .joins(:room)
+                    .where.not(rooms: { issuer_profile_id: profile.id })
+                    .includes(room: [ { issuer_profile: :user }, :room_memberships, :share_link ])
+                    .order("rooms.created_at DESC")
+                    .to_a
+
+    combined = (issued + joined).sort_by { |item|
+      item.is_a?(Room) ? item.created_at : item.room.created_at
+    }.reverse
+
+    @combined = Kaminari.paginate_array(combined).page(params[:page]).per(10)
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,6 +3,7 @@ class ProfilesController < ApplicationController
 
   def index
     @profiles = ProfileSearchQuery.call(q: params[:q], mode: params[:mode])
+               .page(params[:page]).per(8)
 
     if turbo_frame_request?
       render partial: "profiles/profile_list", locals: { profiles: @profiles }

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -5,6 +5,7 @@ class RoomsController < ApplicationController
     @rooms = Room.unlocked
                  .includes(issuer_profile: :user, room_memberships: { profile: :user })
                  .order(created_at: :desc)
+                 .page(params[:page]).per(10)
 
     profile = current_user.profile
     @joined_room_ids = profile&.joined_room_ids || []

--- a/app/queries/profile_search_query.rb
+++ b/app/queries/profile_search_query.rb
@@ -41,7 +41,11 @@ class ProfileSearchQuery
   end
 
   def base_scope
-    Profile.includes(profile_hobbies: { hobby: :hobby_parent_tags }, user: { avatar_attachment: :blob }).order(created_at: :desc)
+    Profile.includes(
+      :hobbies,
+      profile_hobbies: { hobby: :hobby_parent_tags },
+      user: { avatar_attachment: :blob }
+    ).order(created_at: :desc)
   end
 
   def sanitize_sql_like(str)

--- a/app/views/admin/parent_tags/index.html.erb
+++ b/app/views/admin/parent_tags/index.html.erb
@@ -31,7 +31,7 @@
     <% create_parent_path = new_admin_parent_tag_path(room_type:) %>
     <% first_parent_tag = room_parent_tags.first %>
 
-    <section style="margin-bottom: 2rem;">
+    <section data-room-type="<%= room_type %>" style="margin-bottom: 2rem;">
       <div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem; margin-bottom: 0.75rem;">
         <h2 style="font-size: 1.125rem; color: #f9fafb; margin: 0;"><%= room_type %></h2>
         <div style="display: flex; gap: 0.5rem;">
@@ -85,6 +85,9 @@
           <% end %>
         </tbody>
       </table>
+      <div style="min-height: 2.5rem;">
+        <%= paginate room_parent_tags, param_name: :"#{room_type}_page" %>
+      </div>
     </section>
   <% end %>
 </div>

--- a/app/views/admin/unclassified_hobbies/index.html.erb
+++ b/app/views/admin/unclassified_hobbies/index.html.erb
@@ -1,4 +1,4 @@
-<div style="max-width: 72rem; margin: 0 auto;">
+<div style="max-width: 72rem; margin: 0 auto; flex: 1; display: flex; flex-direction: column;">
   <h1 style="font-size: 1.5rem; font-weight: bold; color: #f9fafb; margin-bottom: 1.5rem;">未分類タグ管理</h1>
 
   <%= form_with url: admin_unclassified_hobbies_path, method: :get, local: true do |f| %>
@@ -8,6 +8,7 @@
           style: "margin-left: 0.5rem; background: #374151; color: #f9fafb; border: none; padding: 0.375rem 0.75rem; border-radius: 0.25rem; cursor: pointer;" %>
   <% end %>
 
+  <div style="flex: 1; display: flex; flex-direction: column;">
   <table style="width: 100%; border-collapse: collapse; margin-top: 1.5rem; color: #d1d5db;">
     <thead>
       <tr style="border-bottom: 1px solid #374151; text-align: left;">
@@ -50,4 +51,5 @@
     </tbody>
   </table>
   <%= paginate @hobbies %>
+  </div>
 </div>

--- a/app/views/admin/unclassified_hobbies/index.html.erb
+++ b/app/views/admin/unclassified_hobbies/index.html.erb
@@ -49,4 +49,5 @@
       <% end %>
     </tbody>
   </table>
+  <%= paginate @hobbies %>
 </div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,9 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<%= link_to "«", url, style: "display: inline-flex; align-items: center; justify-content: center; min-width: 2rem; height: 2rem; padding: 0 0.5rem; border-radius: 0.375rem; font-size: 0.875rem; color: #d1d5db; background: rgba(255,255,255,0.05); border: 1px solid rgba(55,65,81,0.5); text-decoration: none;" %>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span style="display: inline-flex; align-items: center; justify-content: center; min-width: 2rem; height: 2rem; color: #6b7280; font-size: 0.875rem;">…</span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,9 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<%= link_to "»", url, style: "display: inline-flex; align-items: center; justify-content: center; min-width: 2rem; height: 2rem; padding: 0 0.5rem; border-radius: 0.375rem; font-size: 0.875rem; color: #d1d5db; background: rgba(255,255,255,0.05); border: 1px solid rgba(55,65,81,0.5); text-decoration: none;" %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,9 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<%= link_to "次へ ›", url, rel: "next", style: "display: inline-flex; align-items: center; justify-content: center; padding: 0 0.75rem; height: 2rem; border-radius: 0.375rem; font-size: 0.875rem; color: #d1d5db; background: rgba(255,255,255,0.05); border: 1px solid rgba(55,65,81,0.5); text-decoration: none;" %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,14 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% if page.current? %>
+  <span style="display: inline-flex; align-items: center; justify-content: center; min-width: 2rem; height: 2rem; padding: 0 0.5rem; border-radius: 0.375rem; font-size: 0.875rem; color: #ffffff; background: #2563eb; border: 1px solid #2563eb; font-weight: 600;"><%= page %></span>
+<% else %>
+  <%= link_to page, url, style: "display: inline-flex; align-items: center; justify-content: center; min-width: 2rem; height: 2rem; padding: 0 0.5rem; border-radius: 0.375rem; font-size: 0.875rem; color: #d1d5db; background: rgba(255,255,255,0.05); border: 1px solid rgba(55,65,81,0.5); text-decoration: none;", rel: page.rel %>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do %>
+  <nav style="display: flex; justify-content: center; align-items: center; gap: 0.25rem; margin-top: 1.5rem; flex-wrap: wrap;">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| %>
+      <% if page.display_tag? %>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? %>
+        <%= gap_tag %>
+      <% end %>
+    <% end %>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,9 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<%= link_to "‹ 前へ", url, rel: "prev", style: "display: inline-flex; align-items: center; justify-content: center; padding: 0 0.75rem; height: 2rem; border-radius: 0.375rem; font-size: 0.875rem; color: #d1d5db; background: rgba(255,255,255,0.05); border: 1px solid rgba(55,65,81,0.5); text-decoration: none;" %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -22,7 +22,7 @@
     <div style="position: fixed; top: 3rem; left: 0; right: 0; z-index: 40; padding: 0.5rem 1rem;">
       <%= render "shared/flash" %>
     </div>
-    <main style="padding: 2rem 1.5rem; margin-top: 1rem;">
+    <main style="padding: 2rem 1.5rem; margin-top: 1rem; display: flex; flex-direction: column; min-height: calc(100vh - 3rem);">
       <%= yield %>
     </main>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
     <div id="flash" style="position: fixed; top: 3rem; left: 0; right: 0; z-index: 40; padding: 0.5rem 1rem;">
         <%= render 'shared/flash' %>
     </div>
-    <main class="<%= content_for?(:landing) ? '' : content_for?(:full_width) ? 'py-8 px-4' : "container mx-auto py-8 px-5 #{content_for?(:no_center) ? '' : 'flex items-center justify-center'}" %>" style="<%= content_for?(:landing) ? '' : 'margin-top: 7rem; position: relative; overflow: hidden; min-height: calc(100vh - 7rem);' %>">
+    <main class="<%= content_for?(:landing) ? '' : content_for?(:full_width) ? 'py-8 px-4' : "container mx-auto py-8 px-5 #{content_for?(:no_center) ? '' : 'flex items-center justify-center'}" %>" style="<%= content_for?(:landing) ? '' : 'margin-top: 7rem; position: relative; overflow-y: auto; height: calc(100vh - 7rem); display: flex; flex-direction: column;' %>">
       <% unless content_for?(:landing) %>
         <%# 背景の装飾 %>
         <div style="position: absolute; inset: 0; opacity: 0.15; pointer-events: none; z-index: 0;">

--- a/app/views/mypage/rooms/index.html.erb
+++ b/app/views/mypage/rooms/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for :no_center, true %>
 
-<div style="max-width: 72rem; margin: 0 auto; padding: 2.5rem 1.5rem;">
+<div style="max-width: 72rem; margin: 0 auto; padding: 1.5rem 1.5rem; flex: 1; min-height: 0; display: flex; flex-direction: column;">
 
   <%# 作成ボタン＋モーダル（部屋一覧見出しと横並び） %>
-  <div data-controller="modal" data-action="turbo:submit-end->modal#closeOnSuccess" style="margin-bottom: 2.5rem;">
+  <div data-controller="modal" data-action="turbo:submit-end->modal#closeOnSuccess" style="margin-bottom: 1rem;">
     <%# 見出し行：部屋一覧 + 新規作成ボタン %>
     <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 0.25rem;">
       <h2 style="font-size: 1.875rem; font-weight: 700; color: #ffffff; margin: 0;">部屋一覧</h2>
@@ -94,8 +94,8 @@
   </div><%# /data-controller="modal" %>
 
   <%# 部屋一覧テーブル %>
-  <section style="margin-bottom: 3rem;">
-    <div style="overflow-x: auto;">
+  <section style="flex: 1; min-height: 0; display: flex; flex-direction: column; margin-bottom: 3rem;">
+    <div style="flex: 1; min-height: 0; overflow: auto;">
       <table style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
         <thead>
           <tr style="border-bottom: 1px solid rgba(55, 65, 81, 0.5);">

--- a/app/views/mypage/rooms/index.html.erb
+++ b/app/views/mypage/rooms/index.html.erb
@@ -109,23 +109,25 @@
           </tr>
         </thead>
         <tbody id="rooms_tbody">
-          <% if @rooms.empty? && @memberships.empty? %>
+          <% if @combined.empty? %>
             <tr>
               <td colspan="7" style="padding: 2rem 1rem; color: #6b7280; text-align: center;">
                 まだ部屋がありません。上のフォームから部屋を作成してみましょう。
               </td>
             </tr>
           <% else %>
-            <% @rooms.each do |room| %>
-              <%= render "mypage/rooms/room", room: room, link: room.share_link %>
-            <% end %>
-            <% @memberships.each do |membership| %>
-              <%= render "mypage/rooms/joined_room", membership: membership %>
+            <% @combined.each do |item| %>
+              <% if item.is_a?(Room) %>
+                <%= render "mypage/rooms/room", room: item, link: item.share_link %>
+              <% else %>
+                <%= render "mypage/rooms/joined_room", membership: item %>
+              <% end %>
             <% end %>
           <% end %>
         </tbody>
       </table>
     </div>
+    <%= paginate @combined %>
   </section>
 
   <div style="margin-top: 1.5rem;">

--- a/app/views/profiles/_profile_card.html.erb
+++ b/app/views/profiles/_profile_card.html.erb
@@ -1,4 +1,5 @@
 <div class="flex h-full flex-col transition-shadow duration-300 hover:shadow-[0_0_20px_rgba(99,102,241,0.2)]"
+     data-testid="profile-card"
      style="border-radius: 1rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); padding: 1.5rem; box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
   <div class="mb-2 flex items-center gap-3">
     <%= avatar_image_tag(profile.user, size: :small) %>

--- a/app/views/profiles/_profile_list.html.erb
+++ b/app/views/profiles/_profile_list.html.erb
@@ -1,5 +1,5 @@
-<%= turbo_frame_tag "profile_list" do %>
-  <div class="grid grid-cols-1 gap-6 items-stretch sm:grid-cols-2 lg:grid-cols-4">
+<%= turbo_frame_tag "profile_list", style: "display: flex; flex-direction: column; flex: 1;" do %>
+  <div class="grid grid-cols-1 gap-6 items-stretch sm:grid-cols-2 lg:grid-cols-4" style="flex: 1; align-content: start;">
     <% profiles.each do |profile| %>
       <%= render "profile_card", profile: profile %>
     <% end %>

--- a/app/views/profiles/_profile_list.html.erb
+++ b/app/views/profiles/_profile_list.html.erb
@@ -4,4 +4,5 @@
       <%= render "profile_card", profile: profile %>
     <% end %>
   </div>
+  <%= paginate profiles, params: { q: params[:q], mode: params[:mode] } %>
 <% end %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full max-w-7xl mx-auto flex flex-col gap-6">
+<div class="w-full max-w-7xl mx-auto flex flex-col gap-6 flex-1">
   <h1 style="font-size: 1.5rem; font-weight: 600; color: #ffffff; margin-bottom: 1rem;">プロフィール一覧</h1>
 
   <!-- 検索フォーム -->
@@ -9,7 +9,7 @@
   <!-- カードグリッド：4列 -->
   <div id="profile_list_loading_container"
        aria-busy="false"
-       style="position: relative;">
+       style="position: relative; flex: 1; display: flex; flex-direction: column;">
     <div data-loading-target="indicator"
          id="profile_list_loading_indicator"
          data-testid="profile-list-loading"

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -40,5 +40,6 @@
       </table>
     </div>
   </section>
+  <%= paginate @rooms %>
 
 </div>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :no_center, true %>
 
-<div style="max-width: 72rem; margin: 0 auto; padding: 2.5rem 1.5rem;">
+<div style="max-width: 72rem; margin: 0 auto; padding: 2.5rem 1.5rem; flex: 1; min-height: 0; display: flex; flex-direction: column;">
   <div style="display: flex; justify-content: space-between; align-items: end; gap: 1rem; margin-bottom: 2rem; flex-wrap: wrap;">
     <div>
       <h1 style="font-size: 1.875rem; font-weight: 700; color: #ffffff; margin: 0 0 0.5rem 0;">公開部屋一覧</h1>
@@ -10,8 +10,8 @@
     <%= link_to "部屋管理へ", mypage_rooms_path, style: "display: inline-flex; align-items: center; justify-content: center; padding: 0.625rem 1rem; border-radius: 0.75rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(55, 65, 81, 0.5); color: #d1d5db; text-decoration: none; font-size: 0.875rem; font-weight: 500;" %>
   </div>
 
-  <section>
-    <div style="overflow-x: auto; border-radius: 1rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
+  <section style="flex: 1; min-height: 0; display: flex; flex-direction: column;">
+    <div style="flex: 1; min-height: 0; overflow: auto; border-radius: 1rem; background: rgba(255,255,255,0.03); border: 1px solid rgba(55, 65, 81, 0.4); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);">
       <table style="width: 100%; min-width: 760px; border-collapse: collapse;">
         <thead>
           <tr style="background: rgba(255,255,255,0.02);">
@@ -39,7 +39,7 @@
         </tbody>
       </table>
     </div>
+    <%= paginate @rooms %>
   </section>
-  <%= paginate @rooms %>
 
 </div>

--- a/spec/factories/share_links.rb
+++ b/spec/factories/share_links.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :share_link do
     room { nil }
-    token { "MyString" }
+    token { SecureRandom.urlsafe_base64(16) }
     expires_at { "2026-02-17 15:23:34" }
   end
 end

--- a/spec/system/admin/parent_tags_pagination_spec.rb
+++ b/spec/system/admin/parent_tags_pagination_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "管理：親タグ一覧 ページネーション", type: :system do
+  # セットアップ：chatタイプの親タグ11件（1ページ10件なので2ページ目が必要）
+  let(:admin_user) { create(:user, :admin) }
+
+  before do
+    create_list(:parent_tag, 11, room_type: "chat")
+    login_as(admin_user, scope: :user)
+    visit admin_parent_tags_path
+  end
+
+  # アサーション：chatセクションに10件表示される
+  it "chatセクションに10件の親タグ行が表示される" do
+    within("section[data-room-type='chat']") do
+      expect(page).to have_css("tbody tr", count: 10)
+    end
+  end
+
+  # アサーション：chatセクションに「次へ」リンクが表示される
+  it "chatセクションに次ページリンクが表示される" do
+    within("section[data-room-type='chat']") do
+      expect(page).to have_link("次へ ›")
+    end
+  end
+
+  # アサーション：chatセクション2ページ目に1件表示される
+  it "chatセクションの2ページ目に残りの1件が表示される" do
+    within("section[data-room-type='chat']") do
+      click_link "次へ ›"
+    end
+    within("section[data-room-type='chat']") do
+      expect(page).to have_css("tbody tr", count: 1)
+    end
+  end
+end

--- a/spec/system/admin/unclassified_hobbies_pagination_spec.rb
+++ b/spec/system/admin/unclassified_hobbies_pagination_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "管理：未分類タグ ページネーション", type: :system do
+  # セットアップ：未分類タグ11件（1ページ10件なので2ページ目が必要）
+  let(:admin_user) { create(:user, :admin) }
+
+  before do
+    create_list(:hobby, 11)
+    login_as(admin_user, scope: :user)
+    visit admin_unclassified_hobbies_path
+  end
+
+  # アサーション：1ページ目に10件表示される
+  it "1ページ目に10件のタグ行が表示される" do
+    expect(page).to have_css("tbody tr", count: 10)
+  end
+
+  # アサーション：「次へ」リンクが表示される
+  it "次ページへのリンクが表示される" do
+    expect(page).to have_link("次へ ›")
+  end
+
+  # アサーション：2ページ目に1件表示される
+  it "2ページ目に残りの1件が表示される" do
+    click_link "次へ ›"
+    expect(page).to have_css("tbody tr", count: 1)
+  end
+end

--- a/spec/system/mypage/rooms_pagination_spec.rb
+++ b/spec/system/mypage/rooms_pagination_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "マイページ部屋一覧ページネーション", type: :system do
+  # セットアップ：管理中6件・参加中6件（合計12件、1ページ10件なので2ページ目が必要）
+  let(:current_user) { create(:user) }
+  let!(:current_profile) { create(:profile, user: current_user) }
+
+  before do
+    # 管理中6件
+    create_list(:room, 6, issuer_profile: current_profile).each do |room|
+      create(:room_membership, room: room, profile: current_profile)
+      create(:share_link, room: room)
+    end
+    # 参加中6件（別ユーザーが作成）
+    other_profile = create(:profile)
+    create_list(:room, 6, issuer_profile: other_profile).each do |room|
+      create(:room_membership, room: room, profile: current_profile)
+      create(:share_link, room: room)
+    end
+
+    login_as(current_user, scope: :user)
+    visit mypage_rooms_path
+  end
+
+  # アサーション：1ページ目に10件表示される
+  it "1ページ目に10件の部屋行が表示される" do
+    expect(page).to have_css("tbody#rooms_tbody tr", count: 10)
+  end
+
+  # アサーション：「次へ」リンクが表示される
+  it "次ページへのリンクが表示される" do
+    expect(page).to have_link("次へ ›")
+  end
+
+  # アサーション：2ページ目に2件表示される
+  it "2ページ目に残りの2件が表示される" do
+    click_link "次へ ›"
+    expect(page).to have_css("tbody#rooms_tbody tr", count: 2)
+  end
+end

--- a/spec/system/profiles/pagination_spec.rb
+++ b/spec/system/profiles/pagination_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "プロフィール一覧ページネーション", type: :system do
+  # セットアップ：9件のプロフィール（1ページ8件なので2ページ目が必要）
+  let(:current_user) { create(:user) }
+
+  before do
+    create_list(:profile, 9)
+    login_as(current_user, scope: :user)
+    visit profiles_path
+  end
+
+  # アサーション：1ページ目は8件表示される
+  it "1ページ目に8件のプロフィールカードが表示される" do
+    expect(page).to have_css("[data-testid='profile-card']", count: 8)
+  end
+
+  # アサーション：「次へ」リンクが表示される
+  it "次ページへのリンクが表示される" do
+    expect(page).to have_link("次へ ›")
+  end
+
+  # アサーション：2ページ目に1件表示される
+  it "2ページ目に残りの1件が表示される" do
+    click_link "次へ ›"
+    expect(page).to have_css("[data-testid='profile-card']", count: 1)
+  end
+end

--- a/spec/system/rooms/pagination_spec.rb
+++ b/spec/system/rooms/pagination_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "公開部屋一覧ページネーション", type: :system do
+  # セットアップ：11件の公開部屋（1ページ10件なので2ページ目が必要）
+  let(:current_user) { create(:user) }
+
+  before do
+    room_owner_profile = create(:profile)
+    create_list(:room, 11, issuer_profile: room_owner_profile, locked: false).each do |room|
+      create(:share_link, room: room)
+    end
+    login_as(current_user, scope: :user)
+    visit rooms_path
+  end
+
+  # アサーション：1ページ目は10件表示される
+  it "1ページ目に10件の部屋行が表示される" do
+    expect(page).to have_css("tbody tr", count: 10)
+  end
+
+  # アサーション：「次へ」リンクが表示される
+  it "次ページへのリンクが表示される" do
+    expect(page).to have_link("次へ ›")
+  end
+
+  # アサーション：2ページ目に1件表示される
+  it "2ページ目に残りの1件が表示される" do
+    click_link "次へ ›"
+    expect(page).to have_css("tbody tr", count: 1)
+  end
+end


### PR DESCRIPTION
## Summary
- Kaminari gem を導入し、Tailwind スタイルのページネーションビューを追加
- プロフィール一覧（8件/ページ）、公開部屋一覧・マイページ部屋一覧・管理：未分類タグ（各10件/ページ）にページネーションを実装
- 管理：親タグ一覧に部屋タイプ別の独立したページネーション（chat_page / study_page / game_page）を実装
- レイアウトの `main` を flex コンテナ化し、各ページのページネーションがビューポート内の固定位置に表示されるよう対応

## Test plan
- [x] RSpec 全通過（563 examples, 0 failures）確認済み
- [x] RuboCop 全通過（no offenses）確認済み
- [x] プロフィール一覧: 8件表示・ページ遷移動作確認
- [x] 公開部屋一覧: 10件表示・ページ遷移動作確認
- [x] マイページ部屋一覧: 10件表示・ページ遷移動作確認
- [x] 管理：未分類タグ: 10件表示・ページ遷移動作確認
- [x] 管理：親タグ一覧: 部屋タイプ別ページネーション動作確認
- [x] 各ページでページネーションがビューポート内の一定位置に表示されることを確認
- [x] 既存の検索・フィルタ機能との組み合わせ動作確認

## Related
- Issue: #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)