### PR TITLE
共有画面の詳細切り替え時に横幅が変動する問題を修正

### DIFF
--- a/app/views/shares/show.html.erb
+++ b/app/views/shares/show.html.erb
@@ -5,7 +5,7 @@
 
 <% content_for :full_width, true %>
 
-<div class="max-w-7xl mx-auto px-4 py-10">
+<div class="w-full max-w-7xl mx-auto px-4 py-10">
   <% unless @viewer_profile %>
     <div class="mb-6 p-4 rounded-lg bg-yellow-100 text-yellow-800 flex justify-between items-center">
       <span>プロフィール未登録です</span>

--- a/spec/system/shares/layout_stability_spec.rb
+++ b/spec/system/shares/layout_stability_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe "共有画面の横位置", type: :system, js: true do
+  let(:viewer_user) { create(:user, nickname: "閲覧者") }
+  let(:viewer_profile) { create(:profile, user: viewer_user) }
+  let(:short_user) { create(:user, nickname: "短文ユーザー") }
+  let(:short_profile) { create(:profile, user: short_user, bio: "短い自己紹介") }
+  let(:long_user) { create(:user, nickname: "長文ユーザー") }
+  let(:long_profile) { create(:profile, user: long_user, bio: "長い自己紹介" * 30) }
+  let(:tag_user) { create(:user, nickname: "タグ切替ユーザー") }
+  let(:tag_profile) { create(:profile, user: tag_user, bio: "タグ切り替え確認用") }
+  let(:room) { create(:room, issuer_profile: viewer_profile, room_type: :chat) }
+  let(:share_link) { create(:share_link, room:, expires_at: 1.hour.from_now) }
+  let(:parent_tag) { create(:parent_tag, room_type: :chat) }
+  let(:short_hobby) { create(:hobby, name: "短文タグ") }
+  let(:long_hobby) { create(:hobby, name: "長文タグ") }
+
+  before do
+    [ viewer_profile, short_profile, long_profile, tag_profile ].each do |profile|
+      create(:room_membership, room:, profile:)
+    end
+
+    create(:hobby_parent_tag, hobby: short_hobby, parent_tag:)
+    create(:hobby_parent_tag, hobby: long_hobby, parent_tag:)
+    create(:profile_hobby, profile: short_profile, hobby: short_hobby, description: "短い説明")
+    create(:profile_hobby, profile: long_profile, hobby: short_hobby, description: "短い説明")
+    create(:profile_hobby, profile: tag_profile, hobby: short_hobby, description: "短い説明")
+    create(:profile_hobby, profile: tag_profile, hobby: long_hobby, description: "長い説明" * 50)
+    8.times do |index|
+      hobby = create(:hobby, name: "追加タグ#{index + 1}")
+      create(:hobby_parent_tag, hobby:, parent_tag:)
+      create(:profile_hobby, profile: long_profile, hobby:, description: "追加説明")
+    end
+
+    login_as(viewer_user, scope: :user)
+    visit share_path(share_link.token)
+  end
+
+  it "ユーザーを切り替えても共有画面の横幅と左位置が変わらない" do
+    select_member("短文ユーザー")
+    before_switch = share_container_rect
+
+    select_member("長文ユーザー")
+    after_switch = share_container_rect
+
+    expect(after_switch["width"]).to be_within(1).of(before_switch["width"])
+    expect(after_switch["left"]).to be_within(1).of(before_switch["left"])
+  end
+
+  it "タグを切り替えても共有画面の横幅と左位置が変わらない" do
+    select_member("タグ切替ユーザー")
+
+    within("turbo-frame#member_detail") do
+      click_button "短文タグ"
+      expect(page).to have_text("短い説明")
+    end
+    before_switch = share_container_rect
+
+    within("turbo-frame#member_detail") do
+      click_button "長文タグ"
+      expect(page).to have_text("長い説明")
+    end
+    after_switch = share_container_rect
+
+    expect(after_switch["width"]).to be_within(1).of(before_switch["width"])
+    expect(after_switch["left"]).to be_within(1).of(before_switch["left"])
+  end
+
+  private
+
+  def select_member(nickname)
+    find("jmnode", text: nickname, exact_text: true).click
+    within("turbo-frame#member_detail") do
+      expect(page).to have_text(nickname)
+    end
+  end
+
+  def share_container_rect
+    page.evaluate_script(<<~JAVASCRIPT)
+      (() => {
+        const rect = document.querySelector("main > div.max-w-7xl").getBoundingClientRect()
+        return { left: rect.left, width: rect.width }
+      })()
+    JAVASCRIPT
+  end
+end


### PR DESCRIPTION
## 概要

共有画面でユーザーや趣味タグを切り替えた際、詳細の内容量によって画面全体が左右に動く問題を修正します。

Closes #280

## 原因

共有画面の外枠がフレックスレイアウト内で幅を明示されておらず、表示内容の幅に応じて外枠の横幅が変化していました。

## 変更内容

- 共有画面の外枠へ `w-full` を追加
- ユーザー切り替え前後で外枠の横幅・左位置が変わらないことをSystem Specで検証
- タグ切り替え前後で外枠の横幅・左位置が変わらないことをSystem Specで検証

## RED → GREEN → REFACTOR

### RED

修正前は、ユーザー切り替え・タグ切り替えの両方で外枠の横幅が `1096px → 1280px` に変化し、System Specが失敗することを確認しました。

### GREEN

共有画面の外枠へ `w-full` を追加し、追加した2件のSystem Specが通ることを確認しました。

### REFACTOR

変更を共有画面の外枠1箇所に限定し、全体レイアウトや詳細パネルの実装には変更を加えていません。

## 影響

ユーザーやタグを切り替えても共有画面の横幅と左位置が維持され、画面全体が左右に動かなくなります。

## 検証

- `docker compose exec web bundle exec rspec spec/system/shares/layout_stability_spec.rb spec/system/rooms/member_detail_tag_toggle_spec.rb spec/requests/shares_spec.rb spec/requests/shares`
  - 32 examples, 0 failures
- `docker compose exec web bundle exec rubocop spec/system/shares/layout_stability_spec.rb`
  - 1 file inspected, no offenses detected
- `docker compose exec web npm run build:css`
  - 成功
- `git diff --check`
  - 問題なし